### PR TITLE
Hotfix/fix user additionals ingestion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [3.15.2](https://github.com/Backbase/stream-services/compare/3.15.1...3.15.2)
+### Changed
+- Add the population of optional user additions to the service used by user ingestion in identity integration mode. 
+User additions are result of data extension to the OOTB user manager service.
+- 
 ## [3.15.1](https://github.com/Backbase/stream-services/compare/3.15.0...3.15.1)
 ### Changed
 - Adding null checks for ingesting legal entity, service agreement and arrangements with no users - User pre enrolment scenario.

--- a/stream-access-control/access-control-core/src/main/java/com/backbase/stream/service/UserService.java
+++ b/stream-access-control/access-control-core/src/main/java/com/backbase/stream/service/UserService.java
@@ -273,6 +273,7 @@ public class UserService {
             createIdentityRequest.setEmailAddress(user.getEmailAddress().getAddress());
             createIdentityRequest.setMobileNumber(user.getMobileNumber().getNumber());
             ofNullable(user.getAttributes()).ifPresent(createIdentityRequest::setAttributes);
+            ofNullable(user.getAdditions()).ifPresent(createIdentityRequest::setAdditions);
         }
 
         return identityManagementApi.createIdentity(createIdentityRequest)


### PR DESCRIPTION
Add the population of optional user additions to the service used by user ingestion in identity integration mode. 
User additions are result of data extension to the OOTB user manager service.