### PR TITLE
Fix 'current investment' mapping for the InvestmentAccount.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [3.20.1](https://github.com/Backbase/stream-services/compare/3.20.0...3.20.1)
+### Added
+- Fixed current investment field mapping for the InvestmentAccount
+
 ## [3.20.0](https://github.com/Backbase/stream-services/compare/3.19.0...3.20.0)
 ### Added
 - Additional groups added as attribute to User model and will be passed to legal-entity-integration service within Legal Entity Saga execution

--- a/stream-product/product-core/src/main/java/com/backbase/stream/product/mapping/ProductMapper.java
+++ b/stream-product/product-core/src/main/java/com/backbase/stream/product/mapping/ProductMapper.java
@@ -6,7 +6,6 @@ import com.backbase.dbs.arrangement.api.service.v2.model.AccountArrangementItemP
 import com.backbase.dbs.arrangement.api.service.v2.model.AccountArrangementItemPut;
 import com.backbase.dbs.arrangement.api.service.v2.model.AccountUserPreferencesItemPut;
 import com.backbase.dbs.arrangement.api.service.v2.model.TimeUnit;
-import com.backbase.stream.legalentity.model.*;
 
 import java.math.BigDecimal;
 import java.time.OffsetDateTime;
@@ -14,6 +13,25 @@ import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import com.backbase.stream.legalentity.model.AvailableBalance;
+import com.backbase.stream.legalentity.model.BaseProduct;
+import com.backbase.stream.legalentity.model.BookedBalance;
+import com.backbase.stream.legalentity.model.CreditCard;
+import com.backbase.stream.legalentity.model.CreditLimit;
+import com.backbase.stream.legalentity.model.CurrentAccount;
+import com.backbase.stream.legalentity.model.CurrentInvestment;
+import com.backbase.stream.legalentity.model.DebitCard;
+import com.backbase.stream.legalentity.model.InterestPaymentFrequencyUnit;
+import com.backbase.stream.legalentity.model.InvestmentAccount;
+import com.backbase.stream.legalentity.model.LegalEntity;
+import com.backbase.stream.legalentity.model.LegalEntityReference;
+import com.backbase.stream.legalentity.model.Loan;
+import com.backbase.stream.legalentity.model.PrincipalAmount;
+import com.backbase.stream.legalentity.model.Product;
+import com.backbase.stream.legalentity.model.SavingsAccount;
+import com.backbase.stream.legalentity.model.TermDeposit;
+import com.backbase.stream.legalentity.model.TermUnit;
+import com.backbase.stream.legalentity.model.UserPreferences;
 import org.mapstruct.InheritConfiguration;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;

--- a/stream-product/product-core/src/main/java/com/backbase/stream/product/mapping/ProductMapper.java
+++ b/stream-product/product-core/src/main/java/com/backbase/stream/product/mapping/ProductMapper.java
@@ -6,24 +6,7 @@ import com.backbase.dbs.arrangement.api.service.v2.model.AccountArrangementItemP
 import com.backbase.dbs.arrangement.api.service.v2.model.AccountArrangementItemPut;
 import com.backbase.dbs.arrangement.api.service.v2.model.AccountUserPreferencesItemPut;
 import com.backbase.dbs.arrangement.api.service.v2.model.TimeUnit;
-import com.backbase.stream.legalentity.model.AvailableBalance;
-import com.backbase.stream.legalentity.model.BaseProduct;
-import com.backbase.stream.legalentity.model.BookedBalance;
-import com.backbase.stream.legalentity.model.CreditCard;
-import com.backbase.stream.legalentity.model.CreditLimit;
-import com.backbase.stream.legalentity.model.CurrentAccount;
-import com.backbase.stream.legalentity.model.DebitCard;
-import com.backbase.stream.legalentity.model.InterestPaymentFrequencyUnit;
-import com.backbase.stream.legalentity.model.InvestmentAccount;
-import com.backbase.stream.legalentity.model.LegalEntity;
-import com.backbase.stream.legalentity.model.LegalEntityReference;
-import com.backbase.stream.legalentity.model.Loan;
-import com.backbase.stream.legalentity.model.PrincipalAmount;
-import com.backbase.stream.legalentity.model.Product;
-import com.backbase.stream.legalentity.model.SavingsAccount;
-import com.backbase.stream.legalentity.model.TermDeposit;
-import com.backbase.stream.legalentity.model.TermUnit;
-import com.backbase.stream.legalentity.model.UserPreferences;
+import com.backbase.stream.legalentity.model.*;
 
 import java.math.BigDecimal;
 import java.time.OffsetDateTime;
@@ -179,6 +162,7 @@ public interface ProductMapper {
     @Mapping(source = ProductMapperConstants.EXTERNAL_PRODUCT_ID, target = ProductMapperConstants.PRODUCT_TYPE_EXTERNAL_ID)
     @Mapping(source = ProductMapperConstants.LEGAL_ENTITY_IDS, target = ProductMapperConstants.LEGAL_ENTITIES)
     @Mapping(source = ProductMapperConstants.ID, target = ProductMapperConstants.INTERNAL_ID)
+    @Mapping(source = "currentInvestmentValue", target = "currentInvestment")
     InvestmentAccount mapInvestmentAccount(AccountArrangementItem product);
 
 
@@ -204,6 +188,13 @@ public interface ProductMapper {
         if (bigDecimal == null)
             return null;
         return new CreditLimit().amount(bigDecimal);
+    }
+
+    default CurrentInvestment mapCurrentInvestment(BigDecimal bigDecimal) {
+        if (bigDecimal == null) {
+            return null;
+        }
+        return new CurrentInvestment().amount(bigDecimal);
     }
 
     default LegalEntity mapLegalEntity(String legalEntityId) {

--- a/stream-product/product-core/src/test/java/com/backbase/stream/product/mapping/ProductMapperTest.java
+++ b/stream-product/product-core/src/test/java/com/backbase/stream/product/mapping/ProductMapperTest.java
@@ -327,6 +327,13 @@ public class ProductMapperTest {
     }
 
     @Test
+    public void mapCurrentInvestment() {
+        BigDecimal source = new BigDecimal("12345.69");
+        CurrentInvestment target = productMapper.mapCurrentInvestment(source);
+        Assertions.assertEquals(source, target.getAmount());
+    }
+
+    @Test
     public void mapPrincipal() {
         BigDecimal source = new BigDecimal("130.79");
         PrincipalAmount target = productMapper.mapPrincipal(source);


### PR DESCRIPTION
The field AccountArrangementItem::currentInvestmentValue is not mapped to InvestmentAccount::currentInvestment because of the name difference. This PR fixes given mapping issue.