### PR TITLE
Addition propagation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [3.39.2](https://github.com/Backbase/stream-services/compare/3.39.0...3.40.1)
+### Changed
+- Propagate additions returned by the Product and Transaction integration layer response to the Product and Transaction composition layer response.
+
 ## [3.39.1](https://github.com/Backbase/stream-services/compare/3.39.0...3.40.1)
 ### Changed
 - Bugfix for putAssignUserPermissions error `Data groups cannot be duplicated in scope of a single function group during assigning permissions`
@@ -20,14 +24,14 @@ All notable changes to this project will be documented in this file.
 ## [3.36.0](https://github.com/Backbase/stream-services/compare/3.35.0...3.36.0)
 ### Added
 - Adds `bankBranchCode` field to `term-deposits.json` events
- 
+
 ## [3.35.0](https://github.com/Backbase/stream-services/compare/3.34.0...3.35.0)
 ### Added
 - Support for creating data group of type `CUSTOM`.
 
 ## [3.34.0](https://github.com/Backbase/stream-services/compare/3.33.1...3.34.0)
 ### Changed
-- Upgraded SSDK to 15.2.0 
+- Upgraded SSDK to 15.2.0
 - Upgraded Banking Services to 2023.02-LTS
 - Fix some breaking changes introduced by 2023.02-LTS
 
@@ -58,7 +62,7 @@ All notable changes to this project will be documented in this file.
 
 ## [3.26.2](https://github.com/Backbase/stream-services/compare/3.26.1...3.26.2)
 ### Added
-- Included property to override the validation of atomic batch responses coming from DBS: When a single item is not successful in the batch response it fails the entire saga. 
+- Included property to override the validation of atomic batch responses coming from DBS: When a single item is not successful in the batch response it fails the entire saga.
 Keeping validation enabled for backwards compatibility: `backbase.stream.dbs.batch.validate-atomic-response=true`.
 - Enhancing logs for legal entity composition subsidiaries processing.
 - Updating the e2e tests images version.
@@ -149,10 +153,10 @@ Keeping validation enabled for backwards compatibility: `backbase.stream.dbs.bat
 
 ## [3.11.0](https://github.com/Backbase/stream-services/compare/3.10.1...3.11.0)
 ### Changed
-- Replaced BatchProductGroupTask.IngestionMode with more flexible BatchProductIngestionMode class. 
-New class keeps ingestion modes separately for each main resource involved in BatchProductIngestionSaga processing: 
-function groups, data groups and arrangements. Two preset modes have been created: BatchProductIngestionMode.UPSERT and 
-BatchProductIngestionMode.REPLACE (equivalents of previous UPDATE and REPLACE, respectively), but new ones can be 
+- Replaced BatchProductGroupTask.IngestionMode with more flexible BatchProductIngestionMode class.
+New class keeps ingestion modes separately for each main resource involved in BatchProductIngestionSaga processing:
+function groups, data groups and arrangements. Two preset modes have been created: BatchProductIngestionMode.UPSERT and
+BatchProductIngestionMode.REPLACE (equivalents of previous UPDATE and REPLACE, respectively), but new ones can be
 composed of any "sub modes" combination.
 
 ## [3.10.1](https://github.com/Backbase/stream-services/compare/3.10.0...3.10.1)
@@ -182,7 +186,7 @@ Using Eureka/Registry (Enabled by default):
 eureka.client.serviceUrl.defaultZone=http://registry:8080/eureka
 eureka.instance.non-secure-port=8080
 ```
-Using Kubernetes: 
+Using Kubernetes:
 ```properties
 eureka.client.enabled=false
 spring.cloud.kubernetes.enabled=true
@@ -219,7 +223,7 @@ spring:
 ```
 
 > **Heads Up!**: The Stream Composition services still don't support client load balancing, hence service discovery isn't available for the moment then you can't configure the spring cloud discovery simple instances. In the scenario where your service don't support, or you want to disable client side load balancers (e.g. `spring.cloud.loadbalancer.enabled=false`), you can override the default DBS services addresses using the `direct-uri` property. e.g.
-> ```properties 
+> ```properties
 > backbase.communication.services.access-control.direct-uri=http://non-discoverable-host:8080/access-control
 > backbase.communication.services.identity.integration.direct-uri=http://non-discoverable-host:8080/identity-integration-service
 > ```
@@ -241,7 +245,7 @@ spring:
 
 ## [3.5.0](https://github.com/Backbase/stream-services/compare/3.4.0...3.5.0)
 ### Added
-- Added support for push ingestion mode for product and transactions 
+- Added support for push ingestion mode for product and transactions
 
 ## [3.4.0](https://github.com/Backbase/stream-services/compare/3.3.0...3.4.0)
 ### Added
@@ -269,7 +273,7 @@ spring:
 
 ## [2.85.0](https://github.com/Backbase/stream-services/compare/2.84.0...2.85.0)
 ### Added
-- Deploying task executables and http services as docker images using `repo.backbase.com/backbase-stream-images` registry. 
+- Deploying task executables and http services as docker images using `repo.backbase.com/backbase-stream-images` registry.
 > e.g. `repo.backbase.com/backbase-stream-images/legal-entity-bootstrap-task:2.85.0`
 
 ### Fixed
@@ -280,8 +284,8 @@ spring:
 
 ## [2.84.0](https://github.com/Backbase/stream-services/compare/2.83.0...2.84.0)
 ### Added
-- Contacts Support Added for Legal Entity, Service Agreement and Users 
-- Usage Sample of Bootstrap json to be added to Legal Entity, Service Agreement and User 
+- Contacts Support Added for Legal Entity, Service Agreement and Users
+- Usage Sample of Bootstrap json to be added to Legal Entity, Service Agreement and User
 
 - Contacts Support for LE Contacts
 ```yaml
@@ -637,7 +641,7 @@ Clean up of many old components and replaced Stream SDK with Service SDK 14
 ### Changed
 - Update Spring Boot to 2.5.14
 - Update Swagger Core to 2.2.0
-- Update bcprov-jdk15on to 1.70 
+- Update bcprov-jdk15on to 1.70
 
 ## [2.71.0]
 ### Added
@@ -671,8 +675,8 @@ Clean up of many old components and replaced Stream SDK with Service SDK 14
 
 ## [2.66.0]
 ### Changed
-- Order of product group stream task processing within legal entity saga is changed to sequential. This is due to the fact that in some 
-  circumstances user permissions update loosing previously assigned permissions during ingestion process (due to the nature of reactive processing) 
+- Order of product group stream task processing within legal entity saga is changed to sequential. This is due to the fact that in some
+  circumstances user permissions update loosing previously assigned permissions during ingestion process (due to the nature of reactive processing)
 ### Fixed
 - Additional headers propagation to several calls within legal entity saga
 
@@ -704,9 +708,9 @@ Clean up of many old components and replaced Stream SDK with Service SDK 14
 - Legal Entity Saga: referenceJobRoleNames are mixed up between users ( when multiple users are ingested)
 
 ## [2.52.0]
-### Removed 
+### Removed
 - Audit Core & Http Service. Created as a demo, never to be used.
-- Erroneous log message removed when assigning permissiosn without datagroups which is not an exception anymore. 
+- Erroneous log message removed when assigning permissiosn without datagroups which is not an exception anymore.
 ### Changed
 - UserService
   - Failed operations in User Service now generally return StreamTaskExceptions allowing for better control and handling of failures.
@@ -741,7 +745,7 @@ Clean up of many old components and replaced Stream SDK with Service SDK 14
 ## [2.47.0]
 ### Added
 - Added support for json logging via logstash-logback-encoder. (could be replaced by service-sdk-starter-logging later on)
-In order to have logging in json format it's possible to provide logback.xml config from the external app 
+In order to have logging in json format it's possible to provide logback.xml config from the external app
 via jvm option `-Dlogging.config=file:logback.xml` or specify in the `application.yml` like `logging.config=file:logback.xml`
 
 ## [2.46.3]
@@ -754,7 +758,7 @@ via jvm option `-Dlogging.config=file:logback.xml` or specify in the `applicatio
 
 ## [2.46.2]
 ### Changed
-- Non existing Business function groups from the request should be persisted.  
+- Non existing Business function groups from the request should be persisted.
 
 ## [2.46.1]
 ### Changed
@@ -772,9 +776,9 @@ with empty functions.
 
 ## [2.45.0]
 ### Fixed
-- Legal Entity Saga 
+- Legal Entity Saga
   - Errors happening in the user profile manager must now correctly be dealt with.
-  - Ensure reactive immutability on user service operations. 
+  - Ensure reactive immutability on user service operations.
 ### Changed
 - Use backbase bom pom instead of banking-service and identity boms
 - Update to 2021.07 release (DBS 2.21.0 and Identity 1.9.0)
@@ -784,11 +788,11 @@ with empty functions.
   - Optional parameter (`xTransactionsUserId`) added to TransactionPresentationServiceApi.patchTransactions.
   - Optional parameter (`xTransactionsUserId`) added to TransactionPresentationServiceApi.postDelete.
   - Optional parameter (`xTransactionsUserId`) added to TransactionPresentationServiceApi.postRefresh.
-### Maintenance 
+### Maintenance
 - Upgrade Spring Boot 2.5.3
 
 ## [2.44.0]
-### Maintenance 
+### Maintenance
 - Cleaned up versions for boat-maven-plugin
 - Added spring-boot-configuration-processors to modules that have configuration classes
 - Moved Product Catalog Model to own package to prevent deep transitive dependencies
@@ -796,7 +800,7 @@ with empty functions.
 
 ## [2.43.0]
 ### Fixed
-- bugfix NPE for AccessGroupService.getUpdatePermissions  
+- bugfix NPE for AccessGroupService.getUpdatePermissions
 
 ## [2.42.0]
 ### Fixed
@@ -1051,7 +1055,7 @@ Example:
 
 ## [2.15.0]
 ### Fixed
-- Fixed implementation of Reference Job Roles where we can assign a list of reference job roles to a specific user. 
+- Fixed implementation of Reference Job Roles where we can assign a list of reference job roles to a specific user.
   * Example with legal-entity-bootstrap-task on how to create a Reference Job Role in the root legal entity and assign it to a user below the hierarchy (example with a subsidiary):
 ```yaml
 bootstrap:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 
 ## [3.39.2](https://github.com/Backbase/stream-services/compare/3.39.0...3.40.1)
 ### Changed
-- Propagate additions returned by the Product and Transaction integration layer response to the Product and Transaction composition layer response.
+- Propagate additions returned by the Product and Transaction integration Response to the Product and Transaction composition Response.
 
 ## [3.39.1](https://github.com/Backbase/stream-services/compare/3.39.0...3.40.1)
 ### Changed
@@ -24,14 +24,14 @@ All notable changes to this project will be documented in this file.
 ## [3.36.0](https://github.com/Backbase/stream-services/compare/3.35.0...3.36.0)
 ### Added
 - Adds `bankBranchCode` field to `term-deposits.json` events
-
+ 
 ## [3.35.0](https://github.com/Backbase/stream-services/compare/3.34.0...3.35.0)
 ### Added
 - Support for creating data group of type `CUSTOM`.
 
 ## [3.34.0](https://github.com/Backbase/stream-services/compare/3.33.1...3.34.0)
 ### Changed
-- Upgraded SSDK to 15.2.0
+- Upgraded SSDK to 15.2.0 
 - Upgraded Banking Services to 2023.02-LTS
 - Fix some breaking changes introduced by 2023.02-LTS
 
@@ -62,7 +62,7 @@ All notable changes to this project will be documented in this file.
 
 ## [3.26.2](https://github.com/Backbase/stream-services/compare/3.26.1...3.26.2)
 ### Added
-- Included property to override the validation of atomic batch responses coming from DBS: When a single item is not successful in the batch response it fails the entire saga.
+- Included property to override the validation of atomic batch responses coming from DBS: When a single item is not successful in the batch response it fails the entire saga. 
 Keeping validation enabled for backwards compatibility: `backbase.stream.dbs.batch.validate-atomic-response=true`.
 - Enhancing logs for legal entity composition subsidiaries processing.
 - Updating the e2e tests images version.
@@ -153,10 +153,10 @@ Keeping validation enabled for backwards compatibility: `backbase.stream.dbs.bat
 
 ## [3.11.0](https://github.com/Backbase/stream-services/compare/3.10.1...3.11.0)
 ### Changed
-- Replaced BatchProductGroupTask.IngestionMode with more flexible BatchProductIngestionMode class.
-New class keeps ingestion modes separately for each main resource involved in BatchProductIngestionSaga processing:
-function groups, data groups and arrangements. Two preset modes have been created: BatchProductIngestionMode.UPSERT and
-BatchProductIngestionMode.REPLACE (equivalents of previous UPDATE and REPLACE, respectively), but new ones can be
+- Replaced BatchProductGroupTask.IngestionMode with more flexible BatchProductIngestionMode class. 
+New class keeps ingestion modes separately for each main resource involved in BatchProductIngestionSaga processing: 
+function groups, data groups and arrangements. Two preset modes have been created: BatchProductIngestionMode.UPSERT and 
+BatchProductIngestionMode.REPLACE (equivalents of previous UPDATE and REPLACE, respectively), but new ones can be 
 composed of any "sub modes" combination.
 
 ## [3.10.1](https://github.com/Backbase/stream-services/compare/3.10.0...3.10.1)
@@ -186,7 +186,7 @@ Using Eureka/Registry (Enabled by default):
 eureka.client.serviceUrl.defaultZone=http://registry:8080/eureka
 eureka.instance.non-secure-port=8080
 ```
-Using Kubernetes:
+Using Kubernetes: 
 ```properties
 eureka.client.enabled=false
 spring.cloud.kubernetes.enabled=true
@@ -223,7 +223,7 @@ spring:
 ```
 
 > **Heads Up!**: The Stream Composition services still don't support client load balancing, hence service discovery isn't available for the moment then you can't configure the spring cloud discovery simple instances. In the scenario where your service don't support, or you want to disable client side load balancers (e.g. `spring.cloud.loadbalancer.enabled=false`), you can override the default DBS services addresses using the `direct-uri` property. e.g.
-> ```properties
+> ```properties 
 > backbase.communication.services.access-control.direct-uri=http://non-discoverable-host:8080/access-control
 > backbase.communication.services.identity.integration.direct-uri=http://non-discoverable-host:8080/identity-integration-service
 > ```
@@ -245,7 +245,7 @@ spring:
 
 ## [3.5.0](https://github.com/Backbase/stream-services/compare/3.4.0...3.5.0)
 ### Added
-- Added support for push ingestion mode for product and transactions
+- Added support for push ingestion mode for product and transactions 
 
 ## [3.4.0](https://github.com/Backbase/stream-services/compare/3.3.0...3.4.0)
 ### Added
@@ -273,7 +273,7 @@ spring:
 
 ## [2.85.0](https://github.com/Backbase/stream-services/compare/2.84.0...2.85.0)
 ### Added
-- Deploying task executables and http services as docker images using `repo.backbase.com/backbase-stream-images` registry.
+- Deploying task executables and http services as docker images using `repo.backbase.com/backbase-stream-images` registry. 
 > e.g. `repo.backbase.com/backbase-stream-images/legal-entity-bootstrap-task:2.85.0`
 
 ### Fixed
@@ -284,8 +284,8 @@ spring:
 
 ## [2.84.0](https://github.com/Backbase/stream-services/compare/2.83.0...2.84.0)
 ### Added
-- Contacts Support Added for Legal Entity, Service Agreement and Users
-- Usage Sample of Bootstrap json to be added to Legal Entity, Service Agreement and User
+- Contacts Support Added for Legal Entity, Service Agreement and Users 
+- Usage Sample of Bootstrap json to be added to Legal Entity, Service Agreement and User 
 
 - Contacts Support for LE Contacts
 ```yaml
@@ -641,7 +641,7 @@ Clean up of many old components and replaced Stream SDK with Service SDK 14
 ### Changed
 - Update Spring Boot to 2.5.14
 - Update Swagger Core to 2.2.0
-- Update bcprov-jdk15on to 1.70
+- Update bcprov-jdk15on to 1.70 
 
 ## [2.71.0]
 ### Added
@@ -675,8 +675,8 @@ Clean up of many old components and replaced Stream SDK with Service SDK 14
 
 ## [2.66.0]
 ### Changed
-- Order of product group stream task processing within legal entity saga is changed to sequential. This is due to the fact that in some
-  circumstances user permissions update loosing previously assigned permissions during ingestion process (due to the nature of reactive processing)
+- Order of product group stream task processing within legal entity saga is changed to sequential. This is due to the fact that in some 
+  circumstances user permissions update loosing previously assigned permissions during ingestion process (due to the nature of reactive processing) 
 ### Fixed
 - Additional headers propagation to several calls within legal entity saga
 
@@ -708,9 +708,9 @@ Clean up of many old components and replaced Stream SDK with Service SDK 14
 - Legal Entity Saga: referenceJobRoleNames are mixed up between users ( when multiple users are ingested)
 
 ## [2.52.0]
-### Removed
+### Removed 
 - Audit Core & Http Service. Created as a demo, never to be used.
-- Erroneous log message removed when assigning permissiosn without datagroups which is not an exception anymore.
+- Erroneous log message removed when assigning permissiosn without datagroups which is not an exception anymore. 
 ### Changed
 - UserService
   - Failed operations in User Service now generally return StreamTaskExceptions allowing for better control and handling of failures.
@@ -745,7 +745,7 @@ Clean up of many old components and replaced Stream SDK with Service SDK 14
 ## [2.47.0]
 ### Added
 - Added support for json logging via logstash-logback-encoder. (could be replaced by service-sdk-starter-logging later on)
-In order to have logging in json format it's possible to provide logback.xml config from the external app
+In order to have logging in json format it's possible to provide logback.xml config from the external app 
 via jvm option `-Dlogging.config=file:logback.xml` or specify in the `application.yml` like `logging.config=file:logback.xml`
 
 ## [2.46.3]
@@ -758,7 +758,7 @@ via jvm option `-Dlogging.config=file:logback.xml` or specify in the `applicatio
 
 ## [2.46.2]
 ### Changed
-- Non existing Business function groups from the request should be persisted.
+- Non existing Business function groups from the request should be persisted.  
 
 ## [2.46.1]
 ### Changed
@@ -776,9 +776,9 @@ with empty functions.
 
 ## [2.45.0]
 ### Fixed
-- Legal Entity Saga
+- Legal Entity Saga 
   - Errors happening in the user profile manager must now correctly be dealt with.
-  - Ensure reactive immutability on user service operations.
+  - Ensure reactive immutability on user service operations. 
 ### Changed
 - Use backbase bom pom instead of banking-service and identity boms
 - Update to 2021.07 release (DBS 2.21.0 and Identity 1.9.0)
@@ -788,11 +788,11 @@ with empty functions.
   - Optional parameter (`xTransactionsUserId`) added to TransactionPresentationServiceApi.patchTransactions.
   - Optional parameter (`xTransactionsUserId`) added to TransactionPresentationServiceApi.postDelete.
   - Optional parameter (`xTransactionsUserId`) added to TransactionPresentationServiceApi.postRefresh.
-### Maintenance
+### Maintenance 
 - Upgrade Spring Boot 2.5.3
 
 ## [2.44.0]
-### Maintenance
+### Maintenance 
 - Cleaned up versions for boat-maven-plugin
 - Added spring-boot-configuration-processors to modules that have configuration classes
 - Moved Product Catalog Model to own package to prevent deep transitive dependencies
@@ -800,7 +800,7 @@ with empty functions.
 
 ## [2.43.0]
 ### Fixed
-- bugfix NPE for AccessGroupService.getUpdatePermissions
+- bugfix NPE for AccessGroupService.getUpdatePermissions  
 
 ## [2.42.0]
 ### Fixed
@@ -1055,7 +1055,7 @@ Example:
 
 ## [2.15.0]
 ### Fixed
-- Fixed implementation of Reference Job Roles where we can assign a list of reference job roles to a specific user.
+- Fixed implementation of Reference Job Roles where we can assign a list of reference job roles to a specific user. 
   * Example with legal-entity-bootstrap-task on how to create a Reference Job Role in the root legal entity and assign it to a user below the hierarchy (example with a subsidiary):
 ```yaml
 bootstrap:

--- a/stream-compositions/api/integrations-api/product-integration-api/src/main/resources/service-api-v2.yaml
+++ b/stream-compositions/api/integrations-api/product-integration-api/src/main/resources/service-api-v2.yaml
@@ -132,6 +132,10 @@ components:
           type: array
           items:
             $ref: '../../../../../../../api/stream-legal-entity/openapi.yaml#/components/schemas/ProductGroup'
+        additions:
+          type: object
+          additionalProperties:
+            type: string
 
     PullArrangementResponse:
       type: object

--- a/stream-compositions/api/integrations-api/transaction-integration-api/src/main/resources/service-api-v2.yaml
+++ b/stream-compositions/api/integrations-api/transaction-integration-api/src/main/resources/service-api-v2.yaml
@@ -80,6 +80,10 @@ components:
           type: array
           items:
             $ref: '../../../target/yaml/transaction-manager/transaction-manager-service-api-v2.10.0.yaml#/components/schemas/TransactionsPostRequestBody'
+        additions:
+          type: object
+          additionalProperties:
+            type: string
 
     InternalServerError:
       required:

--- a/stream-compositions/api/service-api/product-composition-api/src/main/resources/service-api-v2.yaml
+++ b/stream-compositions/api/service-api/product-composition-api/src/main/resources/service-api-v2.yaml
@@ -216,6 +216,10 @@ components:
           type: array
           items:
             $ref: '../../../../../../../api/stream-legal-entity/openapi.yaml#/components/schemas/ProductGroup'
+        additions:
+          type: object
+          additionalProperties:
+            type: string
 
     ArrangementPullIngestionRequest:
       type: object

--- a/stream-compositions/api/service-api/transaction-composition-api/src/main/resources/service-api-v2.yaml
+++ b/stream-compositions/api/service-api/transaction-composition-api/src/main/resources/service-api-v2.yaml
@@ -120,6 +120,10 @@ components:
           type: array
           items:
             $ref: '../../../target/yaml/transaction-manager/transaction-manager-service-api-v2.10.0.yaml#/components/schemas/TransactionsPostResponseBody'
+        additions:
+          type: object
+          additionalProperties:
+            type: string
 
     InternalServerError:
       required:

--- a/stream-compositions/services/product-composition-service/src/main/java/com/backbase/stream/compositions/product/core/mapper/ProductRestMapper.java
+++ b/stream-compositions/services/product-composition-service/src/main/java/com/backbase/stream/compositions/product/core/mapper/ProductRestMapper.java
@@ -66,7 +66,8 @@ public class ProductRestMapper {
                         .withProductGroups(
                                 response.getProductGroups().stream()
                                         .map(productMapper::mapStreamToComposition)
-                                        .collect(Collectors.toList())),
+                                        .collect(Collectors.toList()))
+                                        .withAdditions(response.getAdditions()),
                 HttpStatus.CREATED);
     }
 }

