### PR TITLE
Fix for Custom Job Role Privileges missing when assigned to a user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [2.86.0]
+### Fixed
+- Custom Job Role Mapping Issue is fixed by adding missing mapping of BusinessFunction object of BusinessFunctionGroupMapper class
+
 ## [2.85.0]
 ### Added
 - Deploying task executables and http services as docker images using `repo.backbase.com/backbase-stream-images` registry. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -160,6 +160,9 @@ customServiceAgreement:
       BIC: BOFAUS6H
       bankCode: '121000358'
 ```
+## [2.84.0]
+### Fixed
+- Adding Custom Role Permission Issue
 
 ## [2.82.0]
 ### Fixed

--- a/stream-product/product-ingestion-saga/pom.xml
+++ b/stream-product/product-ingestion-saga/pom.xml
@@ -37,6 +37,12 @@
             <version>${project.version}</version>
         </dependency>
 
+        <dependency>
+            <groupId>com.backbase.buildingblocks</groupId>
+            <artifactId>service-sdk-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
 </project>

--- a/stream-product/product-ingestion-saga/src/main/java/com/backbase/stream/product/BusinessFunctionGroupMapper.java
+++ b/stream-product/product-ingestion-saga/src/main/java/com/backbase/stream/product/BusinessFunctionGroupMapper.java
@@ -1,12 +1,18 @@
 package com.backbase.stream.product;
 
 import com.backbase.dbs.accesscontrol.api.service.v2.model.FunctionGroupItem;
+import com.backbase.dbs.accesscontrol.api.service.v2.model.Permission;
+import com.backbase.stream.legalentity.model.BusinessFunction;
 import com.backbase.stream.legalentity.model.BusinessFunctionGroup;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 
 @Mapper
 public interface BusinessFunctionGroupMapper {
 
+  @Mapping(source = "permissions", target = "functions")
   BusinessFunctionGroup map(FunctionGroupItem functionGroupItem);
 
+  @Mapping(source = "assignedPrivileges", target = "privileges")
+  BusinessFunction mapBusinessFunction(Permission permission);
 }

--- a/stream-product/product-ingestion-saga/src/test/java/com/backbase/stream/product/BusinessFunctionGroupMapperTest.java
+++ b/stream-product/product-ingestion-saga/src/test/java/com/backbase/stream/product/BusinessFunctionGroupMapperTest.java
@@ -1,0 +1,55 @@
+package com.backbase.stream.product;
+
+import com.backbase.dbs.accesscontrol.api.service.v2.model.FunctionGroupItem;
+import com.backbase.dbs.accesscontrol.api.service.v2.model.Permission;
+import com.backbase.dbs.accesscontrol.api.service.v2.model.Privilege;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class BusinessFunctionGroupMapperTest {
+
+    private final BusinessFunctionGroupMapper mapper = new BusinessFunctionGroupMapperImpl();
+
+    @Test
+    void testMap() {
+        // When
+        var result = mapper.map(createFunctionGroupItem());
+
+        // Then
+        assertNotNull(result);
+        assertEquals("1001", result.getId());
+        assertEquals("S001", result.getServiceAgreementId());
+    }
+
+    @Test
+    void testMapBusinessFunction() {
+        // When
+        var result = mapper.map(createFunctionGroupItem());
+
+        // Then
+        assertNotNull(result);
+        assertEquals("F001", result.getFunctions().get(0).getFunctionId());
+        assertEquals("CREATE", result.getFunctions().get(0).getPrivileges().get(0).getPrivilege());
+    }
+
+    private FunctionGroupItem createFunctionGroupItem() {
+        FunctionGroupItem item = new FunctionGroupItem();
+        item.setId("1001");
+        item.setServiceAgreementId("S001");
+        item.setName("Payments");
+        item.setPermissions(Collections.singletonList(createPermisson()));
+        return item;
+    }
+
+    private Permission createPermisson() {
+        Permission permission = new Permission();
+        permission.setFunctionId("F001");
+        permission.setAssignedPrivileges(Collections.singletonList(new Privilege().privilege("CREATE")));
+        return permission;
+    }
+
+}


### PR DESCRIPTION
Fix for [MS-495 & MS-171](https://backbase.atlassian.net/browse/MS-495?atlOrigin=eyJpIjoiMWIzYzY3YmRjOTE1NDFjOWI0OGU2N2JlYWMxNGU2ZDQiLCJwIjoiaiJ9)
With Current Stream Implementation, Able to Create custom job role in a Service agreement but when a user is assigned this role, all the permission from job role table disappears, this fix will map privileges during the mapping from FunctionGroupItem (Access Control) to BusinessFunction (Streams) objects

Fix for Issue: https://github.com/Backbase/stream-services/issues/166