### PR TITLE
Added cherry-picked code from version 2.88.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [2.69.1]
+### Added
+- Ability to clean up UnitOfWorkExecutor when working with InMemoryReactiveRepository.
 
 ## [2.69.0]
 ### Added

--- a/pom.xml
+++ b/pom.xml
@@ -6,13 +6,13 @@
     <parent>
         <groupId>com.backbase.stream</groupId>
         <artifactId>stream-sdk-starter-core</artifactId>
-        <version>2.69.0</version>
+        <version>2.69.1</version>
         <relativePath>stream-sdk/stream-starter-parents/stream-sdk-starter-core</relativePath>
     </parent>
 
     <groupId>com.backbase.stream</groupId>
     <artifactId>stream-services</artifactId>
-    <version>2.69.0</version>
+    <version>2.69.1</version>
 
     <packaging>pom</packaging>
     <name>Stream :: Services</name>

--- a/stream-access-control/access-control-core/pom.xml
+++ b/stream-access-control/access-control-core/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.backbase.stream</groupId>
         <artifactId>stream-access-control</artifactId>
-        <version>2.69.0</version>
+        <version>2.69.1</version>
     </parent>
 
     <artifactId>access-control-core</artifactId>

--- a/stream-access-control/pom.xml
+++ b/stream-access-control/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.backbase.stream</groupId>
         <artifactId>stream-services</artifactId>
-        <version>2.69.0</version>
+        <version>2.69.1</version>
     </parent>
 
     <artifactId>stream-access-control</artifactId>

--- a/stream-approvals/approvals-bootstrap-task/pom.xml
+++ b/stream-approvals/approvals-bootstrap-task/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <groupId>com.backbase.stream</groupId>
         <artifactId>stream-task-starter-parent</artifactId>
-        <version>2.69.0</version>
+        <version>2.69.1</version>
         <relativePath>../../stream-sdk/stream-starter-parents/stream-task-starter-parent</relativePath>
     </parent>
 
     <artifactId>approvals-bootstrap-task</artifactId>
-    <version>2.69.0</version>
+    <version>2.69.1</version>
 
     <packaging>jar</packaging>
     <name>Stream :: Approvals Bootstrap Task</name>

--- a/stream-approvals/approvals-core/pom.xml
+++ b/stream-approvals/approvals-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.backbase.stream</groupId>
         <artifactId>stream-approvals</artifactId>
-        <version>2.69.0</version>
+        <version>2.69.1</version>
     </parent>
 
     <artifactId>approvals-core</artifactId>

--- a/stream-approvals/pom.xml
+++ b/stream-approvals/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.backbase.stream</groupId>
         <artifactId>stream-services</artifactId>
-        <version>2.69.0</version>
+        <version>2.69.1</version>
     </parent>
 
     <artifactId>stream-approvals</artifactId>

--- a/stream-configuration/pom.xml
+++ b/stream-configuration/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.backbase.stream</groupId>
         <artifactId>stream-services</artifactId>
-        <version>2.69.0</version>
+        <version>2.69.1</version>
     </parent>
 
     <artifactId>stream-configuration</artifactId>

--- a/stream-cursor/cursor-core/pom.xml
+++ b/stream-cursor/cursor-core/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.backbase.stream</groupId>
         <artifactId>stream-cursor</artifactId>
-        <version>2.69.0</version>
+        <version>2.69.1</version>
     </parent>
 
     <artifactId>cursor-core</artifactId>

--- a/stream-cursor/cursor-http/pom.xml
+++ b/stream-cursor/cursor-http/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <groupId>com.backbase.stream</groupId>
         <artifactId>stream-http-starter-parent</artifactId>
-        <version>2.69.0</version>
+        <version>2.69.1</version>
         <relativePath>../../stream-sdk/stream-starter-parents/stream-http-starter-parent</relativePath>
     </parent>
 
     <artifactId>cursor-http</artifactId>
-    <version>2.69.0</version>
+    <version>2.69.1</version>
 
     <packaging>jar</packaging>
     <name>Stream :: Cursor HTTP</name>
@@ -25,13 +25,13 @@
         <dependency>
             <groupId>com.backbase.stream</groupId>
             <artifactId>cursor-publishers</artifactId>
-            <version>2.69.0</version>
+            <version>2.69.1</version>
         </dependency>
 
         <dependency>
             <groupId>com.backbase.stream</groupId>
             <artifactId>cursor-store</artifactId>
-            <version>2.69.0</version>
+            <version>2.69.1</version>
         </dependency>
 
     </dependencies>

--- a/stream-cursor/cursor-publishers/pom.xml
+++ b/stream-cursor/cursor-publishers/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.backbase.stream</groupId>
         <artifactId>stream-cursor</artifactId>
-        <version>2.69.0</version>
+        <version>2.69.1</version>
     </parent>
 
     <artifactId>cursor-publishers</artifactId>
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>com.backbase.stream</groupId>
             <artifactId>access-control-core</artifactId>
-            <version>2.69.0</version>
+            <version>2.69.1</version>
         </dependency>
 
         <!-- JMS Dependencies -->
@@ -40,7 +40,7 @@
         <dependency>
             <groupId>com.backbase.stream</groupId>
             <artifactId>cursor-core</artifactId>
-            <version>2.69.0</version>
+            <version>2.69.1</version>
         </dependency>
 
         <dependency>
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>com.backbase.stream</groupId>
             <artifactId>transactions-core</artifactId>
