### PR TITLE
Allow empty product groups to be created

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+## [2.74.0]
+### Fixed
+- Fix allowing empty product-groups to be created.
+
 ## [2.73.0]
 ### Fixed
 - Fix to add an arrangement in more than one product group

--- a/stream-product/product-ingestion-saga/src/main/java/com/backbase/stream/product/BatchProductIngestionSaga.java
+++ b/stream-product/product-ingestion-saga/src/main/java/com/backbase/stream/product/BatchProductIngestionSaga.java
@@ -115,10 +115,6 @@ public class BatchProductIngestionSaga extends ProductIngestionSaga {
                     streamTask.warn(BATCH_PRODUCT_GROUP, VALIDATE, REJECTED, name, null, "Product Group must have users assigned to it!");
                     throw new StreamTaskException(streamTask, "Product Group must have users assigned to it!");
                 }
-                if (StreamUtils.getInternalProductIds(productGroup).isEmpty() && (customDataGroupItems == null || customDataGroupItems.isEmpty())) {
-                    streamTask.warn(BATCH_PRODUCT_GROUP, VALIDATE, REJECTED, name, null, "Product group must have products or Custom Data Group Items assigned to it!");
-                    throw new StreamTaskException(streamTask, "Product group must have products or Custom Data Group Items assigned to it!");
-                }
                 if (customDataGroupItems != null && !customDataGroupItems.isEmpty() && productGroup.getProductGroupType() == null) {
                     streamTask.warn(BATCH_PRODUCT_GROUP, VALIDATE, REJECTED, name, null, "Product Group with Custom Data Group Items must have a Product Group Defined!");
                     throw new StreamTaskException(streamTask, "Product Group with Custom Data Group Items must have a Product Group Defined!");


### PR DESCRIPTION
Using the UI, it is possible to create an account group with no accounts, i.e., it is possible to create a product-group with no data-items.

There is a valid use-case for it: In NBC, we wish to create an "All-Accounts" group which is empty and assign permissions to users on this account group. Then we can add arrangements to the account-group.