### PR TITLE
reorganization of payment ingestion logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ target
 .project
 .settings
 .classpath
+.checkstyle
 **/*.log
 bin
 .DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## 3.7.2
+- Fix payment order core implementation logic
+
 ## [3.7.1](https://github.com/Backbase/stream-services/compare/3.7.0...3.7.1)
 - Fix memory leak with UnitOfWorkExecutor
 

--- a/stream-compositions/services/payment-order-composition-service/src/main/java/com/backbase/stream/compositions/paymentorders/core/mapper/PaymentOrderMapper.java
+++ b/stream-compositions/services/payment-order-composition-service/src/main/java/com/backbase/stream/compositions/paymentorders/core/mapper/PaymentOrderMapper.java
@@ -1,15 +1,23 @@
 package com.backbase.stream.compositions.paymentorders.core.mapper;
 
-import com.backbase.dbs.paymentorder.api.service.v2.model.PaymentOrderPostRequest;
-import com.backbase.dbs.paymentorder.api.service.v2.model.PaymentOrderPostResponse;
-import com.backbase.dbs.paymentorder.api.service.v2.model.UpdateStatusPut;
-import com.backbase.stream.compositions.paymentorder.api.model.PaymentOrderPullIngestionRequest;
-import com.backbase.stream.compositions.paymentorder.integration.client.model.PullIngestionRequest;
-import com.backbase.stream.compositions.paymentorders.core.model.PaymentOrderIngestPullRequest;
+import java.util.List;
+
 import org.mapstruct.InjectionStrategy;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.springframework.stereotype.Component;
+
+import com.backbase.dbs.paymentorder.api.service.v2.model.PaymentOrderPostRequest;
+import com.backbase.dbs.paymentorder.api.service.v2.model.PaymentOrderPostResponse;
+import com.backbase.dbs.paymentorder.api.service.v2.model.UpdateStatusPut;
+import com.backbase.stream.compositions.paymentorder.api.model.PaymentOrderIngestionResponse;
+import com.backbase.stream.compositions.paymentorder.api.model.PaymentOrderPullIngestionRequest;
+import com.backbase.stream.compositions.paymentorder.integration.client.model.PullIngestionRequest;
+import com.backbase.stream.compositions.paymentorders.core.model.PaymentOrderIngestPullRequest;
+import com.backbase.stream.model.response.DeletePaymentOrderIngestDbsResponse;
+import com.backbase.stream.model.response.NewPaymentOrderIngestDbsResponse;
+import com.backbase.stream.model.response.PaymentOrderIngestDbsResponse;
+import com.backbase.stream.model.response.UpdatePaymentOrderIngestDbsResponse;
 
 
 /**
@@ -36,4 +44,31 @@ public interface PaymentOrderMapper {
     PullIngestionRequest mapStreamToIntegration(PaymentOrderIngestPullRequest source);
 
     PaymentOrderIngestPullRequest mapPullRequest(PaymentOrderPullIngestionRequest source);
+
+    default PaymentOrderIngestionResponse mapPaymentOrderIngestionResponse(List<PaymentOrderIngestDbsResponse> paymentOrderIngestDbsResponses) {
+        PaymentOrderIngestionResponse paymentOrderIngestionResponse = new PaymentOrderIngestionResponse();
+        for (PaymentOrderIngestDbsResponse paymentOrderIngestDbsResponse : paymentOrderIngestDbsResponses) {
+            if (paymentOrderIngestDbsResponse instanceof NewPaymentOrderIngestDbsResponse) {
+                NewPaymentOrderIngestDbsResponse newPaymentOrderIngestDbsResponse = (NewPaymentOrderIngestDbsResponse) paymentOrderIngestDbsResponse;
+                paymentOrderIngestionResponse.addNewPaymentOrderItem(
+                    this.mapStreamNewPaymentOrderToComposition(
+                        newPaymentOrderIngestDbsResponse.getPaymentOrderPostResponse()
+                    )
+                );
+            } else if (paymentOrderIngestDbsResponse instanceof UpdatePaymentOrderIngestDbsResponse) {
+                UpdatePaymentOrderIngestDbsResponse updatePaymentOrderIngestDbsResponse = (UpdatePaymentOrderIngestDbsResponse) paymentOrderIngestDbsResponse;
+                paymentOrderIngestionResponse.addUpdatedPaymentOrderItem(
+                    this.mapStreamUpdatePaymentOrderToComposition(
+                        updatePaymentOrderIngestDbsResponse.getUpdateStatusPut()
+                    )
+                );
+            } else if (paymentOrderIngestDbsResponse instanceof DeletePaymentOrderIngestDbsResponse) {
+                DeletePaymentOrderIngestDbsResponse deletePaymentOrderIngestDbsResponse = (DeletePaymentOrderIngestDbsResponse) paymentOrderIngestDbsResponse;
+                paymentOrderIngestionResponse.addDeletedPaymentOrderItem(
+                    deletePaymentOrderIngestDbsResponse.getPaymentOrderId()
+                );
+            }
+        }
+        return paymentOrderIngestionResponse;
+    }
 }

--- a/stream-compositions/services/payment-order-composition-service/src/main/java/com/backbase/stream/compositions/paymentorders/core/model/PaymentOrderIngestResponse.java
+++ b/stream-compositions/services/payment-order-composition-service/src/main/java/com/backbase/stream/compositions/paymentorders/core/model/PaymentOrderIngestResponse.java
@@ -1,6 +1,9 @@
 package com.backbase.stream.compositions.paymentorders.core.model;
 
-import com.backbase.stream.model.PaymentOrderIngestContext;
+import java.util.List;
+
+import com.backbase.stream.model.response.PaymentOrderIngestDbsResponse;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -10,5 +13,5 @@ import lombok.Getter;
 @AllArgsConstructor
 public class PaymentOrderIngestResponse {
     private final String memberNumber;
-    private final PaymentOrderIngestContext paymentOrderIngestContext;
+    private final List<PaymentOrderIngestDbsResponse> paymentOrderIngestDbsResponses;
 }

--- a/stream-compositions/services/payment-order-composition-service/src/main/java/com/backbase/stream/compositions/paymentorders/core/service/PaymentOrderPostIngestionService.java
+++ b/stream-compositions/services/payment-order-composition-service/src/main/java/com/backbase/stream/compositions/paymentorders/core/service/PaymentOrderPostIngestionService.java
@@ -1,18 +1,21 @@
 package com.backbase.stream.compositions.paymentorders.core.service;
 
-import com.backbase.stream.model.PaymentOrderIngestContext;
+import java.util.List;
+
+import com.backbase.stream.model.response.PaymentOrderIngestDbsResponse;
+
 import reactor.core.publisher.Mono;
 
 public interface PaymentOrderPostIngestionService {
     /**
      * Post processing for a completed ingestion process
-     * @param response
+     * @param paymentOrderIngestDbsResponses
      */
