### PR TITLE
Hotfix/brd custom sa for product pull

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [3.4.1](https://github.com/Backbase/stream-services/compare/3.4.0...3.4.1)
+- Set custom service agreement id in the ProductPullIngestionRequest if LE has custom service agreement and doesn't have MSA.
+
 ## [3.4.0](https://github.com/Backbase/stream-services/compare/3.3.0...3.4.0)
 - Enable Multi architecture docker images: arm64 and amd64
 

--- a/stream-compositions/services/legal-entity-composition-service/src/main/java/com/backbase/stream/compositions/legalentity/core/service/impl/LegalEntityPostIngestionServiceImpl.java
+++ b/stream-compositions/services/legal-entity-composition-service/src/main/java/com/backbase/stream/compositions/legalentity/core/service/impl/LegalEntityPostIngestionServiceImpl.java
@@ -14,6 +14,7 @@ import com.backbase.stream.compositions.product.client.model.ProductIngestionRes
 import com.backbase.stream.compositions.product.client.model.ProductPullIngestionRequest;
 import com.backbase.stream.legalentity.model.JobProfileUser;
 import com.backbase.stream.legalentity.model.LegalEntity;
+import com.backbase.stream.legalentity.model.ServiceAgreement;
 import com.backbase.stream.legalentity.model.User;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -110,11 +111,16 @@ public class LegalEntityPostIngestionServiceImpl implements LegalEntityPostInges
         JobProfileUser jpUser = legalEntity.getUsers().get(0);
         User user = jpUser.getUser();
 
+        ServiceAgreement serviceAgreement = legalEntity.getCustomServiceAgreement();
+        if (serviceAgreement == null) {
+            serviceAgreement = legalEntity.getMasterServiceAgreement();
+        }
+
         return Mono.just(new ProductPullIngestionRequest()
                 .withLegalEntityInternalId(legalEntity.getInternalId())
                 .withLegalEntityExternalId(legalEntity.getExternalId())
-                .withServiceAgreementExternalId(legalEntity.getMasterServiceAgreement().getExternalId())
-                .withServiceAgreementInternalId(legalEntity.getMasterServiceAgreement().getInternalId())
+                .withServiceAgreementExternalId(serviceAgreement.getExternalId())
+                .withServiceAgreementInternalId(serviceAgreement.getInternalId())
                 .withMembershipAccounts(res.getMembershipAccounts())
                 .withUserExternalId(user.getExternalId())
                 .withUserInternalId(user.getInternalId())

--- a/stream-compositions/services/legal-entity-composition-service/src/main/java/com/backbase/stream/compositions/legalentity/core/service/impl/LegalEntityPostIngestionServiceImpl.java
+++ b/stream-compositions/services/legal-entity-composition-service/src/main/java/com/backbase/stream/compositions/legalentity/core/service/impl/LegalEntityPostIngestionServiceImpl.java
@@ -111,9 +111,9 @@ public class LegalEntityPostIngestionServiceImpl implements LegalEntityPostInges
         JobProfileUser jpUser = legalEntity.getUsers().get(0);
         User user = jpUser.getUser();
 
-        ServiceAgreement serviceAgreement = legalEntity.getCustomServiceAgreement();
-        if (serviceAgreement == null) {
-            serviceAgreement = legalEntity.getMasterServiceAgreement();
+        ServiceAgreement serviceAgreement = legalEntity.getMasterServiceAgreement();
+        if (serviceAgreement == null && legalEntity.getCustomServiceAgreement() != null) {
+            serviceAgreement = legalEntity.getCustomServiceAgreement();
         }
 
         return Mono.just(new ProductPullIngestionRequest()


### PR DESCRIPTION
Right now if LE has custom SA and no master SA, the LegalEntityPostIngestionServiceImpl::buildProductPullRequest() throws NPE. This PR fixes current behaviour by providing custom SA id to the ProductPullIngestionRequest.