-            <version>2.69.0</version>
+            <version>2.69.1</version>
         </dependency>
 
     </dependencies>

--- a/stream-cursor/cursor-source/pom.xml
+++ b/stream-cursor/cursor-source/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <groupId>com.backbase.stream</groupId>
         <artifactId>stream-source-starter-parent</artifactId>
-        <version>2.69.0</version>
+        <version>2.69.1</version>
         <relativePath>../../stream-sdk/stream-starter-parents/stream-source-starter-parent</relativePath>
     </parent>
 
     <artifactId>cursor-source</artifactId>
-    <version>2.69.0</version>
+    <version>2.69.1</version>
 
     <packaging>jar</packaging>
     <name>Stream :: Cursor Source</name>
@@ -21,7 +21,7 @@
         <dependency>
             <groupId>com.backbase.stream</groupId>
             <artifactId>cursor-publishers</artifactId>
-            <version>2.69.0</version>
+            <version>2.69.1</version>
         </dependency>
 
         <dependency>

--- a/stream-cursor/cursor-store/pom.xml
+++ b/stream-cursor/cursor-store/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.backbase.stream</groupId>
         <artifactId>stream-cursor</artifactId>
-        <version>2.69.0</version>
+        <version>2.69.1</version>
     </parent>
 
     <artifactId>cursor-store</artifactId>
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>com.backbase.stream</groupId>
             <artifactId>cursor-core</artifactId>
-            <version>2.69.0</version>
+            <version>2.69.1</version>
         </dependency>
 
     </dependencies>

--- a/stream-cursor/pom.xml
+++ b/stream-cursor/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.backbase.stream</groupId>
         <artifactId>stream-services</artifactId>
-        <version>2.69.0</version>
+        <version>2.69.1</version>
     </parent>
 
     <artifactId>stream-cursor</artifactId>

--- a/stream-dbs-clients/pom.xml
+++ b/stream-dbs-clients/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.backbase.stream</groupId>
         <artifactId>stream-services</artifactId>
-        <version>2.69.0</version>
+        <version>2.69.1</version>
     </parent>
 
     <artifactId>stream-dbs-clients</artifactId>

--- a/stream-legal-entity/legal-entity-bootstrap-task/pom.xml
+++ b/stream-legal-entity/legal-entity-bootstrap-task/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <groupId>com.backbase.stream</groupId>
         <artifactId>stream-task-starter-parent</artifactId>
-        <version>2.69.0</version>
+        <version>2.69.1</version>
         <relativePath>../../stream-sdk/stream-starter-parents/stream-task-starter-parent</relativePath>
     </parent>
 
     <artifactId>legal-entity-bootstrap-task</artifactId>
-    <version>2.69.0</version>
+    <version>2.69.1</version>
 
     <packaging>jar</packaging>
     <name>Stream :: Legal Entity Bootstrap Task</name>
@@ -25,7 +25,7 @@
         <dependency>
             <groupId>com.backbase.stream</groupId>
             <artifactId>legal-entity-core</artifactId>
-            <version>2.69.0</version>
+            <version>2.69.1</version>
         </dependency>
 
         <dependency>

--- a/stream-legal-entity/legal-entity-core/pom.xml
+++ b/stream-legal-entity/legal-entity-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.backbase.stream</groupId>
         <artifactId>stream-legal-entity</artifactId>
-        <version>2.69.0</version>
+        <version>2.69.1</version>
     </parent>
 
     <artifactId>legal-entity-core</artifactId>

--- a/stream-legal-entity/legal-entity-generator-core/pom.xml
+++ b/stream-legal-entity/legal-entity-generator-core/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.backbase.stream</groupId>
         <artifactId>stream-legal-entity</artifactId>
-        <version>2.69.0</version>
+        <version>2.69.1</version>
     </parent>
 
     <artifactId>legal-entity-generator-core</artifactId>

--- a/stream-legal-entity/legal-entity-generator-source/pom.xml
+++ b/stream-legal-entity/legal-entity-generator-source/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.backbase.stream</groupId>
         <artifactId>stream-source-starter-parent</artifactId>
-        <version>2.69.0</version>
+        <version>2.69.1</version>
         <relativePath>../../stream-sdk/stream-starter-parents/stream-source-starter-parent</relativePath>
     </parent>
 
@@ -14,14 +14,14 @@
 
     <packaging>jar</packaging>
     <name>Stream :: Generator :: Legal Entity Generator Source</name>
-    <version>2.69.0</version>
+    <version>2.69.1</version>
 
     <dependencies>
 
         <dependency>
             <groupId>com.backbase.stream</groupId>
             <artifactId>legal-entity-generator-core</artifactId>
-            <version>2.69.0</version>
+            <version>2.69.1</version>
         </dependency>
 
         <dependency>

--- a/stream-legal-entity/legal-entity-http/pom.xml
+++ b/stream-legal-entity/legal-entity-http/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <groupId>com.backbase.stream</groupId>
         <artifactId>stream-http-starter-parent</artifactId>
-        <version>2.69.0</version>
+        <version>2.69.1</version>
         <relativePath>../../stream-sdk/stream-starter-parents/stream-http-starter-parent</relativePath>
     </parent>
 
     <artifactId>legal-entity-http</artifactId>