-     void handleSuccess(PaymentOrderIngestContext response);
+     void handleSuccess(List<PaymentOrderIngestDbsResponse> paymentOrderIngestDbsResponses);
 
     /**
      * Post processing for a failed ingestion process
      * @param error
      */
-    Mono<PaymentOrderIngestContext> handleFailure(Throwable error);
+    Mono<List<PaymentOrderIngestDbsResponse>> handleFailure(Throwable error);
 }

--- a/stream-compositions/services/payment-order-composition-service/src/main/java/com/backbase/stream/compositions/paymentorders/core/service/impl/PaymentOrderIngestionServiceImpl.java
+++ b/stream-compositions/services/payment-order-composition-service/src/main/java/com/backbase/stream/compositions/paymentorders/core/service/impl/PaymentOrderIngestionServiceImpl.java
@@ -1,5 +1,11 @@
 package com.backbase.stream.compositions.paymentorders.core.service.impl;
 
+import java.util.List;
+import java.util.stream.Collector;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+
 import com.backbase.dbs.paymentorder.api.service.v2.model.PaymentOrderPostRequest;
 import com.backbase.stream.PaymentOrderService;
 import com.backbase.stream.compositions.paymentorders.core.mapper.PaymentOrderMapper;
@@ -8,15 +14,11 @@ import com.backbase.stream.compositions.paymentorders.core.model.PaymentOrderIng
 import com.backbase.stream.compositions.paymentorders.core.service.PaymentOrderIngestionService;
 import com.backbase.stream.compositions.paymentorders.core.service.PaymentOrderIntegrationService;
 import com.backbase.stream.compositions.paymentorders.core.service.PaymentOrderPostIngestionService;
-import com.backbase.stream.model.PaymentOrderIngestContext;
+import com.backbase.stream.model.response.PaymentOrderIngestDbsResponse;
 import com.backbase.stream.worker.model.UnitOfWork;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.databind.json.JsonMapper;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Service;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -39,7 +41,7 @@ public class PaymentOrderIngestionServiceImpl implements PaymentOrderIngestionSe
                 .flatMap(this::sendToDbs)
                 .doOnSuccess(this::handleSuccess)
                 .onErrorResume(e -> handleError(e))
-                .map(paymentOrderIngestContext -> buildResponse(paymentOrderIngestContext, ingestPullRequest));
+                .map(paymentOrderIngestDbsResponses -> buildResponse(paymentOrderIngestDbsResponses, ingestPullRequest));
     }
 
     private Mono<PaymentOrderIngestPullRequest> buildIntegrationRequest(PaymentOrderIngestPullRequest paymentOrderIngestPullRequest) {
@@ -57,30 +59,35 @@ public class PaymentOrderIngestionServiceImpl implements PaymentOrderIngestionSe
                 .map(paymentOrderMapper::mapIntegrationToStream);
     }
 
