### PR TITLE
adding requestedExecutionDate and nextExecutionDate update

### DIFF
--- a/stream-compositions/services/payment-order-composition-service/src/main/java/com/backbase/stream/compositions/paymentorders/core/mapper/PaymentOrderMapper.java
+++ b/stream-compositions/services/payment-order-composition-service/src/main/java/com/backbase/stream/compositions/paymentorders/core/mapper/PaymentOrderMapper.java
@@ -2,6 +2,7 @@ package com.backbase.stream.compositions.paymentorders.core.mapper;
 
 import java.util.List;
 
+import com.backbase.dbs.paymentorder.api.service.v2.model.PaymentOrderPutResponse;
 import org.mapstruct.InjectionStrategy;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
@@ -39,7 +40,7 @@ public interface PaymentOrderMapper {
      com.backbase.stream.compositions.paymentorder.api.model.PaymentOrderPostResponse mapStreamNewPaymentOrderToComposition(PaymentOrderPostResponse source);
 
     @Mapping(target="id", source="bankReferenceId")
-    com.backbase.stream.compositions.paymentorder.api.model.PaymentOrderPostResponse mapStreamUpdatePaymentOrderToComposition(UpdateStatusPut source);
+    com.backbase.stream.compositions.paymentorder.api.model.PaymentOrderPostResponse mapStreamUpdatePaymentOrderToComposition(PaymentOrderPutResponse source);
 
     PullIngestionRequest mapStreamToIntegration(PaymentOrderIngestPullRequest source);
 
@@ -59,7 +60,7 @@ public interface PaymentOrderMapper {
                 UpdatePaymentOrderIngestDbsResponse updatePaymentOrderIngestDbsResponse = (UpdatePaymentOrderIngestDbsResponse) paymentOrderIngestDbsResponse;
                 paymentOrderIngestionResponse.addUpdatedPaymentOrderItem(
                     this.mapStreamUpdatePaymentOrderToComposition(
-                        updatePaymentOrderIngestDbsResponse.getUpdateStatusPut()
+                        updatePaymentOrderIngestDbsResponse.getPaymentOrderPutResponse()
                     )
                 );
             } else if (paymentOrderIngestDbsResponse instanceof DeletePaymentOrderIngestDbsResponse) {

--- a/stream-compositions/services/payment-order-composition-service/src/main/java/com/backbase/stream/compositions/paymentorders/core/service/impl/PaymentOrderIntegrationServiceImpl.java
+++ b/stream-compositions/services/payment-order-composition-service/src/main/java/com/backbase/stream/compositions/paymentorders/core/service/impl/PaymentOrderIntegrationServiceImpl.java
@@ -29,5 +29,4 @@ public class PaymentOrderIntegrationServiceImpl implements PaymentOrderIntegrati
                         paymentOrderMapper.mapStreamToIntegration(ingestPullRequest))
                 .flatMapIterable(PullPaymentOrderResponse::getPaymentOrder);
     }
-
 }

--- a/stream-compositions/services/payment-order-composition-service/src/test/java/com/backbase/stream/compositions/paymentorders/http/PaymentOrderControllerTest.java
+++ b/stream-compositions/services/payment-order-composition-service/src/test/java/com/backbase/stream/compositions/paymentorders/http/PaymentOrderControllerTest.java
@@ -1,6 +1,7 @@
 package com.backbase.stream.compositions.paymentorders.http;
 
 import com.backbase.dbs.paymentorder.api.service.v2.model.PaymentOrderPostResponse;
+import com.backbase.dbs.paymentorder.api.service.v2.model.PaymentOrderPutResponse;
 import com.backbase.dbs.paymentorder.api.service.v2.model.UpdateStatusPut;
 import com.backbase.stream.PaymentOrderService;
 import com.backbase.stream.compositions.paymentorder.api.model.PaymentOrderIngestionResponse;
