### PR TITLE
Hotfix/payment get endpoint update

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,3 +56,4 @@ Please see the license terms [here](LICENSE.txt).
 
 ## Contributing
 This is an open-source project! Please check our contribution guidelines [here](CONTRIBUTING.md).
+

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Stream Services are an Open-Source accelerator to connect with Backbase "out-of-
 The orchestration of calling different services is written in a functional programming style on project reactor enabling resiliency and scalability. 
 Stream Services are packaged as libraries that can be included in any project, REST Service and/or Spring Cloud Data Flow Applications.
 
-The Services are listed with Service name and how they are packaged.
+The Services are listed with Service name and how they are packaged
 
 Currently, the following DBS services are exposed as Stream Components:
 * [Stream Legal Entity](stream-legal-entity) (Lib, Rest, Task) → Legal Entity Ingestion Service that orchestrate all calls to DBS from a single aggregate model. This service is exposed as a library and a REST full service. Supports retry of the aggregate and uses the Legal Entity Ingestion Model to have a single interface into DBS. Requires Access Control, Product Summary

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Stream Services are an Open-Source accelerator to connect with Backbase "out-of-
 The orchestration of calling different services is written in a functional programming style on project reactor enabling resiliency and scalability. 
 Stream Services are packaged as libraries that can be included in any project, REST Service and/or Spring Cloud Data Flow Applications.
 
-The Services are listed with Service name and how they are packaged
+The Services are listed with Service name and how they are packaged.
 
 Currently, the following DBS services are exposed as Stream Components:
 * [Stream Legal Entity](stream-legal-entity) (Lib, Rest, Task) → Legal Entity Ingestion Service that orchestrate all calls to DBS from a single aggregate model. This service is exposed as a library and a REST full service. Supports retry of the aggregate and uses the Legal Entity Ingestion Model to have a single interface into DBS. Requires Access Control, Product Summary

--- a/stream-compositions/services/payment-order-composition-service/src/main/java/com/backbase/stream/compositions/paymentorders/core/mapper/PaymentOrderMapper.java
+++ b/stream-compositions/services/payment-order-composition-service/src/main/java/com/backbase/stream/compositions/paymentorders/core/mapper/PaymentOrderMapper.java
@@ -2,6 +2,7 @@ package com.backbase.stream.compositions.paymentorders.core.mapper;
 
 import java.util.List;
 
+import com.backbase.dbs.paymentorder.api.service.v2.model.PaymentOrderPutResponse;
 import org.mapstruct.InjectionStrategy;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
@@ -40,7 +41,7 @@ public interface PaymentOrderMapper {
      com.backbase.stream.compositions.paymentorder.api.model.PaymentOrderPostResponse mapStreamNewPaymentOrderToComposition(PaymentOrderPostResponse source);
 
     @Mapping(target="id", source="bankReferenceId")
-    com.backbase.stream.compositions.paymentorder.api.model.PaymentOrderPostResponse mapStreamUpdatePaymentOrderToComposition(UpdateStatusPut source);
+    com.backbase.stream.compositions.paymentorder.api.model.PaymentOrderPostResponse mapStreamUpdatePaymentOrderToComposition(PaymentOrderPutResponse source);
 
     PullIngestionRequest mapStreamToIntegration(PaymentOrderIngestPullRequest source);
 
@@ -62,7 +63,7 @@ public interface PaymentOrderMapper {
                 UpdatePaymentOrderIngestDbsResponse updatePaymentOrderIngestDbsResponse = (UpdatePaymentOrderIngestDbsResponse) paymentOrderIngestDbsResponse;
                 paymentOrderIngestionResponse.addUpdatedPaymentOrderItem(
                     this.mapStreamUpdatePaymentOrderToComposition(
-                        updatePaymentOrderIngestDbsResponse.getUpdateStatusPut()
+                        updatePaymentOrderIngestDbsResponse.getPaymentOrderPutResponse()
                     )
                 );
             } else if (paymentOrderIngestDbsResponse instanceof DeletePaymentOrderIngestDbsResponse) {

--- a/stream-compositions/services/payment-order-composition-service/src/main/java/com/backbase/stream/compositions/paymentorders/core/service/impl/PaymentOrderIntegrationServiceImpl.java
+++ b/stream-compositions/services/payment-order-composition-service/src/main/java/com/backbase/stream/compositions/paymentorders/core/service/impl/PaymentOrderIntegrationServiceImpl.java
@@ -29,5 +29,4 @@ public class PaymentOrderIntegrationServiceImpl implements PaymentOrderIntegrati
                         paymentOrderMapper.mapStreamToIntegration(ingestPullRequest))
                 .flatMapIterable(PullPaymentOrderResponse::getPaymentOrder);
     }