-    <version>2.69.0</version>
+    <version>2.69.1</version>
 
     <packaging>jar</packaging>
     <name>Stream :: Legal Entity HTTP</name>
@@ -25,7 +25,7 @@
         <dependency>
             <groupId>com.backbase.stream</groupId>
             <artifactId>legal-entity-core</artifactId>
-            <version>2.69.0</version>
+            <version>2.69.1</version>
         </dependency>
 
         <dependency>

--- a/stream-legal-entity/legal-entity-sink/pom.xml
+++ b/stream-legal-entity/legal-entity-sink/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <groupId>com.backbase.stream</groupId>
         <artifactId>stream-sink-starter-parent</artifactId>
-        <version>2.69.0</version>
+        <version>2.69.1</version>
         <relativePath>../../stream-sdk/stream-starter-parents/stream-sink-starter-parent</relativePath>
     </parent>
 
     <artifactId>legal-entity-sink</artifactId>
-    <version>2.69.0</version>
+    <version>2.69.1</version>
 
     <packaging>jar</packaging>
     <name>Stream :: Legal Entity Sink</name>
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>com.backbase.stream</groupId>
             <artifactId>legal-entity-core</artifactId>
-            <version>2.69.0</version>
+            <version>2.69.1</version>
         </dependency>
 
     </dependencies>

--- a/stream-legal-entity/pom.xml
+++ b/stream-legal-entity/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.backbase.stream</groupId>
         <artifactId>stream-services</artifactId>
-        <version>2.69.0</version>
+        <version>2.69.1</version>
     </parent>
 
     <artifactId>stream-legal-entity</artifactId>

--- a/stream-limits/limits-core/pom.xml
+++ b/stream-limits/limits-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.backbase.stream</groupId>
         <artifactId>stream-limits</artifactId>
-        <version>2.69.0</version>
+        <version>2.69.1</version>
     </parent>
 
     <artifactId>limits-core</artifactId>

--- a/stream-limits/pom.xml
+++ b/stream-limits/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.backbase.stream</groupId>
         <artifactId>stream-services</artifactId>
-        <version>2.69.0</version>
+        <version>2.69.1</version>
     </parent>
 
     <artifactId>stream-limits</artifactId>

--- a/stream-models/approval-model/pom.xml
+++ b/stream-models/approval-model/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.backbase.stream</groupId>
         <artifactId>stream-models</artifactId>
-        <version>2.69.0</version>
+        <version>2.69.1</version>
     </parent>
 
     <artifactId>approval-model</artifactId>

--- a/stream-models/legal-entity-model/pom.xml
+++ b/stream-models/legal-entity-model/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.backbase.stream</groupId>
         <artifactId>stream-models</artifactId>
-        <version>2.69.0</version>
+        <version>2.69.1</version>
     </parent>
 
     <artifactId>legal-entity-model</artifactId>

--- a/stream-models/pom.xml
+++ b/stream-models/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.backbase.stream</groupId>
         <artifactId>stream-services</artifactId>
-        <version>2.69.0</version>
+        <version>2.69.1</version>
     </parent>
 
     <artifactId>stream-models</artifactId>

--- a/stream-models/product-catalog-model/pom.xml
+++ b/stream-models/product-catalog-model/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.backbase.stream</groupId>
         <artifactId>stream-models</artifactId>
-        <version>2.69.0</version>
+        <version>2.69.1</version>
     </parent>
 
     <artifactId>product-catalog-model</artifactId>

--- a/stream-product-catalog/pom.xml
+++ b/stream-product-catalog/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.backbase.stream</groupId>
         <artifactId>stream-services</artifactId>
-        <version>2.69.0</version>
+        <version>2.69.1</version>
     </parent>
 
     <artifactId>stream-product-catalog</artifactId>

--- a/stream-product-catalog/product-catalog-core/pom.xml
+++ b/stream-product-catalog/product-catalog-core/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.backbase.stream</groupId>
         <artifactId>stream-product-catalog</artifactId>
-        <version>2.69.0</version>
+        <version>2.69.1</version>
     </parent>
 
     <artifactId>product-catalog-core</artifactId>

--- a/stream-product-catalog/product-catalog-http/pom.xml
+++ b/stream-product-catalog/product-catalog-http/pom.xml
@@ -6,12 +6,12 @@
     <parent>
         <groupId>com.backbase.stream</groupId>
         <artifactId>stream-http-starter-parent</artifactId>
-        <version>2.69.0</version>
+        <version>2.69.1</version>
         <relativePath>../../stream-sdk/stream-starter-parents/stream-http-starter-parent</relativePath>
     </parent>
 
     <artifactId>product-catalog-http</artifactId>
-    <version>2.69.0</version>
+    <version>2.69.1</version>
 
     <packaging>jar</packaging>
     <name>Stream :: Product Catalog HTTP</name>
@@ -26,7 +26,7 @@
         <dependency>
             <groupId>com.backbase.stream</groupId>
             <artifactId>product-catalog-core</artifactId>
-            <version>2.69.0</version>
+            <version>2.69.1</version>
         </dependency>
 
     </dependencies>

--- a/stream-product-catalog/product-catalog-task/pom.xml
+++ b/stream-product-catalog/product-catalog-task/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <groupId>com.backbase.stream</groupId>
         <artifactId>stream-task-starter-parent</artifactId>