--- a/stream-compositions/services/product-composition-service/src/main/java/com/backbase/stream/compositions/product/core/model/ProductIngestPullRequest.java
+++ b/stream-compositions/services/product-composition-service/src/main/java/com/backbase/stream/compositions/product/core/model/ProductIngestPullRequest.java
@@ -5,8 +5,10 @@ import java.util.Map;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.Setter;
 
 @Getter
+@Setter
 @Builder
 @AllArgsConstructor
 public class ProductIngestPullRequest {

--- a/stream-compositions/services/transaction-composition-service/src/main/java/com/backbase/stream/compositions/transaction/core/model/TransactionIngestResponse.java
+++ b/stream-compositions/services/transaction-composition-service/src/main/java/com/backbase/stream/compositions/transaction/core/model/TransactionIngestResponse.java
@@ -6,6 +6,7 @@ import lombok.Builder;
 import lombok.Getter;
 
 import java.util.List;
+import java.util.Map;
 
 @Getter
 @Builder
@@ -13,4 +14,5 @@ import java.util.List;
 public class TransactionIngestResponse {
     private final String arrangementId;
     private final List<TransactionsPostResponseBody> transactions;
+    private final Map<String, String> additions;
 }

--- a/stream-compositions/services/transaction-composition-service/src/main/java/com/backbase/stream/compositions/transaction/core/service/impl/TransactionIngestionServiceImpl.java
+++ b/stream-compositions/services/transaction-composition-service/src/main/java/com/backbase/stream/compositions/transaction/core/service/impl/TransactionIngestionServiceImpl.java
@@ -217,6 +217,7 @@ public class TransactionIngestionServiceImpl implements TransactionIngestionServ
         return TransactionIngestResponse.builder()
                 .transactions(transactions)
                 .arrangementId(ingestRequest.getArrangementId())
+                .additions(ingestRequest.getAdditions())
                 .build();
     }
 

--- a/stream-compositions/services/transaction-composition-service/src/main/java/com/backbase/stream/compositions/transaction/http/TransactionController.java
+++ b/stream-compositions/services/transaction-composition-service/src/main/java/com/backbase/stream/compositions/transaction/http/TransactionController.java
@@ -89,7 +89,8 @@ public class TransactionController implements TransactionCompositionApi {
         return new ResponseEntity<>(
                 new TransactionIngestionResponse()
                         .withTransactions(
-                                response.getTransactions().stream().map(mapper::mapStreamToComposition).collect(Collectors.toList())),
+                                response.getTransactions().stream().map(mapper::mapStreamToComposition).collect(Collectors.toList()))
+                        .withAdditions(response.getAdditions()),
                 HttpStatus.CREATED);
     }
 }


### PR DESCRIPTION
Cherry picking of changes implemented in PR https://github.com/Backbase/stream-services/pull/311 and released in version `3.33.2`.

The idea here is to be able to propagate additions returned by the integration layer response to the composition layer response.

```
ProductIngestionResponse.additions -> ProductIngestionResponse.additions

PullTransactionsResponse.additions -> TransactionIngestResponse.additions
```