### PR TITLE
Added qualifier for WebClient in ContactsServiceConfiguration.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [2.86.1]
+### Fixed
+- Added qualifier for WebClient in ContactsServiceConfiguration.
+
 ## [2.86.0]
 ### Fixed
 - Custom Job Role Mapping Issue is fixed by adding missing mapping of BusinessFunction object of BusinessFunctionGroupMapper class
@@ -1009,3 +1013,4 @@ backbase:
 [2.6.0]: https://github.com/Backbase/stream-services/releases/tag/2.6.0
 [2.70.1]: https://github.com/Backbase/stream-services/compare/2.71.0...2.70.1
 [2.75.0]: https://github.com/Backbase/stream-services/compare/2.74.0...2.75.0
+[2.86.1]: https://github.com/Backbase/stream-services/compare/2.86.0...2.86.1

--- a/stream-contacts/contacts-core/src/main/java/com/backbase/stream/configuration/ContactsServiceConfiguration.java
+++ b/stream-contacts/contacts-core/src/main/java/com/backbase/stream/configuration/ContactsServiceConfiguration.java
@@ -15,6 +15,8 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.beans.factory.annotation.Qualifier;
+import com.backbase.buildingblocks.webclient.WebClientConstants;
 
 import java.text.DateFormat;
 
@@ -29,7 +31,7 @@ public class ContactsServiceConfiguration {
     private final BackbaseStreamConfigurationProperties backbaseStreamConfigurationProperties;
 
     @Bean
-    protected ContactsApi contactsApi(WebClient dbsWebClient, ObjectMapper objectMapper, DateFormat dateFormat) {
+    protected ContactsApi contactsApi(@Qualifier(WebClientConstants.INTER_SERVICE_WEB_CLIENT_NAME) WebClient dbsWebClient, ObjectMapper objectMapper, DateFormat dateFormat) {
         ApiClient apiClient = new ApiClient(dbsWebClient, objectMapper, dateFormat);
         apiClient.setBasePath(backbaseStreamConfigurationProperties.getDbs().getContactManagerBaseUrl());
         return new ContactsApi(apiClient);


### PR DESCRIPTION
While just using `LegalEntitySagaConfiguration` we are unable to start the application as there is a bean conflict.
``` log
+[ Description:
+[ 
+[ Parameter 0 of method contactsApi in com.backbase.stream.configuration.ContactsServiceConfiguration required a single bean, but 2 were found:
+[ 	- accessProviderWebClient: defined by method 'accessProviderWebClient' in class path resource [com/backbase/buildingblocks/webclient/InterServiceWebClientConfiguration$Oauth2ClientConfiguration.class]
+[ 	- interServiceWebClient: defined by method 'interServiceWebClient' in class path resource [com/backbase/buildingblocks/webclient/InterServiceWebClientConfiguration.class]
```
To resolve this added a qualifier for `WebClient`.