-        <version>2.69.0</version>
+        <version>2.69.1</version>
         <relativePath>../../stream-sdk/stream-starter-parents/stream-task-starter-parent</relativePath>
     </parent>
 
     <artifactId>product-catalog-task</artifactId>
-    <version>2.69.0</version>
+    <version>2.69.1</version>
 
     <packaging>jar</packaging>
     <name>Stream :: Product Catalog Task</name>
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>com.backbase.stream</groupId>
             <artifactId>product-catalog-core</artifactId>
-            <version>2.69.0</version>
+            <version>2.69.1</version>
         </dependency>
 
         <dependency>

--- a/stream-product/pom.xml
+++ b/stream-product/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.backbase.stream</groupId>
         <artifactId>stream-services</artifactId>
-        <version>2.69.0</version>
+        <version>2.69.1</version>
     </parent>
 
     <artifactId>stream-product</artifactId>

--- a/stream-product/product-core/pom.xml
+++ b/stream-product/product-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.backbase.stream</groupId>
         <artifactId>stream-product</artifactId>
-        <version>2.69.0</version>
+        <version>2.69.1</version>
     </parent>
 
     <artifactId>product-core</artifactId>

--- a/stream-product/product-generator-core/pom.xml
+++ b/stream-product/product-generator-core/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.backbase.stream</groupId>
         <artifactId>stream-product</artifactId>
-        <version>2.69.0</version>
+        <version>2.69.1</version>
     </parent>
 
     <artifactId>product-generator-core</artifactId>

--- a/stream-product/product-ingestion-saga/pom.xml
+++ b/stream-product/product-ingestion-saga/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.backbase.stream</groupId>
         <artifactId>stream-product</artifactId>
-        <version>2.69.0</version>
+        <version>2.69.1</version>
     </parent>
 
     <artifactId>product-ingestion-saga</artifactId>
@@ -18,13 +18,13 @@
         <dependency>
             <groupId>com.backbase.stream</groupId>
             <artifactId>product-core</artifactId>
-            <version>2.69.0</version>
+            <version>2.69.1</version>
         </dependency>
 
         <dependency>
             <groupId>com.backbase.stream</groupId>
             <artifactId>access-control-core</artifactId>
-            <version>2.69.0</version>
+            <version>2.69.1</version>
         </dependency>
 
         <dependency>

--- a/stream-product/product-sink/pom.xml
+++ b/stream-product/product-sink/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <groupId>com.backbase.stream</groupId>
         <artifactId>stream-sink-starter-parent</artifactId>
-        <version>2.69.0</version>
+        <version>2.69.1</version>
         <relativePath>../../stream-sdk/stream-starter-parents/stream-sink-starter-parent</relativePath>
     </parent>
 
     <artifactId>product-sink</artifactId>
-    <version>2.69.0</version>
+    <version>2.69.1</version>
 
     <packaging>jar</packaging>
     <name>Stream :: Product Sink</name>
@@ -20,13 +20,13 @@
         <dependency>
             <groupId>com.backbase.stream</groupId>
             <artifactId>product-ingestion-saga</artifactId>
-            <version>2.69.0</version>
+            <version>2.69.1</version>
         </dependency>
 
         <dependency>
             <groupId>com.backbase.stream</groupId>
             <artifactId>access-control-core</artifactId>
-            <version>2.69.0</version>
+            <version>2.69.1</version>
         </dependency>
 
     </dependencies>

--- a/stream-sdk/pom.xml
+++ b/stream-sdk/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.backbase.stream</groupId>
     <artifactId>stream-sdk</artifactId>
-    <version>2.69.0</version>
+    <version>2.69.1</version>
     <packaging>pom</packaging>
 
     <name>Stream :: SDK</name>

--- a/stream-sdk/stream-parent/pom.xml
+++ b/stream-sdk/stream-parent/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>com.backbase.stream</groupId>
     <artifactId>stream-parent</artifactId>
-    <version>2.69.0</version>
+    <version>2.69.1</version>
     <packaging>pom</packaging>
     <name>Stream :: SDK :: Parent</name>
     <description>Parent for all Stream SDK modules</description>

--- a/stream-sdk/stream-parent/stream-dbs-web-client/pom.xml
+++ b/stream-sdk/stream-parent/stream-dbs-web-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.backbase.stream</groupId>
         <artifactId>stream-parent</artifactId>
-        <version>2.69.0</version>
+        <version>2.69.1</version>
     </parent>
 
     <artifactId>stream-dbs-web-client</artifactId>

--- a/stream-sdk/stream-parent/stream-micrometer-support/pom.xml
+++ b/stream-sdk/stream-parent/stream-micrometer-support/pom.xml
@@ -5,11 +5,11 @@
     <parent>
         <groupId>com.backbase.stream</groupId>
         <artifactId>stream-parent</artifactId>
-        <version>2.69.0</version>
+        <version>2.69.1</version>
     </parent>
 
     <artifactId>stream-micrometer-support</artifactId>
-    <version>2.69.0</version>
+    <version>2.69.1</version>
     <packaging>jar</packaging>
     <name>Stream :: SDK :: Stream Micro Meter Support</name>
     <description>Autoconfigure Stream Micro Meter tags exposing correct information</description>

--- a/stream-sdk/stream-parent/stream-openapi-support/pom.xml
+++ b/stream-sdk/stream-parent/stream-openapi-support/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.backbase.stream</groupId>
         <artifactId>stream-parent</artifactId>
