### PR TITLE
Remove ingestion-mode property definition from application.yml becaus…

### DIFF
--- a/stream-compositions/services/product-composition-service/README.md
+++ b/stream-compositions/services/product-composition-service/README.md
@@ -14,5 +14,4 @@ backbase.stream.compositions.product.chains.transaction-composition.async | The 
 backbase.stream.compositions.product.chains.transaction-composition.excludeProductTypeExternalIds | The Product Types to be excluded during chaining
 backbase.stream.compositions.product.chains.events.enableCompleted | The toggle for enabling events on composition completion
 backbase.stream.compositions.product.chains.events.enableFailed | The toggle for enabling events on composition failure
-backbase.stream.compositions.product.ingestion-mode | The Ingestion mode [UPDATE,REPLACE]
 

--- a/stream-compositions/services/product-composition-service/src/main/resources/application.yml
+++ b/stream-compositions/services/product-composition-service/src/main/resources/application.yml
@@ -52,7 +52,6 @@ backbase:
         cursor:
           enabled: false
           base-url: http://product-cursor:8080
-        ingestion-mode: UPDATE
 
 logging:
   level:


### PR DESCRIPTION
Remove ingestion-mode property definition from application.yml because it is preventing product-composition-service to run on BaaS. ingestion-mode property was changed from string to object in version 3.11 and it is no longer valid.