### PR TITLE
Fix for Custom Job Role Privileges missing when assigned to a user

### DIFF
--- a/stream-product/product-ingestion-saga/src/main/java/com/backbase/stream/product/BusinessFunctionGroupMapper.java
+++ b/stream-product/product-ingestion-saga/src/main/java/com/backbase/stream/product/BusinessFunctionGroupMapper.java
@@ -1,12 +1,18 @@
 package com.backbase.stream.product;
 
 import com.backbase.dbs.accesscontrol.api.service.v2.model.FunctionGroupItem;
+import com.backbase.dbs.accesscontrol.api.service.v2.model.Permission;
+import com.backbase.stream.legalentity.model.BusinessFunction;
 import com.backbase.stream.legalentity.model.BusinessFunctionGroup;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 
 @Mapper
 public interface BusinessFunctionGroupMapper {
 
+  @Mapping(source = "permissions", target = "functions")
   BusinessFunctionGroup map(FunctionGroupItem functionGroupItem);
 
+  @Mapping(source = "assignedPrivileges", target = "privileges")
+  BusinessFunction mapBusinessFunction(Permission permission);
 }


### PR DESCRIPTION
Fix for [MS-495 & MS-171](https://backbase.atlassian.net/browse/MS-495?atlOrigin=eyJpIjoiMWIzYzY3YmRjOTE1NDFjOWI0OGU2N2JlYWMxNGU2ZDQiLCJwIjoiaiJ9) 
With Current Stream Implementation, Able to Create custom job role in a Service agreement but when a user is assigned this role, all the permission from job role table disappears, this fix will map privileges during the mapping from FunctionGroupItem (Access Control) to BusinessFunction (Streams) objects

Fix for Issue: https://github.com/Backbase/stream-services/issues/166