-        <version>2.69.0</version>
+        <version>2.69.1</version>
     </parent>
 
     <artifactId>stream-openapi-support</artifactId>

--- a/stream-sdk/stream-parent/stream-scs-starter-config/pom.xml
+++ b/stream-sdk/stream-parent/stream-scs-starter-config/pom.xml
@@ -5,11 +5,11 @@
     <parent>
         <groupId>com.backbase.stream</groupId>
         <artifactId>stream-parent</artifactId>
-        <version>2.69.0</version>
+        <version>2.69.1</version>
     </parent>
 
     <artifactId>stream-scs-starter-config</artifactId>
-    <version>2.69.0</version>
+    <version>2.69.1</version>
     <packaging>jar</packaging>
     <name>Stream :: SDK :: SCS Starter Configuration</name>
     <description>Default Configuration for Stream Spring Cloud Stream Starters</description>

--- a/stream-sdk/stream-parent/stream-test-support/pom.xml
+++ b/stream-sdk/stream-parent/stream-test-support/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.backbase.stream</groupId>
         <artifactId>stream-parent</artifactId>
-        <version>2.69.0</version>
+        <version>2.69.1</version>
     </parent>
 
     <artifactId>stream-test-support</artifactId>
@@ -27,7 +27,7 @@
         <dependency>
             <groupId>com.backbase.stream</groupId>
             <artifactId>stream-dbs-web-client</artifactId>
-            <version>2.69.0</version>
+            <version>2.69.1</version>
             <optional>true</optional>
             <scope>provided</scope>
         </dependency>

--- a/stream-sdk/stream-parent/stream-web-start-mvc/pom.xml
+++ b/stream-sdk/stream-parent/stream-web-start-mvc/pom.xml
@@ -5,11 +5,11 @@
     <parent>
         <groupId>com.backbase.stream</groupId>
         <artifactId>stream-parent</artifactId>
-        <version>2.69.0</version>
+        <version>2.69.1</version>
     </parent>
 
     <artifactId>stream-web-start-mvc</artifactId>
-    <version>2.69.0</version>
+    <version>2.69.1</version>
     <packaging>jar</packaging>
     <name>Stream :: SDK :: Web Start MVC</name>
     <description>Start Page Processing for Spring MVC projects</description>

--- a/stream-sdk/stream-parent/stream-web-start-ui/pom.xml
+++ b/stream-sdk/stream-parent/stream-web-start-ui/pom.xml
@@ -5,11 +5,11 @@
     <parent>
         <groupId>com.backbase.stream</groupId>
         <artifactId>stream-parent</artifactId>
-        <version>2.69.0</version>
+        <version>2.69.1</version>
     </parent>
 
     <artifactId>stream-web-start-ui</artifactId>
-    <version>2.69.0</version>
+    <version>2.69.1</version>
     <packaging>jar</packaging>
     <name>Stream :: SDK :: Web Start UI</name>
     <description>Shared Start Page for Web Apps based on Stream SDK</description>

--- a/stream-sdk/stream-parent/stream-worker/pom.xml
+++ b/stream-sdk/stream-parent/stream-worker/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.backbase.stream</groupId>
         <artifactId>stream-parent</artifactId>
-        <version>2.69.0</version>
+        <version>2.69.1</version>
     </parent>
 
     <artifactId>stream-worker</artifactId>

--- a/stream-sdk/stream-parent/stream-worker/src/main/java/com/backbase/stream/worker/UnitOfWorkExecutor.java
+++ b/stream-sdk/stream-parent/stream-worker/src/main/java/com/backbase/stream/worker/UnitOfWorkExecutor.java
@@ -6,8 +6,7 @@ import com.backbase.stream.worker.model.StreamTask;
 import com.backbase.stream.worker.model.TaskHistory;
 import com.backbase.stream.worker.model.UnitOfWork;
 import com.backbase.stream.worker.repository.UnitOfWorkRepository;
-import java.time.OffsetDateTime;
-import java.util.stream.Collectors;
+import com.backbase.stream.worker.repository.impl.InMemoryReactiveUnitOfWorkRepository;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.cloud.sleuth.annotation.ContinueSpan;
 import org.springframework.cloud.sleuth.annotation.NewSpan;
@@ -16,6 +15,9 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Scheduler;
 import reactor.core.scheduler.Schedulers;
