### PR TITLE
BugFix #138 - Fixes NPE when there are no products.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+## [2.70.1]
+### Fixed
+- Fix for issue https://github.com/Backbase/stream-services/issues/138
+
 ## [2.70.0]
 ### Changed
 - Upgraded to DBS 2022.04
@@ -623,3 +628,4 @@ backbase:
 [2.8.0]: https://github.com/Backbase/stream-services/compare/2.7.0...2.8.0
 [2.7.0]: https://github.com/Backbase/stream-services/compare/2.6.0...2.7.0
 [2.6.0]: https://github.com/Backbase/stream-services/releases/tag/2.6.0
+[2.70.1]: https://github.com/Backbase/stream-services/compare/2.70.0...2.70.1

--- a/stream-product/product-ingestion-saga/src/main/java/com/backbase/stream/product/BatchProductIngestionSaga.java
+++ b/stream-product/product-ingestion-saga/src/main/java/com/backbase/stream/product/BatchProductIngestionSaga.java
@@ -115,7 +115,7 @@ public class BatchProductIngestionSaga extends ProductIngestionSaga {
                     streamTask.warn(BATCH_PRODUCT_GROUP, VALIDATE, REJECTED, name, null, "Product Group must have users assigned to it!");
                     throw new StreamTaskException(streamTask, "Product Group must have users assigned to it!");
                 }
-                if (StreamUtils.getInternalProductIds(productGroup).isEmpty() && customDataGroupItems.isEmpty()) {
+                if (StreamUtils.getInternalProductIds(productGroup).isEmpty() && (customDataGroupItems == null || customDataGroupItems.isEmpty())) {
                     streamTask.warn(BATCH_PRODUCT_GROUP, VALIDATE, REJECTED, name, null, "Product group must have products or Custom Data Group Items assigned to it!");
                     throw new StreamTaskException(streamTask, "Product group must have products or Custom Data Group Items assigned to it!");
                 }


### PR DESCRIPTION
Fixes #138 

Solved by adding a null check before checking for an empty list.

https://github.com/Backbase/stream-services/blob/2c5e54e58badadfe1f7cadb3b8dfcdd27c21dbb6/stream-product/product-ingestion-saga/src/main/java/com/backbase/stream/product/BatchProductIngestionSaga.java#L118