@@ -58,7 +59,7 @@ class PaymentOrderControllerTest {
 
         List<PaymentOrderIngestDbsResponse> paymentOrderIngestDbsResponses = new ArrayList<>();
         paymentOrderIngestDbsResponses.add(new NewPaymentOrderIngestDbsResponse(new PaymentOrderPostResponse()));
-        paymentOrderIngestDbsResponses.add(new UpdatePaymentOrderIngestDbsResponse(new UpdateStatusPut()));
+        paymentOrderIngestDbsResponses.add(new UpdatePaymentOrderIngestDbsResponse(new PaymentOrderPutResponse()));
         paymentOrderIngestDbsResponses.add(new DeletePaymentOrderIngestDbsResponse("paymentOrderId"));
 
         doAnswer(invocation -> {

--- a/stream-configuration/src/main/java/com/backbase/stream/config/BackbaseStreamConfigurationProperties.java
+++ b/stream-configuration/src/main/java/com/backbase/stream/config/BackbaseStreamConfigurationProperties.java
@@ -56,7 +56,7 @@ public class BackbaseStreamConfigurationProperties {
         /**
          * The location of DBS User Profile Manager Service.
          */
-        private String paymentOrderBaseUrl = "http://localhost:8090/payment-order-service";
+        private String paymentOrderBaseUrl = "http://payment-order-service:8080";
         /**
          * The location of Portfolio Service.
          */

--- a/stream-configuration/src/main/java/com/backbase/stream/config/BackbaseStreamConfigurationProperties.java
+++ b/stream-configuration/src/main/java/com/backbase/stream/config/BackbaseStreamConfigurationProperties.java
@@ -56,7 +56,7 @@ public class BackbaseStreamConfigurationProperties {
         /**
          * The location of DBS User Profile Manager Service.
          */
-        private String paymentOrderBaseUrl = "http://payment-order-service:8080";
+        private String paymentOrderBaseUrl = "http://localhost:8090/payment-order-service";
         /**
          * The location of Portfolio Service.
          */

--- a/stream-payment-order/payment-order-core/src/main/java/com/backbase/stream/mappers/PaymentOrderTypeMapper.java
+++ b/stream-payment-order/payment-order-core/src/main/java/com/backbase/stream/mappers/PaymentOrderTypeMapper.java
@@ -4,12 +4,14 @@ import com.backbase.dbs.paymentorder.api.service.v2.model.GetPaymentOrderRespons
 import com.backbase.dbs.paymentorder.api.service.v2.model.PaymentOrderPostRequest;
 import com.backbase.dbs.paymentorder.api.service.v2.model.PaymentOrderPutRequest;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 
 import java.util.List;
 
 @Mapper(componentModel = "spring")
 public interface PaymentOrderTypeMapper {
 
+    @Mapping(source = "schedule.nextExecutionDate", target = "nextExecutionDate")
     PaymentOrderPutRequest mapPaymentOrderPostRequest(PaymentOrderPostRequest paymentOrderPostRequest);
 
     List<PaymentOrderPostRequest> mapPaymentOrderPostRequest(List<GetPaymentOrderResponse> paymentOrderPostRequest);

--- a/stream-payment-order/payment-order-core/src/main/java/com/backbase/stream/model/response/UpdatePaymentOrderIngestDbsResponse.java
+++ b/stream-payment-order/payment-order-core/src/main/java/com/backbase/stream/model/response/UpdatePaymentOrderIngestDbsResponse.java
@@ -1,6 +1,6 @@
 package com.backbase.stream.model.response;
 
-import com.backbase.dbs.paymentorder.api.service.v2.model.UpdateStatusPut;
+import com.backbase.dbs.paymentorder.api.service.v2.model.PaymentOrderPutResponse;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -11,6 +11,6 @@ import lombok.ToString;
 @ToString
 public class UpdatePaymentOrderIngestDbsResponse implements PaymentOrderIngestDbsResponse {
 
-    private final UpdateStatusPut updateStatusPut;
+    private final PaymentOrderPutResponse paymentOrderPutResponse;
 
 }

--- a/stream-payment-order/payment-order-core/src/main/java/com/backbase/stream/paymentorder/PaymentOrderTaskExecutor.java
+++ b/stream-payment-order/payment-order-core/src/main/java/com/backbase/stream/paymentorder/PaymentOrderTaskExecutor.java
@@ -33,7 +33,7 @@ public class PaymentOrderTaskExecutor implements StreamTaskExecutor<PaymentOrder
 
     private final PaymentOrdersApi paymentOrdersApi;
 
-    private final String BANK_REFERENCE_ID = "BANKREFERENCEID";
+    private final String BANK_REFERENCE_ID_FIELD_NAME = "BANKREFERENCEID";
 
     @Override
     public Mono<PaymentOrderTask> executeTask(PaymentOrderTask streamTask) {
@@ -142,7 +142,7 @@ public class PaymentOrderTaskExecutor implements StreamTaskExecutor<PaymentOrder
     private Mono<PaymentOrderPutResponse> updatePaymentOrderStatus(String bankReferenceId,
                                                            PaymentOrderPutRequest paymentOrderPutRequest) {
 
-        return paymentOrdersApi.updatePaymentOrder(bankReferenceId, BANK_REFERENCE_ID, paymentOrderPutRequest);
+        return paymentOrdersApi.updatePaymentOrder(bankReferenceId, BANK_REFERENCE_ID_FIELD_NAME, paymentOrderPutRequest);
     }
 
     /**


### PR DESCRIPTION
The previous endpoint (https://developer.backbase.com/apis/specs/payment/payment-order-service-api/2.11.0/operations/PaymentOrders/putUpdateStatus/), 
did not allow for nextExecutionDate and requestedExecutionDate to be updated.
I replaced the update with another endpoint to solve this (https://developer.backbase.com/apis/specs/payment/payment-order-service-api/2.11.0/operations/PaymentOrders/putUpdateStatus/)