+
+import java.time.OffsetDateTime;
+import java.util.stream.Collectors;
 
 @Slf4j
 public abstract class UnitOfWorkExecutor<T extends StreamTask> {
@@ -44,6 +46,16 @@ public abstract class UnitOfWorkExecutor<T extends StreamTask> {
 
     public Mono<UnitOfWork<T>> retrieve(String unitOfWorkId) {
         return repository.findById(unitOfWorkId);
+    }
+
+    private Mono<UnitOfWork<T>> cleanup(UnitOfWork<T> unitOfWork) {
+        // Clean up completed/errored out unit of works from the InMemoryRepository
+        if (repository instanceof InMemoryReactiveUnitOfWorkRepository) {
+            log.info("Cleaning up Unit Of Work: {}", unitOfWork.getUnitOfOWorkId());
+            return repository.delete(unitOfWork)
+                    .thenReturn(unitOfWork);
+        }
+        return Mono.just(unitOfWork);
     }
 
     private Mono<UnitOfWork<T>> complete(UnitOfWork<T> unitOfWork) {
@@ -80,7 +92,8 @@ public abstract class UnitOfWorkExecutor<T extends StreamTask> {
         return Mono.just(unitOfWork)
             .flatMap(this::setLocked)
             .flatMap(this::executeTasks)
-            .flatMap(this::complete);
+            .flatMap(this::complete)
+            .doFinally(r -> cleanup(unitOfWork));
     }
 
     @ContinueSpan(log = "Locking Unit Of Work")
@@ -113,14 +126,15 @@ public abstract class UnitOfWorkExecutor<T extends StreamTask> {
                 return actual;
             })
             .onErrorResume(Throwable.class, throwable -> {
+                streamTask.setState(StreamTask.State.FAILED);
+                streamTask.setError(throwable.getMessage());
                 log.error("Stream Task: {} from Unit Of Work: {} failed: \n{}",
                     streamTaskId,
                     streamTask.getId(),
                     streamTask.getHistory().stream().map(TaskHistory::toString)
                         .collect(Collectors.joining("\n")));
-                streamTask.setState(StreamTask.State.FAILED);
-                return Mono.error(throwable);
-//                return Mono.just(streamTask);
+
+                return Mono.just(streamTask);
             });
     }
 

--- a/stream-sdk/stream-starter-parents/pom.xml
+++ b/stream-sdk/stream-starter-parents/pom.xml
@@ -5,13 +5,13 @@
     <parent>
         <artifactId>stream-parent</artifactId>
         <groupId>com.backbase.stream</groupId>
-        <version>2.69.0</version>
+        <version>2.69.1</version>
         <relativePath>../stream-parent</relativePath>
     </parent>
 
     <groupId>com.backbase.stream</groupId>
     <artifactId>stream-starter-parents</artifactId>
-    <version>2.69.0</version>
+    <version>2.69.1</version>
     <packaging>pom</packaging>
     <name>Stream :: SDK :: Starter Parents</name>
     <description>Parent for all Stream SDK modules</description>

--- a/stream-sdk/stream-starter-parents/stream-aio-starter-parent/pom.xml
+++ b/stream-sdk/stream-starter-parents/stream-aio-starter-parent/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <groupId>com.backbase.stream</groupId>
         <artifactId>stream-sdk-starter-core</artifactId>
-        <version>2.69.0</version>
+        <version>2.69.1</version>
         <relativePath>../stream-sdk-starter-core</relativePath>
     </parent>
 
     <artifactId>stream-aio-starter-parent</artifactId>
-    <version>2.69.0</version>
+    <version>2.69.1</version>
     <packaging>pom</packaging>
     <name>Stream :: SDK :: All-In-One Service</name>
 
@@ -55,7 +55,7 @@
         <dependency>
             <groupId>com.backbase.stream</groupId>
             <artifactId>stream-openapi-support</artifactId>
-            <version>2.69.0</version>
+            <version>2.69.1</version>
         </dependency>
 
     </dependencies>

--- a/stream-sdk/stream-starter-parents/stream-batch-starter-parent/pom.xml
+++ b/stream-sdk/stream-starter-parents/stream-batch-starter-parent/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <groupId>com.backbase.stream</groupId>
         <artifactId>stream-sdk-starter-core</artifactId>
-        <version>2.69.0</version>
+        <version>2.69.1</version>
         <relativePath>../stream-sdk-starter-core</relativePath>
     </parent>
 
     <artifactId>stream-batch-starter-parent</artifactId>
-    <version>2.69.0</version>
+    <version>2.69.1</version>
     <packaging>pom</packaging>
     <name>Stream :: SDK :: Batch Starter</name>
     <description>Parent for Spring Batch</description>

--- a/stream-sdk/stream-starter-parents/stream-generated-client-starter-parent/pom.xml
+++ b/stream-sdk/stream-starter-parents/stream-generated-client-starter-parent/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <groupId>com.backbase.stream</groupId>
         <artifactId>stream-sdk-starter-core</artifactId>
-        <version>2.69.0</version>
+        <version>2.69.1</version>
         <relativePath>../stream-sdk-starter-core</relativePath>
     </parent>
 
     <artifactId>stream-generated-client-starter-parent</artifactId>
-    <version>2.69.0</version>
+    <version>2.69.1</version>
     <packaging>pom</packaging>
     <name>Stream :: SDK :: Generated Web Client Starter</name>
     <description>Parent for all Generated Web Clients from OpenAPI. Disables checkstyle plugin, as generated code does not

--- a/stream-sdk/stream-starter-parents/stream-http-starter-parent/pom.xml
+++ b/stream-sdk/stream-starter-parents/stream-http-starter-parent/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <groupId>com.backbase.stream</groupId>
         <artifactId>stream-sdk-starter-core</artifactId>
-        <version>2.69.0</version>
+        <version>2.69.1</version>
         <relativePath>../stream-sdk-starter-core</relativePath>
     </parent>
 
     <artifactId>stream-http-starter-parent</artifactId>
-    <version>2.69.0</version>
+    <version>2.69.1</version>
     <packaging>pom</packaging>
     <name>Stream :: SDK :: HTTP Services Starter</name>
     <description>Parent for Stream HTTP Services</description>

--- a/stream-sdk/stream-starter-parents/stream-processor-starter-parent/pom.xml
+++ b/stream-sdk/stream-starter-parents/stream-processor-starter-parent/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <groupId>com.backbase.stream</groupId>
         <artifactId>stream-sdk-starter-core</artifactId>
-        <version>2.69.0</version>
+        <version>2.69.1</version>
         <relativePath>../stream-sdk-starter-core</relativePath>
     </parent>
 
     <artifactId>stream-processor-starter-parent</artifactId>
-    <version>2.69.0</version>
+    <version>2.69.1</version>
     <packaging>pom</packaging>
     <name>Stream :: SDK :: Processor Starter</name>
     <description>Parent for Spring Cloud Stream Data Flow Source</description>
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>com.backbase.stream</groupId>
             <artifactId>stream-scs-starter-config</artifactId>
-            <version>2.69.0</version>
+            <version>2.69.1</version>
         </dependency>
 
     </dependencies>

--- a/stream-sdk/stream-starter-parents/stream-sdk-starter-core/pom.xml
+++ b/stream-sdk/stream-starter-parents/stream-sdk-starter-core/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>com.backbase.stream</groupId>
     <artifactId>stream-sdk-starter-core</artifactId>
-    <version>2.69.0</version>
+    <version>2.69.1</version>
     <packaging>pom</packaging>
     <name>Stream :: SDK :: Starter Core</name>
     <description>Parent for all Stream SDK modules</description>
@@ -298,7 +298,7 @@
         <dependency>
             <groupId>com.backbase.stream</groupId>
             <artifactId>stream-test-support</artifactId>
-            <version>2.69.0</version>
+            <version>2.69.1</version>
             <scope>test</scope>
         </dependency>
 

--- a/stream-sdk/stream-starter-parents/stream-sink-starter-parent/pom.xml
+++ b/stream-sdk/stream-starter-parents/stream-sink-starter-parent/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <groupId>com.backbase.stream</groupId>
         <artifactId>stream-sdk-starter-core</artifactId>
-        <version>2.69.0</version>
+        <version>2.69.1</version>
         <relativePath>../stream-sdk-starter-core</relativePath>
     </parent>
 
     <artifactId>stream-sink-starter-parent</artifactId>
-    <version>2.69.0</version>
+    <version>2.69.1</version>
     <packaging>pom</packaging>
     <name>Stream :: SDK :: Sink Starter</name>
     <description>Parent for Spring Cloud Stream Data Flow Source</description>
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>com.backbase.stream</groupId>
             <artifactId>stream-scs-starter-config</artifactId>
-            <version>2.69.0</version>
+            <version>2.69.1</version>
         </dependency>
 
     </dependencies>

--- a/stream-sdk/stream-starter-parents/stream-source-starter-parent/pom.xml
+++ b/stream-sdk/stream-starter-parents/stream-source-starter-parent/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <groupId>com.backbase.stream</groupId>
         <artifactId>stream-sdk-starter-core</artifactId>
-        <version>2.69.0</version>
+        <version>2.69.1</version>
         <relativePath>../stream-sdk-starter-core</relativePath>
     </parent>
 
     <artifactId>stream-source-starter-parent</artifactId>
-    <version>2.69.0</version>
+    <version>2.69.1</version>
     <packaging>pom</packaging>
     <name>Stream :: SDK :: Source Starter</name>
     <description>Parent for Spring Cloud Stream Data Flow Source</description>
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>com.backbase.stream</groupId>
             <artifactId>stream-scs-starter-config</artifactId>
-            <version>2.69.0</version>
+            <version>2.69.1</version>
         </dependency>
 
           </dependencies>

--- a/stream-sdk/stream-starter-parents/stream-task-starter-parent/pom.xml
+++ b/stream-sdk/stream-starter-parents/stream-task-starter-parent/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <groupId>com.backbase.stream</groupId>
         <artifactId>stream-sdk-starter-core</artifactId>
-        <version>2.69.0</version>
+        <version>2.69.1</version>
         <relativePath>../stream-sdk-starter-core</relativePath>
     </parent>
 
     <artifactId>stream-task-starter-parent</artifactId>
-    <version>2.69.0</version>
+    <version>2.69.1</version>
     <packaging>pom</packaging>
     <name>Stream :: SDK :: Task Starter</name>
     <description>Parent for Spring Cloud Stream Data Flow Task</description>

--- a/stream-transactions/pom.xml
+++ b/stream-transactions/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.backbase.stream</groupId>
         <artifactId>stream-services</artifactId>
-        <version>2.69.0</version>
+        <version>2.69.1</version>
     </parent>
 
     <artifactId>stream-transactions</artifactId>

--- a/stream-transactions/transactions-core/pom.xml
+++ b/stream-transactions/transactions-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.backbase.stream</groupId>
         <artifactId>stream-transactions</artifactId>
-        <version>2.69.0</version>
+        <version>2.69.1</version>
     </parent>
 
     <artifactId>transactions-core</artifactId>

--- a/stream-transactions/transactions-core/src/main/java/com/backbase/stream/transaction/TransactionTaskExecutor.java
+++ b/stream-transactions/transactions-core/src/main/java/com/backbase/stream/transaction/TransactionTaskExecutor.java
@@ -5,11 +5,12 @@ import com.backbase.dbs.transaction.api.service.v2.model.TransactionsPostRequest
 import com.backbase.dbs.transaction.api.service.v2.model.TransactionsPostResponseBody;
 import com.backbase.stream.worker.StreamTaskExecutor;
 import com.backbase.stream.worker.exception.StreamTaskException;
-import java.util.List;
-import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
 import reactor.core.publisher.Mono;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Slf4j
 public class TransactionTaskExecutor implements StreamTaskExecutor<TransactionTask> {
@@ -35,7 +36,7 @@ public class TransactionTaskExecutor implements StreamTaskExecutor<TransactionTa
             })
             .collectList()
             .map(transactionIds -> {
-                streamTask.error("transactions", "post", "success", externalIds, transactionIds.stream().map(
+                streamTask.info("transactions", "post", "success", externalIds, transactionIds.stream().map(
                     TransactionsPostResponseBody::getId).collect(Collectors.joining(",")), "Ingested Transactions");
                 streamTask.setResponse(transactionIds);
                 return streamTask;

--- a/stream-transactions/transactions-generator-core/pom.xml
+++ b/stream-transactions/transactions-generator-core/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.backbase.stream</groupId>
         <artifactId>stream-transactions</artifactId>
-        <version>2.69.0</version>
+        <version>2.69.1</version>
     </parent>
 
     <artifactId>transactions-generator-core</artifactId>
@@ -19,7 +19,7 @@
         <dependency>
             <groupId>com.backbase.stream</groupId>
             <artifactId>cursor-core</artifactId>
-            <version>2.69.0</version>
+            <version>2.69.1</version>
         </dependency>
         <dependency>
             <groupId>org.iban4j</groupId>

--- a/stream-transactions/transactions-generator-processor/pom.xml
+++ b/stream-transactions/transactions-generator-processor/pom.xml
@@ -6,12 +6,12 @@
   <parent>
     <groupId>com.backbase.stream</groupId>
     <artifactId>stream-processor-starter-parent</artifactId>
-    <version>2.69.0</version>
+    <version>2.69.1</version>
     <relativePath>../../stream-sdk/stream-starter-parents/stream-processor-starter-parent</relativePath>
   </parent>
 
   <artifactId>transactions-generator-processor</artifactId>
-  <version>2.69.0</version>
+  <version>2.69.1</version>
 
   <packaging>jar</packaging>
   <name>Stream :: Generator :: Transaction Generator Processor</name>
@@ -21,7 +21,7 @@
     <dependency>
       <groupId>com.backbase.stream</groupId>
       <artifactId>transactions-generator-core</artifactId>
-      <version>2.69.0</version>
+      <version>2.69.1</version>
     </dependency>
 
   </dependencies>

--- a/stream-transactions/transactions-http/pom.xml
+++ b/stream-transactions/transactions-http/pom.xml
@@ -6,12 +6,12 @@
     <parent>
         <groupId>com.backbase.stream</groupId>
         <artifactId>stream-http-starter-parent</artifactId>
-        <version>2.69.0</version>
+        <version>2.69.1</version>
         <relativePath>../../stream-sdk/stream-starter-parents/stream-http-starter-parent</relativePath>
     </parent>
 
     <artifactId>transactions-http</artifactId>
-    <version>2.69.0</version>
+    <version>2.69.1</version>
 
     <packaging>jar</packaging>
     <name>Stream :: Transaction HTTP</name>
@@ -21,7 +21,7 @@
         <dependency>
             <groupId>com.backbase.stream</groupId>
             <artifactId>transactions-core</artifactId>
-            <version>2.69.0</version>
+            <version>2.69.1</version>
         </dependency>
 
     </dependencies>

--- a/stream-transactions/transactions-item-writer/pom.xml
+++ b/stream-transactions/transactions-item-writer/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <groupId>com.backbase.stream</groupId>
         <artifactId>stream-batch-starter-parent</artifactId>
-        <version>2.69.0</version>
+        <version>2.69.1</version>
         <relativePath>../../stream-sdk/stream-starter-parents/stream-batch-starter-parent</relativePath>
     </parent>
 
     <artifactId>transactions-item-writer</artifactId>
-    <version>2.69.0</version>
+    <version>2.69.1</version>
 
     <packaging>jar</packaging>
     <name>Stream :: Transactions Item Writer for Spring Batch</name>
@@ -24,7 +24,7 @@
         <dependency>
             <groupId>com.backbase.stream</groupId>
             <artifactId>transactions-core</artifactId>
-            <version>2.69.0</version>
+            <version>2.69.1</version>
         </dependency>
 
     </dependencies>

--- a/stream-transactions/transactions-sink/pom.xml
+++ b/stream-transactions/transactions-sink/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <groupId>com.backbase.stream</groupId>
         <artifactId>stream-sink-starter-parent</artifactId>
-        <version>2.69.0</version>
+        <version>2.69.1</version>
         <relativePath>../../stream-sdk/stream-starter-parents/stream-sink-starter-parent</relativePath>
     </parent>
 
     <artifactId>transactions-sink</artifactId>
-    <version>2.69.0</version>
+    <version>2.69.1</version>
 
     <packaging>jar</packaging>
     <name>Stream :: Transactions Sink</name>
@@ -25,7 +25,7 @@
         <dependency>
             <groupId>com.backbase.stream</groupId>
             <artifactId>transactions-core</artifactId>
-            <version>2.69.0</version>
+            <version>2.69.1</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Fixed memory leak with UnitOfWorkExecutor when working with InMemoryReactiveRepository