### PR TITLE
Added app.yaml configuration to enable/disable transaction ID persistence

### DIFF
--- a/stream-compositions/cursors/transaction-cursor/src/main/java/com/backbase/stream/compositions/transaction/cursor/core/config/TransactionCursorConfigurationProperties.java
+++ b/stream-compositions/cursors/transaction-cursor/src/main/java/com/backbase/stream/compositions/transaction/cursor/core/config/TransactionCursorConfigurationProperties.java
@@ -1,0 +1,18 @@
+package com.backbase.stream.compositions.transaction.cursor.core.config;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Data
+@Configuration
+@ConfigurationProperties("backbase.stream.transaction-cursor")
+public class TransactionCursorConfigurationProperties {
+
+    private TransactionIdPersistence transactionIdPersistence;
+
+    @Data
+    public static class TransactionIdPersistence {
+        private boolean enabled;
+    }
+}

--- a/stream-compositions/cursors/transaction-cursor/src/main/resources/application-local.yml
+++ b/stream-compositions/cursors/transaction-cursor/src/main/resources/application-local.yml
@@ -48,7 +48,7 @@ backbase:
       identity-integration-base-url: http://localhost:8181/identity-integration-service
     transaction-cursor:
       transaction-id-persistence:
-        enabled: false
+        enabled: true
 
 logging:
   level:

--- a/stream-compositions/cursors/transaction-cursor/src/main/resources/application-local.yml
+++ b/stream-compositions/cursors/transaction-cursor/src/main/resources/application-local.yml
@@ -46,6 +46,9 @@ backbase:
       arrangement-manager-base-url: http://localhost:8082/arrangement-manager
     identity:
       identity-integration-base-url: http://localhost:8181/identity-integration-service
+    transaction-cursor:
+      transaction-id-persistence:
+        enabled: false
 
 logging:
   level:

--- a/stream-compositions/cursors/transaction-cursor/src/main/resources/application.yml
+++ b/stream-compositions/cursors/transaction-cursor/src/main/resources/application.yml
@@ -45,6 +45,9 @@ backbase:
       arrangement-manager-base-url: http://arrangement-manager-nextgen:8080
     identity:
       identity-integration-base-url: http://identity-integration-service:8080
+    transaction-cursor:
+      transaction-id-persistence:
+        enabled: false
 
 logging:
   level:


### PR DESCRIPTION
Added app.yaml configuration to enable/disable transaction ID persistence in the transaction cursor DB.