-
 }

--- a/stream-compositions/services/payment-order-composition-service/src/main/resources/application-local.yml
+++ b/stream-compositions/services/payment-order-composition-service/src/main/resources/application-local.yml
@@ -36,6 +36,9 @@ backbase:
   activemq:
     enabled: true
   stream:
+    paymentorder:
+      worker:
+        deletePaymentOrder: false
     compositions:
       paymentorder:
         integration-base-url: http://localhost:7004

--- a/stream-compositions/services/payment-order-composition-service/src/main/resources/application.yml
+++ b/stream-compositions/services/payment-order-composition-service/src/main/resources/application.yml
@@ -44,6 +44,9 @@ backbase:
       authentication:
         required-scope: api:service
   stream:
+    paymentorder:
+      worker:
+        deletePaymentOrder: false
     compositions:
       paymentorder:
         integration-base-url: http://payment-order-integration:8080

--- a/stream-compositions/services/payment-order-composition-service/src/test/java/com/backbase/stream/compositions/paymentorders/http/PaymentOrderControllerTest.java
+++ b/stream-compositions/services/payment-order-composition-service/src/test/java/com/backbase/stream/compositions/paymentorders/http/PaymentOrderControllerTest.java
@@ -1,6 +1,7 @@
 package com.backbase.stream.compositions.paymentorders.http;
 
 import com.backbase.dbs.paymentorder.api.service.v2.model.PaymentOrderPostResponse;
+import com.backbase.dbs.paymentorder.api.service.v2.model.PaymentOrderPutResponse;
 import com.backbase.dbs.paymentorder.api.service.v2.model.UpdateStatusPut;
 import com.backbase.stream.PaymentOrderService;
 import com.backbase.stream.compositions.paymentorder.api.model.PaymentOrderIngestionResponse;
