### PR TITLE
Fix Duplicate dataGroupIdentifiers for functionGroupDataGroups in putAssignUserPermissions API Call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [3.40.0](https://github.com/Backbase/stream-services/compare/3.39.0...3.40.0)
+### Added
+- Bugfix for putAssignUserPermissions error `Data groups cannot be duplicated in scope of a single function group during assigning permissions`
+
 ## [3.39.0](https://github.com/Backbase/stream-services/compare/3.38.0...3.39.0)
 ### Added
 - Add PermissionSetApi to stream-dbs-clients for APS ingestion scenarios

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
-## [3.40.0](https://github.com/Backbase/stream-services/compare/3.39.0...3.40.0)
-### Added
+## [3.39.1](https://github.com/Backbase/stream-services/compare/3.39.0...3.40.1)
+### Changed
 - Bugfix for putAssignUserPermissions error `Data groups cannot be duplicated in scope of a single function group during assigning permissions`
 
 ## [3.39.0](https://github.com/Backbase/stream-services/compare/3.38.0...3.39.0)

--- a/stream-access-control/access-control-core/src/main/java/com/backbase/stream/service/AccessGroupService.java
+++ b/stream-access-control/access-control-core/src/main/java/com/backbase/stream/service/AccessGroupService.java
@@ -643,17 +643,17 @@ public class AccessGroupService {
                                             .filter(mergedFunctionDataGroup -> hasTheSameFunctionGroupId(mergedFunctionDataGroup, requestFunctionDataGroup))
                                             .findFirst();
 
-                            // If requested function group is already ingested, merge the request and existing function group
-                            if (mergedFunctionGroupOptional.isPresent()) {
-                                PresentationFunctionGroupDataGroup mergedFunctionGroup = mergedFunctionGroupOptional.get();
-
-                                if (mergedFunctionGroup.getDataGroupIdentifiers() != null) {
-                                    mergedFunctionGroup.getDataGroupIdentifiers().addAll(requestFunctionDataGroup.getDataGroupIdentifiers());
-                                }
-                            // otherwise we should copy the function group from the request completely
-                            } else {
-                                mergedUserPermissions.addFunctionGroupDataGroupsItem(requestFunctionDataGroup);
-                            }
+                            mergedFunctionGroupOptional.ifPresentOrElse(mergedFunctionGroup ->
+                                    // If requested function group is already ingested, merge the request and existing function group
+                                    mergedFunctionGroup.setDataGroupIdentifiers(
+                                        Stream.of(mergedFunctionGroup.getDataGroupIdentifiers(),
+                                                requestFunctionDataGroup.getDataGroupIdentifiers())
+                                            .filter(Objects::nonNull)
+                                            .flatMap(List::stream)
+                                            .distinct()
+                                            .toList()),
+                                // otherwise we should copy the function group from the request completely
+                                () -> mergedUserPermissions.addFunctionGroupDataGroupsItem(requestFunctionDataGroup));
                         });
                     }
                     return mergedUserPermissions;

--- a/stream-access-control/access-control-core/src/test/java/com/backbase/stream/service/AccessGroupServiceTest.java
+++ b/stream-access-control/access-control-core/src/test/java/com/backbase/stream/service/AccessGroupServiceTest.java
@@ -351,7 +351,8 @@ class AccessGroupServiceTest {
         batchProductGroupTask.setIngestionMode(BatchProductIngestionMode.UPSERT);
 
         Map<BusinessFunctionGroup, List<BaseProductGroup>> baseProductGroupMap = new HashMap<>();
-        baseProductGroupMap.put(new BusinessFunctionGroup().id("business-function-group-id-1"), Collections.emptyList());
+        baseProductGroupMap.put(new BusinessFunctionGroup().id("business-function-group-id-1"),
+            List.of(new BaseProductGroup().internalId("data-group-id")));
 
         Map<User, Map<BusinessFunctionGroup, List<BaseProductGroup>>> usersPermissions = new HashMap<>();
         usersPermissions.put(
@@ -372,7 +373,7 @@ class AccessGroupServiceTest {
                     ).dataGroupIdentifiers(Collections.emptyList()),
                     new PresentationFunctionGroupDataGroup().functionGroupIdentifier(
                         new PresentationIdentifier().idIdentifier("business-function-group-id-1")
-                    ).dataGroupIdentifiers(Collections.emptyList())
+                    ).dataGroupIdentifiers(List.of(new PresentationDataGroupIdentifier().idIdentifier("data-group-id")))
                 ))
         );
 
@@ -386,7 +387,8 @@ class AccessGroupServiceTest {
             .thenReturn(Mono.just(new PersistenceApprovalPermissions().items(Arrays.asList(
                 new PersistenceApprovalPermissionsGetResponseBody().functionGroupId("system-group-id-1").dataGroupIds(Collections.emptyList()),
                 new PersistenceApprovalPermissionsGetResponseBody().functionGroupId("system-group-id-2").dataGroupIds(Collections.emptyList()),
-                new PersistenceApprovalPermissionsGetResponseBody().functionGroupId("system-group-id-3").dataGroupIds(Collections.emptyList())
+                new PersistenceApprovalPermissionsGetResponseBody().functionGroupId("system-group-id-3").dataGroupIds(Collections.emptyList()),
+                new PersistenceApprovalPermissionsGetResponseBody().functionGroupId("business-function-group-id-1").dataGroupIds(List.of("data-group-id"))
             ))));
 
         when(accessControlUsersApi.putAssignUserPermissions(expectedPermissions))


### PR DESCRIPTION
**Description:**

In the recent April release, there is a new validation check in DBS access control for the putAssignUserPermissions operation where upon having duplicated dataGroupIdentifiers in the request the DBS reject it with the below error. Stream was having this bug before but without any side-effect and it got exposed while using the latest DBS version.

```
Data groups cannot be duplicated in scope of a single function group during assigning permissions
```