-    private Mono<PaymentOrderIngestContext> sendToDbs(Flux<PaymentOrderPostRequest> paymentOrderPostRequestFlux) {
+    private Mono<List<PaymentOrderIngestDbsResponse>> sendToDbs(Flux<PaymentOrderPostRequest> paymentOrderPostRequestFlux) {
 
         return paymentOrderPostRequestFlux
                 .publish(paymentOrderService::processPaymentOrder)
                 .flatMapIterable(UnitOfWork::getStreamTasks)
-                .next()
-                .flatMap(x -> Mono.just(x.getResponse()));
+                .collectList()
+                .flatMap(paymentOrderTaskList -> {
+                    List<PaymentOrderIngestDbsResponse> paymentOrderIngestDbsResponses = paymentOrderTaskList.stream()
+                    .flatMap(paymentOrderTask -> paymentOrderTask.getResponses().stream())
+                    .collect(Collectors.toList());
+                   return Mono.just(paymentOrderIngestDbsResponses);
+                });
     }
 
-    private PaymentOrderIngestResponse buildResponse(PaymentOrderIngestContext paymentOrderIngestContext,
+    private PaymentOrderIngestResponse buildResponse(List<PaymentOrderIngestDbsResponse> paymentOrderIngestDbsResponses,
                                                     PaymentOrderIngestPullRequest ingestPullRequest) {
         return PaymentOrderIngestResponse.builder()
-                .paymentOrderIngestContext(paymentOrderIngestContext)
+                .paymentOrderIngestDbsResponses(paymentOrderIngestDbsResponses)
                 .memberNumber(ingestPullRequest.getMemberNumber())
                 .build();
     }
 
-    private void handleSuccess(PaymentOrderIngestContext paymentOrderIngestContext) {
+    private void handleSuccess(List<PaymentOrderIngestDbsResponse> paymentOrderIngestDbsResponses) {
         // if we add cursor in the future, this needs to be updated to success here
-        paymentOrderPostIngestionService.handleSuccess(paymentOrderIngestContext);
-        log.debug("Ingested payment orders (success): {}", paymentOrderIngestContext);
+        paymentOrderPostIngestionService.handleSuccess(paymentOrderIngestDbsResponses);
+        log.debug("Ingested payment orders (success): {}", paymentOrderIngestDbsResponses);
     }
 
-    private Mono<PaymentOrderIngestContext> handleError(Throwable e) {
+    private Mono<List<PaymentOrderIngestDbsResponse>> handleError(Throwable e) {
         // if we add cursor in the future, this needs to be updated to failure here
         log.debug("Ingested payment orders (fail): {}", e.getMessage());
         return paymentOrderPostIngestionService.handleFailure(e);

--- a/stream-compositions/services/payment-order-composition-service/src/main/java/com/backbase/stream/compositions/paymentorders/core/service/impl/PaymentOrderPostIngestionServiceImpl.java
+++ b/stream-compositions/services/payment-order-composition-service/src/main/java/com/backbase/stream/compositions/paymentorders/core/service/impl/PaymentOrderPostIngestionServiceImpl.java
@@ -1,12 +1,16 @@
 package com.backbase.stream.compositions.paymentorders.core.service.impl;
 
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
 import com.backbase.buildingblocks.backend.communication.event.proxy.EventBus;
 import com.backbase.stream.compositions.paymentorders.core.config.PaymentOrderConfigurationProperties;
 import com.backbase.stream.compositions.paymentorders.core.service.PaymentOrderPostIngestionService;
-import com.backbase.stream.model.PaymentOrderIngestContext;
+import com.backbase.stream.model.response.PaymentOrderIngestDbsResponse;
+
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Service;
 import reactor.core.publisher.Mono;
 
 @Service
@@ -18,13 +22,13 @@ public class PaymentOrderPostIngestionServiceImpl implements PaymentOrderPostIng
     private final PaymentOrderConfigurationProperties paymentOrderConfigurationProperties;
 
     @Override
-    public void handleSuccess(PaymentOrderIngestContext response) {
+    public void handleSuccess(List<PaymentOrderIngestDbsResponse> paymentOrderIngestDbsResponses) {
         log.info("Payment Order ingestion completed successfully.");
         // events can be handled here as part of a different ticket.
     }
 
     @Override
-    public Mono<PaymentOrderIngestContext> handleFailure(Throwable error) {
+    public Mono<List<PaymentOrderIngestDbsResponse>> handleFailure(Throwable error) {
         // events can be handled here as part of a different ticket.
         return Mono.empty();
     }

--- a/stream-compositions/services/payment-order-composition-service/src/main/java/com/backbase/stream/compositions/paymentorders/http/PaymentOrderController.java
+++ b/stream-compositions/services/payment-order-composition-service/src/main/java/com/backbase/stream/compositions/paymentorders/http/PaymentOrderController.java
@@ -1,6 +1,7 @@
 package com.backbase.stream.compositions.paymentorders.http;
 
-import java.util.stream.Collectors;
+import java.util.List;
+
 import javax.validation.Valid;
 
 import org.springframework.http.HttpStatus;
@@ -8,6 +9,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ServerWebExchange;
+
 import com.backbase.stream.PaymentOrderService;
 import com.backbase.stream.compositions.paymentorder.api.PaymentOrderCompositionApi;
 import com.backbase.stream.compositions.paymentorder.api.model.PaymentOrderIngestionResponse;
@@ -15,14 +17,14 @@ import com.backbase.stream.compositions.paymentorder.api.model.PaymentOrderPullI
 import com.backbase.stream.compositions.paymentorders.core.mapper.PaymentOrderMapper;
 import com.backbase.stream.compositions.paymentorders.core.model.PaymentOrderIngestResponse;
 import com.backbase.stream.compositions.paymentorders.core.service.PaymentOrderIngestionService;
+import com.backbase.stream.model.response.PaymentOrderIngestDbsResponse;
+
 import io.swagger.annotations.ApiParam;
 import lombok.AllArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import reactor.core.publisher.Mono;
 
 @RestController
 @AllArgsConstructor
-@Slf4j
 public class PaymentOrderController implements PaymentOrderCompositionApi {
 
     PaymentOrderIngestionService paymentOrderIngestionService;
@@ -51,24 +53,7 @@ public class PaymentOrderController implements PaymentOrderCompositionApi {
      * @return IngestionResponse
      */
     private ResponseEntity<PaymentOrderIngestionResponse> mapIngestionToResponse(PaymentOrderIngestResponse response) {
-        return new ResponseEntity<>(
-                new PaymentOrderIngestionResponse()
-                        .withNewPaymentOrder(
-                                response.getPaymentOrderIngestContext().newPaymentOrderResponse()
-                                        .stream()
-                                        .map(paymentOrderMapper::mapStreamNewPaymentOrderToComposition)
-                                        .collect(Collectors.toList()))
-                        .withUpdatedPaymentOrder(
-                                response.getPaymentOrderIngestContext().updatedPaymentOrderResponse()
-                                        .stream()
-                                        .map(paymentOrderMapper::mapStreamUpdatePaymentOrderToComposition)
-                                        .collect(Collectors.toList())
-                        )
-                        .withDeletedPaymentOrder(
-                                response.getPaymentOrderIngestContext().deletePaymentOrderResponse()
-                                        .stream()
-                                        .collect(Collectors.toList())
-                        ),
-                HttpStatus.CREATED);
+        List<PaymentOrderIngestDbsResponse> paymentOrderIngestDbsResponses = response.getPaymentOrderIngestDbsResponses();
+        return new ResponseEntity<>(paymentOrderMapper.mapPaymentOrderIngestionResponse(paymentOrderIngestDbsResponses), HttpStatus.CREATED);
     }
 }

--- a/stream-compositions/services/payment-order-composition-service/src/test/java/com/backbase/stream/compositions/paymentorders/core/service/impl/PaymentOrderIngestionServiceImplTest.java
+++ b/stream-compositions/services/payment-order-composition-service/src/test/java/com/backbase/stream/compositions/paymentorders/core/service/impl/PaymentOrderIngestionServiceImplTest.java
@@ -17,6 +17,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.backbase.buildingblocks.backend.communication.event.proxy.EventBus;
 import com.backbase.dbs.paymentorder.api.service.v2.model.PaymentOrderPostRequest;
+import com.backbase.dbs.paymentorder.api.service.v2.model.PaymentOrderPutRequest;
 import com.backbase.stream.PaymentOrderService;
 import com.backbase.stream.compositions.paymentorders.core.config.PaymentOrderConfigurationProperties;
 import com.backbase.stream.compositions.paymentorders.core.mapper.PaymentOrderMapper;
@@ -25,7 +26,11 @@ import com.backbase.stream.compositions.paymentorders.core.model.PaymentOrderIng
 import com.backbase.stream.compositions.paymentorders.core.service.PaymentOrderIngestionService;
 import com.backbase.stream.compositions.paymentorders.core.service.PaymentOrderIntegrationService;
 import com.backbase.stream.compositions.paymentorders.core.service.PaymentOrderPostIngestionService;
-import com.backbase.stream.model.PaymentOrderIngestContext;
+import com.backbase.stream.model.request.DeletePaymentOrderIngestRequest;
+import com.backbase.stream.model.request.NewPaymentOrderIngestRequest;
+import com.backbase.stream.model.request.PaymentOrderIngestRequest;
+import com.backbase.stream.model.request.UpdatePaymentOrderIngestRequest;
+import com.backbase.stream.model.response.PaymentOrderIngestDbsResponse;
 import com.backbase.stream.paymentorder.PaymentOrderTask;
 import com.backbase.stream.worker.model.UnitOfWork;
 
@@ -90,14 +95,16 @@ class PaymentOrderIngestionServiceImplTest {
         when(paymentOrderIntegrationService.pullPaymentOrder(paymentOrderIngestPullRequest))
             .thenReturn(paymentOrderPostRequestFlux);
 
-        PaymentOrderPostRequest paymentOrderPostRequestMapped = new PaymentOrderPostRequest();
-
         String unitOfOWorkId = "payment-orders-mixed-" + System.currentTimeMillis();
-        List<PaymentOrderPostRequest> data = new ArrayList<PaymentOrderPostRequest>();
-        data.add(paymentOrderPostRequestMapped);
+        List<PaymentOrderIngestRequest> data = new ArrayList<>();
+        data.add(new NewPaymentOrderIngestRequest(new PaymentOrderPostRequest()));
+        data.add(new UpdatePaymentOrderIngestRequest(new PaymentOrderPutRequest()));
+        data.add(new DeletePaymentOrderIngestRequest("paymentOrderId", "bankReferenceId"));
+
+        List<PaymentOrderIngestDbsResponse> responses = new ArrayList<>();
 
         PaymentOrderTask paymentOrderTask = new PaymentOrderTask(unitOfOWorkId, data);
-        paymentOrderTask.setResponse(new PaymentOrderIngestContext());
+        paymentOrderTask.setResponses(responses);
 
         Stream<UnitOfWork<PaymentOrderTask>> unitOfWorkStream = Stream.of(
             UnitOfWork.from(unitOfOWorkId, paymentOrderTask)

--- a/stream-compositions/services/payment-order-composition-service/src/test/java/com/backbase/stream/compositions/paymentorders/http/PaymentOrderControllerTest.java
+++ b/stream-compositions/services/payment-order-composition-service/src/test/java/com/backbase/stream/compositions/paymentorders/http/PaymentOrderControllerTest.java
@@ -8,7 +8,11 @@ import com.backbase.stream.compositions.paymentorder.api.model.PaymentOrderPullI
 import com.backbase.stream.compositions.paymentorders.core.mapper.PaymentOrderMapper;
 import com.backbase.stream.compositions.paymentorders.core.model.PaymentOrderIngestResponse;
 import com.backbase.stream.compositions.paymentorders.core.service.PaymentOrderIngestionService;
-import com.backbase.stream.model.PaymentOrderIngestContext;
+import com.backbase.stream.model.response.DeletePaymentOrderIngestDbsResponse;
+import com.backbase.stream.model.response.NewPaymentOrderIngestDbsResponse;
+import com.backbase.stream.model.response.PaymentOrderIngestDbsResponse;
+import com.backbase.stream.model.response.UpdatePaymentOrderIngestDbsResponse;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -52,22 +56,19 @@ class PaymentOrderControllerTest {
         Mono<PaymentOrderPullIngestionRequest> requestMono = Mono.just(
                 new PaymentOrderPullIngestionRequest().withInternalUserId("internalUserId"));
 
-        List<PaymentOrderPostResponse> newPaymentOrderResponse = new ArrayList<>();
-        PaymentOrderPostResponse paymentOrderPostResponse = new PaymentOrderPostResponse().id("id");
-        newPaymentOrderResponse.add(paymentOrderPostResponse);
-
-        List<UpdateStatusPut> updatedPaymentOrderResponse = new ArrayList<>();
-        List<String> deletePaymentOrderResponse = new ArrayList<>();
+        List<PaymentOrderIngestDbsResponse> paymentOrderIngestDbsResponses = new ArrayList<>();
+        paymentOrderIngestDbsResponses.add(new NewPaymentOrderIngestDbsResponse(new PaymentOrderPostResponse()));
+        paymentOrderIngestDbsResponses.add(new UpdatePaymentOrderIngestDbsResponse(new UpdateStatusPut()));
+        paymentOrderIngestDbsResponses.add(new DeletePaymentOrderIngestDbsResponse("paymentOrderId"));
 
         doAnswer(invocation -> {
 
-            return Mono.just(PaymentOrderIngestResponse.builder()
-                            .paymentOrderIngestContext(new PaymentOrderIngestContext()
-                                    .internalUserId("internalId")
-                                    .newPaymentOrderResponse(newPaymentOrderResponse)
-                                    .updatedPaymentOrderResponse(updatedPaymentOrderResponse)
-                                    .deletePaymentOrderResponse(deletePaymentOrderResponse))
-                    .build());
+            return Mono.just(
+                PaymentOrderIngestResponse.builder()
+                    .memberNumber("memberNumber")
+                    .paymentOrderIngestDbsResponses(paymentOrderIngestDbsResponses)
+                    .build()
+            );
         }).when(paymentOrderIngestionService).ingestPull(any());
 
         ResponseEntity<PaymentOrderIngestionResponse> responseEntity = paymentOrderController.pullPaymentOrder(requestMono, null)

--- a/stream-payment-order/payment-order-core/src/main/java/com/backbase/stream/config/PaymentOrderServiceConfiguration.java
+++ b/stream-payment-order/payment-order-core/src/main/java/com/backbase/stream/config/PaymentOrderServiceConfiguration.java
@@ -35,20 +35,24 @@ public class PaymentOrderServiceConfiguration {
 
     private final PaymentOrderTypeMapper paymentOrderTypeMapper;
 
+    @Bean
+    public PaymentOrdersApi paymentOrdersApi(ApiClient paymentOrderApiClient) {
+        return new PaymentOrdersApi(paymentOrderApiClient);
+    }
 
     @Bean
-    public PaymentOrderTaskExecutor paymentOrderTaskExecutor(ApiClient paymentOrderApiClient) {
-        PaymentOrdersApi paymentOrdersApi = new PaymentOrdersApi(paymentOrderApiClient);
-        return new PaymentOrderTaskExecutor(paymentOrdersApi, paymentOrderTypeMapper);
+    public PaymentOrderTaskExecutor paymentOrderTaskExecutor(PaymentOrdersApi paymentOrdersApi) {
+        return new PaymentOrderTaskExecutor(paymentOrdersApi);
     }
 
     @Bean
     public PaymentOrderUnitOfWorkExecutor paymentOrderUnitOfWorkExecutor(PaymentOrderTaskExecutor paymentOrderTaskExecutor,
                                                                         PaymentOrderUnitOfWorkRepository paymentOrderUnitOfWorkRepository,
-                                                                        PaymentOrderWorkerConfigurationProperties paymentOrderWorkerConfigurationProperties) {
+                                                                        PaymentOrderWorkerConfigurationProperties paymentOrderWorkerConfigurationProperties,
+                                                                        PaymentOrdersApi paymentOrdersApi) {
 
         return new PaymentOrderUnitOfWorkExecutor(paymentOrderUnitOfWorkRepository, paymentOrderTaskExecutor,
-                paymentOrderWorkerConfigurationProperties);
+                paymentOrderWorkerConfigurationProperties, paymentOrdersApi, paymentOrderTypeMapper);
     }
 
     @Bean

--- a/stream-payment-order/payment-order-core/src/main/java/com/backbase/stream/config/PaymentOrderWorkerConfigurationProperties.java
+++ b/stream-payment-order/payment-order-core/src/main/java/com/backbase/stream/config/PaymentOrderWorkerConfigurationProperties.java
@@ -13,4 +13,6 @@ public class PaymentOrderWorkerConfigurationProperties extends StreamWorkerConfi
     private boolean groupPerArrangementId;
 
     private boolean continueOnError;
+
+    private boolean deletePaymentOrder = true;
 }

--- a/stream-payment-order/payment-order-core/src/main/java/com/backbase/stream/model/PaymentOrderIngestContext.java
+++ b/stream-payment-order/payment-order-core/src/main/java/com/backbase/stream/model/PaymentOrderIngestContext.java
@@ -1,15 +1,13 @@
 package com.backbase.stream.model;
 
-import com.backbase.dbs.paymentorder.api.service.v2.model.GetPaymentOrderResponse;
-import com.backbase.dbs.paymentorder.api.service.v2.model.PaymentOrderPostRequest;
-import com.backbase.dbs.paymentorder.api.service.v2.model.PaymentOrderPostResponse;
-import com.backbase.dbs.paymentorder.api.service.v2.model.PaymentOrderPutRequest;
-import com.backbase.dbs.paymentorder.api.service.v2.model.UpdateStatusPut;
-import lombok.Data;
-import lombok.experimental.Accessors;
-
 import java.util.ArrayList;
 import java.util.List;
+
+import com.backbase.dbs.paymentorder.api.service.v2.model.GetPaymentOrderResponse;
+import com.backbase.dbs.paymentorder.api.service.v2.model.PaymentOrderPostRequest;
+
+import lombok.Data;
+import lombok.experimental.Accessors;
 
 @Data
 @Accessors(fluent = true)
@@ -18,15 +16,5 @@ public class PaymentOrderIngestContext {
     private String internalUserId;
     private List<PaymentOrderPostRequest> corePaymentOrder = new ArrayList<>();
     private List<GetPaymentOrderResponse> existingPaymentOrder = new ArrayList<>();
-
-
-    private List<PaymentOrderPostRequest> newPaymentOrder = new ArrayList<>();
-    private List<PaymentOrderPutRequest> updatePaymentOrder = new ArrayList<>();
-    // we only need the internal Ids of the payment orders we need to delete
-    private List<String> deletePaymentOrder = new ArrayList<>();
-
-    private List<PaymentOrderPostResponse> newPaymentOrderResponse = new ArrayList<>();
-    private List<UpdateStatusPut> updatedPaymentOrderResponse = new ArrayList<>();
-    private List<String> deletePaymentOrderResponse = new ArrayList<>();
 
 }

--- a/stream-payment-order/payment-order-core/src/main/java/com/backbase/stream/model/request/DeletePaymentOrderIngestRequest.java
+++ b/stream-payment-order/payment-order-core/src/main/java/com/backbase/stream/model/request/DeletePaymentOrderIngestRequest.java
@@ -1,0 +1,18 @@
+package com.backbase.stream.model.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class DeletePaymentOrderIngestRequest implements PaymentOrderIngestRequest  {
+
+    private final String paymentOrderId;
+    private final String bankReferenceId;
+
+    @Override
+    public String getBankReferenceId() {
+        return bankReferenceId;
+    }
+
+}

--- a/stream-payment-order/payment-order-core/src/main/java/com/backbase/stream/model/request/NewPaymentOrderIngestRequest.java
+++ b/stream-payment-order/payment-order-core/src/main/java/com/backbase/stream/model/request/NewPaymentOrderIngestRequest.java
@@ -1,0 +1,19 @@
+package com.backbase.stream.model.request;
+
+import com.backbase.dbs.paymentorder.api.service.v2.model.PaymentOrderPostRequest;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class NewPaymentOrderIngestRequest implements PaymentOrderIngestRequest {
+
+    private final PaymentOrderPostRequest paymentOrderPostRequest;
+
+    @Override
+    public String getBankReferenceId() {
+        return paymentOrderPostRequest.getBankReferenceId();
+    }
+
+}

--- a/stream-payment-order/payment-order-core/src/main/java/com/backbase/stream/model/request/PaymentOrderIngestRequest.java
+++ b/stream-payment-order/payment-order-core/src/main/java/com/backbase/stream/model/request/PaymentOrderIngestRequest.java
@@ -1,0 +1,7 @@
+package com.backbase.stream.model.request;
+
+public interface PaymentOrderIngestRequest {
+
+    String getBankReferenceId();
+
+}

--- a/stream-payment-order/payment-order-core/src/main/java/com/backbase/stream/model/request/UpdatePaymentOrderIngestRequest.java
+++ b/stream-payment-order/payment-order-core/src/main/java/com/backbase/stream/model/request/UpdatePaymentOrderIngestRequest.java
@@ -1,0 +1,19 @@
+package com.backbase.stream.model.request;
+
+import com.backbase.dbs.paymentorder.api.service.v2.model.PaymentOrderPutRequest;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class UpdatePaymentOrderIngestRequest implements PaymentOrderIngestRequest {
+
+    private final PaymentOrderPutRequest paymentOrderPutRequest;
+
+    @Override
+    public String getBankReferenceId() {
+        return paymentOrderPutRequest.getBankReferenceId();
+    }
+
+}

--- a/stream-payment-order/payment-order-core/src/main/java/com/backbase/stream/model/response/DeletePaymentOrderIngestDbsResponse.java
+++ b/stream-payment-order/payment-order-core/src/main/java/com/backbase/stream/model/response/DeletePaymentOrderIngestDbsResponse.java
@@ -1,0 +1,14 @@
+package com.backbase.stream.model.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.ToString;
+
+@AllArgsConstructor
+@Getter
+@ToString
+public class DeletePaymentOrderIngestDbsResponse implements PaymentOrderIngestDbsResponse {
+
+    private final String paymentOrderId;
+
+}

--- a/stream-payment-order/payment-order-core/src/main/java/com/backbase/stream/model/response/NewPaymentOrderIngestDbsResponse.java
+++ b/stream-payment-order/payment-order-core/src/main/java/com/backbase/stream/model/response/NewPaymentOrderIngestDbsResponse.java
@@ -1,0 +1,16 @@
+package com.backbase.stream.model.response;
+
+import com.backbase.dbs.paymentorder.api.service.v2.model.PaymentOrderPostResponse;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.ToString;
+
+@AllArgsConstructor
+@Getter
+@ToString
+public class NewPaymentOrderIngestDbsResponse implements PaymentOrderIngestDbsResponse {
+
+    private final PaymentOrderPostResponse paymentOrderPostResponse;
+
+}

--- a/stream-payment-order/payment-order-core/src/main/java/com/backbase/stream/model/response/PaymentOrderIngestDbsResponse.java
+++ b/stream-payment-order/payment-order-core/src/main/java/com/backbase/stream/model/response/PaymentOrderIngestDbsResponse.java
@@ -1,0 +1,5 @@
+package com.backbase.stream.model.response;
+
+public interface PaymentOrderIngestDbsResponse {
+
+}

--- a/stream-payment-order/payment-order-core/src/main/java/com/backbase/stream/model/response/UpdatePaymentOrderIngestDbsResponse.java
+++ b/stream-payment-order/payment-order-core/src/main/java/com/backbase/stream/model/response/UpdatePaymentOrderIngestDbsResponse.java
@@ -1,0 +1,16 @@
+package com.backbase.stream.model.response;
+
+import com.backbase.dbs.paymentorder.api.service.v2.model.UpdateStatusPut;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.ToString;
+
+@AllArgsConstructor
+@Getter
+@ToString
+public class UpdatePaymentOrderIngestDbsResponse implements PaymentOrderIngestDbsResponse {
+
+    private final UpdateStatusPut updateStatusPut;
+
+}

--- a/stream-payment-order/payment-order-core/src/main/java/com/backbase/stream/paymentorder/PaymentOrderTask.java
+++ b/stream-payment-order/payment-order-core/src/main/java/com/backbase/stream/paymentorder/PaymentOrderTask.java
@@ -1,9 +1,12 @@
 package com.backbase.stream.paymentorder;
 
-import com.backbase.dbs.paymentorder.api.service.v2.model.PaymentOrderPostRequest;
-import com.backbase.stream.model.PaymentOrderIngestContext;
-import com.backbase.stream.worker.model.StreamTask;
+import java.util.ArrayList;
 import java.util.List;
+
+import com.backbase.stream.model.request.PaymentOrderIngestRequest;
+import com.backbase.stream.model.response.PaymentOrderIngestDbsResponse;
+import com.backbase.stream.worker.model.StreamTask;
+
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
@@ -12,13 +15,13 @@ import lombok.EqualsAndHashCode;
 public class PaymentOrderTask extends StreamTask {
 
     public PaymentOrderTask(String unitOfWorkId,
-                            List<PaymentOrderPostRequest> data) {
+                            List<PaymentOrderIngestRequest> data) {
         super(unitOfWorkId);
         this.data = data;
     }
 
-    private List<PaymentOrderPostRequest> data;
-    private PaymentOrderIngestContext response;
+    private List<PaymentOrderIngestRequest> data;
+    private List<PaymentOrderIngestDbsResponse> responses = new ArrayList<>();
 
     @Override
     public String getName() {

--- a/stream-payment-order/payment-order-core/src/main/java/com/backbase/stream/paymentorder/PaymentOrderTaskExecutor.java
+++ b/stream-payment-order/payment-order-core/src/main/java/com/backbase/stream/paymentorder/PaymentOrderTaskExecutor.java
@@ -37,7 +37,7 @@ public class PaymentOrderTaskExecutor implements StreamTaskExecutor<PaymentOrder
 
     @Override
     public Mono<PaymentOrderTask> executeTask(PaymentOrderTask streamTask) {
-        
+
       String externalIds = streamTask.getData().stream().map(PaymentOrderIngestRequest::getBankReferenceId)
       .collect(Collectors.joining(","));
 
@@ -99,7 +99,7 @@ public class PaymentOrderTaskExecutor implements StreamTaskExecutor<PaymentOrder
             paymentOrderPutRequest.getNextExecutionDate()
         )
             .doOnNext(response -> log.debug("Updated Payment Order status: {}", response))
-            .map(updateStatusPut -> new UpdatePaymentOrderIngestDbsResponse(updateStatusPut));
+            .map(UpdatePaymentOrderIngestDbsResponse::new);
     }
 
     /**

--- a/stream-payment-order/payment-order-core/src/main/java/com/backbase/stream/paymentorder/PaymentOrderTaskExecutor.java
+++ b/stream-payment-order/payment-order-core/src/main/java/com/backbase/stream/paymentorder/PaymentOrderTaskExecutor.java
@@ -1,216 +1,118 @@
 package com.backbase.stream.paymentorder;
 
+import java.time.LocalDate;
+import java.util.UUID;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+
 import com.backbase.dbs.paymentorder.api.service.v2.PaymentOrdersApi;
-import com.backbase.dbs.paymentorder.api.service.v2.model.GetPaymentOrderResponse;
-import com.backbase.dbs.paymentorder.api.service.v2.model.PaymentOrderPostFilterRequest;
-import com.backbase.dbs.paymentorder.api.service.v2.model.PaymentOrderPostFilterResponse;
 import com.backbase.dbs.paymentorder.api.service.v2.model.PaymentOrderPostRequest;
 import com.backbase.dbs.paymentorder.api.service.v2.model.PaymentOrderPostResponse;
 import com.backbase.dbs.paymentorder.api.service.v2.model.PaymentOrderPutRequest;
 import com.backbase.dbs.paymentorder.api.service.v2.model.Status;
 import com.backbase.dbs.paymentorder.api.service.v2.model.UpdateStatusPut;
-import com.backbase.stream.mappers.PaymentOrderTypeMapper;
-import com.backbase.stream.model.PaymentOrderIngestContext;
+import com.backbase.stream.model.request.DeletePaymentOrderIngestRequest;
+import com.backbase.stream.model.request.NewPaymentOrderIngestRequest;
+import com.backbase.stream.model.request.PaymentOrderIngestRequest;
+import com.backbase.stream.model.request.UpdatePaymentOrderIngestRequest;
+import com.backbase.stream.model.response.DeletePaymentOrderIngestDbsResponse;
+import com.backbase.stream.model.response.NewPaymentOrderIngestDbsResponse;
+import com.backbase.stream.model.response.PaymentOrderIngestDbsResponse;
+import com.backbase.stream.model.response.UpdatePaymentOrderIngestDbsResponse;
 import com.backbase.stream.worker.StreamTaskExecutor;
 import com.backbase.stream.worker.exception.StreamTaskException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.databind.json.JsonMapper;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.web.reactive.function.client.WebClientResponseException;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
-
-import javax.validation.Valid;
-import javax.validation.constraints.NotNull;
-import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.UUID;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
-
-import static com.backbase.dbs.paymentorder.api.service.v2.model.Status.*;
 
 @Slf4j
 @RequiredArgsConstructor
 public class PaymentOrderTaskExecutor implements StreamTaskExecutor<PaymentOrderTask> {
 
     private final PaymentOrdersApi paymentOrdersApi;
-    private final PaymentOrderTypeMapper paymentOrderTypeMapper;
 
     @Override
     public Mono<PaymentOrderTask> executeTask(PaymentOrderTask streamTask) {
+        
+      String externalIds = streamTask.getData().stream().map(PaymentOrderIngestRequest::getBankReferenceId)
+      .collect(Collectors.joining(","));
 
-        PaymentOrderIngestContext paymentOrderIngestContext = new PaymentOrderIngestContext();
-        List<PaymentOrderPostRequest> corePaymentOrderPostRequestList = streamTask.getData();
-        paymentOrderIngestContext.corePaymentOrder(corePaymentOrderPostRequestList);
-        paymentOrderIngestContext.internalUserId(corePaymentOrderPostRequestList.get(0).getInternalUserId());
+        return  Flux.fromIterable(streamTask.getData())
+        .flatMap(this::executePaymentOrderRequest)
+        .onErrorResume(WebClientResponseException.class, throwable -> {
+          streamTask.error("payments", "post", "failed", externalIds, null, throwable,
+                  throwable.getResponseBodyAsString(), "Failed to ingest payment order");
+          return Mono.error(new StreamTaskException(streamTask, throwable,
+                  "Failed to Ingest Payment Order: " + throwable.getMessage()));
+        })
+        .collectList()
+        .map(paymentOrderIngestResponses -> {
+            streamTask.setResponses(paymentOrderIngestResponses);
+            return streamTask;
+        });
 
-        String externalIds = streamTask.getData().stream().map(PaymentOrderPostRequest::getBankReferenceId)
-                .collect(Collectors.joining(","));
-
-        return buildPaymentOrderIngestContext(paymentOrderIngestContext)
-                .flatMap(this::persistNewPaymentOrders)
-                .flatMap(this::updatePaymentOrder)
-                .flatMap(this::deletePaymentOrder)
-                .onErrorResume(WebClientResponseException.class, throwable -> {
-                    streamTask.error("payments", "post", "failed", externalIds, null, throwable,
-                            throwable.getResponseBodyAsString(), "Failed to ingest payment order");
-                    return Mono.error(new StreamTaskException(streamTask, throwable,
-                            "Failed to Ingest Payment Order: " + throwable.getMessage()));
-                })
-                .map(paymentOrderContext -> {
-                    streamTask.error("payments", "post", "success", externalIds, paymentOrderContext.internalUserId(), "Ingested Payment Order");
-                    streamTask.setResponse(paymentOrderContext);
-                    return streamTask;
-                });
     }
 
-    public Mono<PaymentOrderIngestContext> buildPaymentOrderIngestContext(PaymentOrderIngestContext paymentOrderIngestContext) {
-
-        return getPersistedScheduledTransfers(paymentOrderIngestContext)
-                .flatMap(this::buildIngestPaymentOrderList)
-                .map(response -> {
-                    log.debug("Ingestion context successfully build and ready for add, update and delete");
-                    return response;
-                });
-    }
-
-    public Mono<PaymentOrderIngestContext> buildIngestPaymentOrderList(PaymentOrderIngestContext paymentOrderIngestContext) {
-
-        List<PaymentOrderPostRequest> newPaymentOrder = new ArrayList<>();
-        List<PaymentOrderPutRequest> updatePaymentOrder = new ArrayList<>();
-        List<String> deletePaymentOrder = new ArrayList<>();
-
-        // list of all the bank ref ids in core
-        List<String> coreBankRefIds = new ArrayList<>();
-        for (PaymentOrderPostRequest coreBankRefId : paymentOrderIngestContext.corePaymentOrder() ) {
-            coreBankRefIds.add(coreBankRefId.getBankReferenceId());
+    public Mono<PaymentOrderIngestDbsResponse> executePaymentOrderRequest(PaymentOrderIngestRequest paymentOrderIngestRequest) {
+        if (paymentOrderIngestRequest instanceof NewPaymentOrderIngestRequest) {
+            return persistNewPaymentOrders(paymentOrderIngestRequest);
+        } else if (paymentOrderIngestRequest instanceof UpdatePaymentOrderIngestRequest) {
+            return updatePaymentOrder(paymentOrderIngestRequest);
+        } else if (paymentOrderIngestRequest instanceof DeletePaymentOrderIngestRequest) {
+            return deletePaymentOrder(paymentOrderIngestRequest);
         }
-
-        // list of all the bank ref ids in DBS (existing)
-        List<String> existingBankRefIds = new ArrayList<>();
-        for (GetPaymentOrderResponse existingBankRefId : paymentOrderIngestContext.existingPaymentOrder() ) {
-            existingBankRefIds.add(existingBankRefId.getBankReferenceId());
-        }
-
-        // build new payment list (Bank ref is in core, but not in DBS)
-        paymentOrderIngestContext.corePaymentOrder().forEach(corePaymentOrder -> {
-
-            if(!existingBankRefIds.contains(corePaymentOrder.getBankReferenceId())) {
-                newPaymentOrder.add(corePaymentOrder);
-            }
-        });
-
-        // build update payment list (Bank ref is in core and DBS)
-        paymentOrderIngestContext.corePaymentOrder().forEach(corePaymentOrder -> {
-            if(existingBankRefIds.contains(corePaymentOrder.getBankReferenceId())) {
-                updatePaymentOrder.add(paymentOrderTypeMapper.mapPaymentOrderPostRequest(corePaymentOrder));
-            }
-        });
-
-        // build delete payment list (Bank ref is in DBS, but not in core)
-        paymentOrderIngestContext.existingPaymentOrder().forEach(existingPaymentOrder -> {
-
-            if(!coreBankRefIds.contains(existingPaymentOrder.getBankReferenceId())) {
-                deletePaymentOrder.add(existingPaymentOrder.getId());
-            }
-        });
-
-        paymentOrderIngestContext.newPaymentOrder(newPaymentOrder);
-        paymentOrderIngestContext.updatePaymentOrder(updatePaymentOrder);
-        paymentOrderIngestContext.deletePaymentOrder(deletePaymentOrder);
-        return Mono.just(paymentOrderIngestContext);
+        return Mono.empty();
     }
-
-    /**
-     * Gets the list of payments that are persisted in DBS for a specific user.
-     * The transfers have been divided by destination product type.
-     *
-     * @param paymentOrderIngestContext Holds all the Ingestion details.
-     * @return A Mono of List of GetPaymentOrderResponse.
-     */
-    public @NotNull @Valid Mono<PaymentOrderIngestContext> getPersistedScheduledTransfers(PaymentOrderIngestContext paymentOrderIngestContext) {
-
-        List<GetPaymentOrderResponse> listOfPayments = new ArrayList<>();
-
-        return getPayments(paymentOrderIngestContext.internalUserId())
-                .map(response -> {
-                        listOfPayments.addAll(response.getPaymentOrders());
-                    return listOfPayments;
-                })
-                .map(getPaymentOrderResponses -> paymentOrderIngestContext.existingPaymentOrder(getPaymentOrderResponses))
-                .doOnSuccess(result ->
-                        log.debug("Successfully fetched dbs scheduled payment orders"));
-    }
-
 
     /**
      * Submits a new payment request to the payment order service.
      *
-     * @param paymentOrderIngestContext Holds details of current payment ingestion.
-     * @return The list of all the response for each request. List<PaymentOrderPostResponse>
+     * @param paymentOrderIngestRequest
+     * @return Mono<PaymentOrderIngestDbsResponse>
      */
-    public Mono<PaymentOrderIngestContext> persistNewPaymentOrders(
-            PaymentOrderIngestContext paymentOrderIngestContext) {
-
-        List<PaymentOrderPostRequest> paymentOrderPostRequestList = paymentOrderIngestContext.newPaymentOrder();
-
-        return Flux.fromIterable(paymentOrderPostRequestList)
-                .flatMap(this::persistNewPaymentOrder)
-                .doOnNext(response -> log.debug("Saved new Payment Order: {}", response))
-                .collectList()
-                .map(paymentOrderPostResponses -> paymentOrderIngestContext.newPaymentOrderResponse(paymentOrderPostResponses))
-                .doOnSuccess(paymentOrderResult ->
-                        log.debug("Successfully persisted: {} new scheduled transfers.",
-                                paymentOrderResult.newPaymentOrderResponse().size()));
+    private Mono<PaymentOrderIngestDbsResponse> persistNewPaymentOrders(PaymentOrderIngestRequest paymentOrderIngestRequest) {
+        NewPaymentOrderIngestRequest newPaymentOrderIngestRequest = (NewPaymentOrderIngestRequest) paymentOrderIngestRequest;
+        return persistNewPaymentOrder(newPaymentOrderIngestRequest.getPaymentOrderPostRequest())
+            .doOnNext(response -> log.debug("Saved new Payment Order: {}", response))
+            .map(paymentOrderPostResponse -> new NewPaymentOrderIngestDbsResponse(paymentOrderPostResponse));
     }
 
     /**
      * Submit request to update a payment status.
      *
-     * @param paymentOrderIngestContext Holds details of current payment ingestion.
-     * @return The response from the api. Mono<List<UpdateStatusPut>>
+     * @param paymentOrderIngestRequest
+     * @return Mono<PaymentOrderIngestDbsResponse>
      */
-    public Mono<PaymentOrderIngestContext> updatePaymentOrder(
-            PaymentOrderIngestContext paymentOrderIngestContext) {
-
-        return Flux.fromIterable(paymentOrderIngestContext.updatePaymentOrder())
-                .flatMap(request -> updatePaymentOrderStatus(
-                        request.getBankReferenceId(),
-                        request.getStatus(),
-                        request.getBankStatus(),
-                        request.getNextExecutionDate()
-                ))
-                .doOnNext(response -> log.debug("Updated Payment Order status: {}", response))
-                .collectList()
-                .map(updateStatusPuts -> paymentOrderIngestContext.updatedPaymentOrderResponse(updateStatusPuts))
-                .onErrorContinue((t, o) -> log.error(String.format("Update status failed: %s", o), t))
-                .doOnSuccess(paymentOrderResult ->
-                        log.debug("Successfully persisted: {} Payment Order updates.",
-                                paymentOrderResult.updatedPaymentOrderResponse().size()));
+    private Mono<PaymentOrderIngestDbsResponse> updatePaymentOrder(
+        PaymentOrderIngestRequest paymentOrderIngestRequest
+    ) {
+        UpdatePaymentOrderIngestRequest updatePaymentOrderIngestRequest = (UpdatePaymentOrderIngestRequest) paymentOrderIngestRequest;
+        PaymentOrderPutRequest paymentOrderPutRequest = updatePaymentOrderIngestRequest.getPaymentOrderPutRequest();
+        return updatePaymentOrderStatus(
+            paymentOrderPutRequest.getBankReferenceId(),
+            paymentOrderPutRequest.getStatus(),
+            paymentOrderPutRequest.getBankStatus(),
+            paymentOrderPutRequest.getNextExecutionDate()
+        )
+            .doOnNext(response -> log.debug("Updated Payment Order status: {}", response))
+            .map(updateStatusPut -> new UpdatePaymentOrderIngestDbsResponse(updateStatusPut));
     }
 
     /**
      * Submit request to update a payment status.
      *
-     * @param paymentOrderIngestContext Holds details of current payment ingestion.
-     * @return The response from the api. Mono<List<UpdateStatusPut>>
+     * @param paymentOrderIngestRequest
+     * @return Mono<PaymentOrderIngestDbsResponse>
      */
-    public Mono<PaymentOrderIngestContext> deletePaymentOrder(
-            PaymentOrderIngestContext paymentOrderIngestContext) {
-
-        return Flux.fromIterable(paymentOrderIngestContext.deletePaymentOrder())
-                .flatMap(request -> deletePaymentOrder(request))
-                .doOnNext(response -> log.debug("Deleted Payment Order status: {}", response))
-                .collectList()
-                .map(paymentOrderIngestContext::deletePaymentOrderResponse)
-                .onErrorContinue((t, o) -> log.error(String.format("Update status failed: %s", o), t))
-                .doOnSuccess(paymentOrderResult ->
-                        log.debug("Successfully deleted items: {} Payment Order updates."));
+    private Mono<PaymentOrderIngestDbsResponse> deletePaymentOrder(PaymentOrderIngestRequest paymentOrderIngestRequest) {
+        DeletePaymentOrderIngestRequest deletePaymentOrderIngestRequest = (DeletePaymentOrderIngestRequest) paymentOrderIngestRequest;
+        return deletePaymentOrder(deletePaymentOrderIngestRequest.getPaymentOrderId())
+            .doOnNext(response -> log.debug("Deleted Payment Order status: " + response))
+            .map(paymentOrderId -> new DeletePaymentOrderIngestDbsResponse(paymentOrderId));
     }
 
     @Override
@@ -260,25 +162,8 @@ public class PaymentOrderTaskExecutor implements StreamTaskExecutor<PaymentOrder
      * @return A Mono with the response from the service api.
      */
     private Mono<String> deletePaymentOrder(String internalPaymentOrderId) {
-        paymentOrdersApi.deletePaymentOrder(internalPaymentOrderId);
-        return Mono.just(internalPaymentOrderId);
-    }
-
-    /**
-     * Calls the payment order service to retrieve existing payments.
-     *
-     * @param internalUserId   The user's internal id that came with the Payments.
-     * @return A Mono with the response from the service api.
-     */
-    private Mono<PaymentOrderPostFilterResponse> getPayments(String internalUserId) {
-        var paymentOrderPostFilterRequest = new PaymentOrderPostFilterRequest();
-        paymentOrderPostFilterRequest.setStatuses(
-                List.of(READY, ACCEPTED, PROCESSED, CANCELLED, REJECTED, CANCELLATION_PENDING));
-
-        return paymentOrdersApi.postFilterPaymentOrders(
-                null, null, null, null, null, null, null, null, null, null, null,
-                internalUserId, null, null, Integer.MAX_VALUE, null,
-                null, paymentOrderPostFilterRequest);
+        return paymentOrdersApi.deletePaymentOrder(internalPaymentOrderId)
+            .thenReturn(internalPaymentOrderId);
     }
 
     /**


### PR DESCRIPTION
problems in the stream-services internal code:

=> the delete payments step is not working because the reactor event flow is not connected correctly.
possible solution in the PaymentOrderTaskExecutor class:
```
private Mono<String> deletePaymentOrder(String internalPaymentOrderId) {

        return paymentOrdersApi.deletePaymentOrder(internalPaymentOrderId)

            .thenReturn(internalPaymentOrderId);

}

```

=> the newPaymentOrder, updatePaymentOrder and deletePaymentOrder list calculation logic is not working properly because the method that processes it uses only a partial list of 10 PaymentOrderPostRequest at a time, sometimes causing inconsistency in checking whether a payment order should be updated or not, for example. This happens because the PaymentOrderTask execution is configured to be emitted each time the buffer reaches 10 elements.

=> the PaymentOrderIngestContext response returned by the api is just from the last block of 10 PaymentOrderPostRequest elements processed.