@@ -58,7 +59,7 @@ class PaymentOrderControllerTest {
 
         List<PaymentOrderIngestDbsResponse> paymentOrderIngestDbsResponses = new ArrayList<>();
         paymentOrderIngestDbsResponses.add(new NewPaymentOrderIngestDbsResponse(new PaymentOrderPostResponse()));
-        paymentOrderIngestDbsResponses.add(new UpdatePaymentOrderIngestDbsResponse(new UpdateStatusPut()));
+        paymentOrderIngestDbsResponses.add(new UpdatePaymentOrderIngestDbsResponse(new PaymentOrderPutResponse()));
         paymentOrderIngestDbsResponses.add(new DeletePaymentOrderIngestDbsResponse("paymentOrderId"));
 
         doAnswer(invocation -> {

--- a/stream-payment-order/payment-order-core/src/main/java/com/backbase/stream/config/PaymentOrderWorkerConfigurationProperties.java
+++ b/stream-payment-order/payment-order-core/src/main/java/com/backbase/stream/config/PaymentOrderWorkerConfigurationProperties.java
@@ -14,5 +14,5 @@ public class PaymentOrderWorkerConfigurationProperties extends StreamWorkerConfi
 
     private boolean continueOnError;
 
-    private boolean deletePaymentOrder = true;
+    private boolean deletePaymentOrder = false;
 }

--- a/stream-payment-order/payment-order-core/src/main/java/com/backbase/stream/mappers/PaymentOrderTypeMapper.java
+++ b/stream-payment-order/payment-order-core/src/main/java/com/backbase/stream/mappers/PaymentOrderTypeMapper.java
@@ -4,12 +4,14 @@ import com.backbase.dbs.paymentorder.api.service.v2.model.GetPaymentOrderRespons
 import com.backbase.dbs.paymentorder.api.service.v2.model.PaymentOrderPostRequest;
 import com.backbase.dbs.paymentorder.api.service.v2.model.PaymentOrderPutRequest;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 
 import java.util.List;
 
 @Mapper(componentModel = "spring")
 public interface PaymentOrderTypeMapper {
 
+    @Mapping(source = "schedule.nextExecutionDate", target = "nextExecutionDate")
     PaymentOrderPutRequest mapPaymentOrderPostRequest(PaymentOrderPostRequest paymentOrderPostRequest);
 
     List<PaymentOrderPostRequest> mapPaymentOrderPostRequest(List<GetPaymentOrderResponse> paymentOrderPostRequest);

--- a/stream-payment-order/payment-order-core/src/main/java/com/backbase/stream/model/response/UpdatePaymentOrderIngestDbsResponse.java
+++ b/stream-payment-order/payment-order-core/src/main/java/com/backbase/stream/model/response/UpdatePaymentOrderIngestDbsResponse.java
@@ -1,6 +1,6 @@
 package com.backbase.stream.model.response;
 
-import com.backbase.dbs.paymentorder.api.service.v2.model.UpdateStatusPut;
+import com.backbase.dbs.paymentorder.api.service.v2.model.PaymentOrderPutResponse;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -11,6 +11,6 @@ import lombok.ToString;
 @ToString
 public class UpdatePaymentOrderIngestDbsResponse implements PaymentOrderIngestDbsResponse {
 
-    private final UpdateStatusPut updateStatusPut;
+    private final PaymentOrderPutResponse paymentOrderPutResponse;
 
 }

--- a/stream-payment-order/payment-order-core/src/main/java/com/backbase/stream/paymentorder/PaymentOrderTaskExecutor.java
+++ b/stream-payment-order/payment-order-core/src/main/java/com/backbase/stream/paymentorder/PaymentOrderTaskExecutor.java
@@ -1,18 +1,16 @@
 package com.backbase.stream.paymentorder;
 
-import java.time.LocalDate;
 import java.util.UUID;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+import com.backbase.dbs.paymentorder.api.service.v2.model.PaymentOrderPutResponse;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
 
 import com.backbase.dbs.paymentorder.api.service.v2.PaymentOrdersApi;
 import com.backbase.dbs.paymentorder.api.service.v2.model.PaymentOrderPostRequest;
 import com.backbase.dbs.paymentorder.api.service.v2.model.PaymentOrderPostResponse;
 import com.backbase.dbs.paymentorder.api.service.v2.model.PaymentOrderPutRequest;
-import com.backbase.dbs.paymentorder.api.service.v2.model.Status;
-import com.backbase.dbs.paymentorder.api.service.v2.model.UpdateStatusPut;
 import com.backbase.stream.model.request.DeletePaymentOrderIngestRequest;
 import com.backbase.stream.model.request.NewPaymentOrderIngestRequest;
 import com.backbase.stream.model.request.PaymentOrderIngestRequest;
@@ -34,6 +32,8 @@ import reactor.core.publisher.Mono;
 public class PaymentOrderTaskExecutor implements StreamTaskExecutor<PaymentOrderTask> {
 
     private final PaymentOrdersApi paymentOrdersApi;
+
+    private final String BANK_REFERENCE_ID = "BANKREFERENCEID";
 
     @Override
     public Mono<PaymentOrderTask> executeTask(PaymentOrderTask streamTask) {
@@ -92,11 +92,10 @@ public class PaymentOrderTaskExecutor implements StreamTaskExecutor<PaymentOrder
     ) {
         UpdatePaymentOrderIngestRequest updatePaymentOrderIngestRequest = (UpdatePaymentOrderIngestRequest) paymentOrderIngestRequest;
         PaymentOrderPutRequest paymentOrderPutRequest = updatePaymentOrderIngestRequest.getPaymentOrderPutRequest();
+
         return updatePaymentOrderStatus(
             paymentOrderPutRequest.getBankReferenceId(),
-            paymentOrderPutRequest.getStatus(),
-            paymentOrderPutRequest.getBankStatus(),
-            paymentOrderPutRequest.getNextExecutionDate()
+                paymentOrderPutRequest
         )
             .doOnNext(response -> log.debug("Updated Payment Order status: {}", response))
             .map(updateStatusPut -> new UpdatePaymentOrderIngestDbsResponse(updateStatusPut));
@@ -137,22 +136,13 @@ public class PaymentOrderTaskExecutor implements StreamTaskExecutor<PaymentOrder
      * Calls the payment order service to update the status of an existing payment.
      *
      * @param bankReferenceId   The bank reference id.
-     * @param status            the status of the transaction
-     * @param bankStatus        The bank status.
-     * @param nextExecutionDate The next execution date.
+     * @param paymentOrderPutRequest holds all the data that needs to be updated
      * @return A Mono with the response from the service api.
      */
-    private Mono<UpdateStatusPut> updatePaymentOrderStatus(String bankReferenceId,
-                                                     Status status,
-                                                     String bankStatus,
-                                                     LocalDate nextExecutionDate) {
+    private Mono<PaymentOrderPutResponse> updatePaymentOrderStatus(String bankReferenceId,
+                                                           PaymentOrderPutRequest paymentOrderPutRequest) {
 
-        var updatePaymentStatus = new UpdateStatusPut()
-                .bankReferenceId(bankReferenceId)
-                .status(status)
-                .bankStatus(bankStatus)
-                .nextExecutionDate(nextExecutionDate);
-        return paymentOrdersApi.putUpdateStatus(updatePaymentStatus);
+        return paymentOrdersApi.updatePaymentOrder(bankReferenceId, BANK_REFERENCE_ID, paymentOrderPutRequest);
     }
 
     /**

--- a/stream-payment-order/payment-order-core/src/main/java/com/backbase/stream/paymentorder/PaymentOrderTaskExecutor.java
+++ b/stream-payment-order/payment-order-core/src/main/java/com/backbase/stream/paymentorder/PaymentOrderTaskExecutor.java
@@ -33,7 +33,7 @@ public class PaymentOrderTaskExecutor implements StreamTaskExecutor<PaymentOrder
 
     private final PaymentOrdersApi paymentOrdersApi;
 
-    private final String BANK_REFERENCE_ID = "BANKREFERENCEID";
+    private final String BANK_REFERENCE_ID_FIELD_NAME = "BANKREFERENCEID";
 
     @Override
     public Mono<PaymentOrderTask> executeTask(PaymentOrderTask streamTask) {
@@ -142,7 +142,7 @@ public class PaymentOrderTaskExecutor implements StreamTaskExecutor<PaymentOrder
     private Mono<PaymentOrderPutResponse> updatePaymentOrderStatus(String bankReferenceId,
                                                            PaymentOrderPutRequest paymentOrderPutRequest) {
 
-        return paymentOrdersApi.updatePaymentOrder(bankReferenceId, BANK_REFERENCE_ID, paymentOrderPutRequest);
+        return paymentOrdersApi.updatePaymentOrder(bankReferenceId, BANK_REFERENCE_ID_FIELD_NAME, paymentOrderPutRequest);
     }
 
     /**


### PR DESCRIPTION
This is a cherry-pick merge from a prior support fix: https://github.com/Backbase/stream-services/pull/268

In addition to that, we've also included the configuration (stream.paymentorder.worker.deletePaymentOrder: true/false) on whether a Payment should be deleted or not from the DBS database. Some clients do not ever delete a payment (only expire them) and others do. This should accommodate both. 
