### PR TITLE
Updated stream `portfolio.yaml` schema to include `arrangementId`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [3.30.2](https://github.com/Backbase/stream-services/compare/3.30.1...3.30.2)
+### Changed
+- Updated stream `portfolio.yaml` schema to include `arrangementId`. from 2023.03 it's mandatory for portfolio
+
 ## [3.30.1](https://github.com/Backbase/stream-services/compare/3.30.0...3.30.1)
 ### Changed
 - A fix for when zipkin is enabled preventing the boostrap tasks to stop running.

--- a/api/stream-portfolio/schemas/v1/portfolio.yaml
+++ b/api/stream-portfolio/schemas/v1/portfolio.yaml
@@ -4,9 +4,14 @@ required:
   - iban
 type: object
 properties:
+  arrangementId:
+    type: string
+    minLength: 1
+    maxLength: 50
+    description: The external arrangement id. Primary arrangement for the portfolio.
   code:
     type: string
-    description: Unique identificator for a portfolio, used to identify portfolio at a bank or an investment firm.
+    description: Unique identifier for a portfolio, used to identify portfolio at a bank or an investment firm.
   name:
     type: string
     description: Name of a portfolio.
@@ -24,13 +29,13 @@ properties:
     description: Valuation of a portfolio, expressed as a monetary amount.
   ytdPerformance:
     type: number
-    description: Year-to-date performance of a portflio, expressed as a percentage.
+    description: Year-to-date performance of a portfolio, expressed as a percentage.
   ytdPerformanceValue:
     $ref: money.yaml
     description: Year-to-date performance of a portfolio, expressed as a monetary amount.
   mtdPerformance:
     type: number
-    description: Month-to-date performance of a portflio, expressed as a percentage.
+    description: Month-to-date performance of a portfolio, expressed as a percentage.
   mtdPerformanceValue:
     $ref: money.yaml
     description: Month-to-date performance of a portfolio, expressed as a monetary amount.


### PR DESCRIPTION
starting from 2023.03 it's mandatory for portfolio