### PR TITLE
Zip layout for composition services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 All notable changes to this project will be documented in this file.
 ## [3.10.0](https://github.com/Backbase/stream-services/compare/3.9.3...3.10.0)
 ### Added
-- Zip layout to composition services. This allows to add external jars to the classpath using `loader.path` property.
+- Zip layout to composition services. This allows the addition of external jars to the classpath using `loader.path` property.
 
 ## [3.9.3](https://github.com/Backbase/stream-services/compare/3.9.2...3.9.3)
 - Fix memory leak with UnitOfWorkExecutor

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 All notable changes to this project will be documented in this file.
+## [3.10.0](https://github.com/Backbase/stream-services/compare/3.9.3...3.10.0)
+### Added
+- Zip layout to composition services. This allows to add external jars to the classpath using `loader.path` property.
+
 ## [3.9.3](https://github.com/Backbase/stream-services/compare/3.9.2...3.9.3)
 - Fix memory leak with UnitOfWorkExecutor
 

--- a/stream-compositions/pom.xml
+++ b/stream-compositions/pom.xml
@@ -130,6 +130,21 @@
                 <artifactId>sonar-maven-plugin</artifactId>
                 <version>${sonar-maven-plugin.version}</version>
             </plugin>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>repackage</id>
+                        <goals>
+                            <goal>repackage</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <layout>ZIP</layout>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
Added zip layout to composition services. This allows the addition of external jars to the classpath using `loader.path` property.