### PR TITLE
Feature/create identity with additions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 All notable changes to this project will be documented in this file.
+## [3.48.0](https://github.com/Backbase/stream-services/compare/3.47.0...3.48.0)
+### Changed
+- Updated UserService.createOrImportIdentityUser to populate user's additions to DBS with IMPORT_FROM_IDENTITY linking strategy
+
 ## [3.47.0](https://github.com/Backbase/stream-services/compare/3.46.0...3.47.0)
 ### Changed
 - Removed unused parameter from Payment Orders filter request. 

--- a/stream-access-control/access-control-core/src/main/java/com/backbase/stream/service/UserService.java
+++ b/stream-access-control/access-control-core/src/main/java/com/backbase/stream/service/UserService.java
@@ -276,6 +276,7 @@ public class UserService {
         CreateIdentityRequest createIdentityRequest = new CreateIdentityRequest();
         createIdentityRequest.setLegalEntityInternalId(legalEntityInternalId);
         createIdentityRequest.setExternalId(user.getExternalId());
+        createIdentityRequest.setAdditions(user.getAdditions());
 
         if (IdentityUserLinkStrategy.CREATE_IN_IDENTITY.equals(user.getIdentityLinkStrategy())) {
             Objects.requireNonNull(user.getFullName(), "User Full Name is required for user: " + user.getExternalId() + " in legal entity: " + legalEntityInternalId);
@@ -286,7 +287,6 @@ public class UserService {
             createIdentityRequest.setEmailAddress(user.getEmailAddress().getAddress());
             createIdentityRequest.setMobileNumber(user.getMobileNumber().getNumber());
             ofNullable(user.getAttributes()).ifPresent(createIdentityRequest::setAttributes);
-            ofNullable(user.getAdditions()).ifPresent(createIdentityRequest::setAdditions);
         }
 
         return identityManagementApi.createIdentity(createIdentityRequest)

--- a/stream-access-control/access-control-core/src/test/java/com/backbase/stream/service/UserServiceTest.java
+++ b/stream-access-control/access-control-core/src/test/java/com/backbase/stream/service/UserServiceTest.java
@@ -1,5 +1,14 @@
 package com.backbase.stream.service;
 
+import static com.backbase.stream.legalentity.model.IdentityUserLinkStrategy.CREATE_IN_IDENTITY;
+import static com.backbase.stream.legalentity.model.IdentityUserLinkStrategy.IMPORT_FROM_IDENTIY;
+import static com.backbase.stream.LambdaAssertions.assertEqualsTo;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
 import com.backbase.dbs.user.api.service.v2.IdentityManagementApi;
 import com.backbase.dbs.user.api.service.v2.UserManagementApi;
 import com.backbase.dbs.user.api.service.v2.model.*;
@@ -10,6 +19,13 @@ import com.backbase.stream.legalentity.model.EmailAddress;
 import com.backbase.stream.legalentity.model.IdentityUserLinkStrategy;
 import com.backbase.stream.legalentity.model.PhoneNumber;
 import com.backbase.stream.legalentity.model.User;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+
 import com.backbase.stream.product.task.ProductGroupTask;
 import com.backbase.stream.worker.exception.StreamTaskException;
 import com.backbase.stream.worker.model.StreamTask;
@@ -24,19 +40,6 @@ import org.springframework.web.reactive.function.client.WebClientResponseExcepti
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
-
-import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Map;
-import java.util.Optional;
-
-import static com.backbase.stream.LambdaAssertions.assertEqualsTo;
-import static com.backbase.stream.legalentity.model.IdentityUserLinkStrategy.CREATE_IN_IDENTITY;
-import static com.backbase.stream.legalentity.model.IdentityUserLinkStrategy.IMPORT_FROM_IDENTIY;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class UserServiceTest {
@@ -152,21 +155,21 @@ class UserServiceTest {
         String email = "some@email.com";
 
         EnhancedUserRepresentation enhancedUserRepresentation = new EnhancedUserRepresentation().id(internalId)
-                .email(email).addGroupsItem("group1").addGroupsItem("group2");
+            .email(email).addGroupsItem("group1").addGroupsItem("group2");
         when(identityIntegrationApi.getUserById(realm, internalId))
-                .thenReturn(Mono.just(enhancedUserRepresentation));
+            .thenReturn(Mono.just(enhancedUserRepresentation));
         when(identityIntegrationApi.updateUserById(eq(realm), eq(internalId), any(UserRequestBody.class)))
-                .thenReturn(Mono.empty());
+            .thenReturn(Mono.empty());
 
         User user = new User().internalId(internalId)
-                .additionalGroups(Arrays.asList("group2", "group3"));
+            .additionalGroups(Arrays.asList("group2", "group3"));
         Mono<User> result = subject.updateUserState(user, realm);
 
 
         result.subscribe(assertEqualsTo(user));
         verify(identityIntegrationApi).getUserById(realm, internalId);
         UserRequestBody expectedUser = new UserRequestBody().id(internalId).email(email)
-                .credentials(Collections.emptyList()).groups(Arrays.asList("group1", "group2", "group3"));
+            .credentials(Collections.emptyList()).groups(Arrays.asList("group1", "group2", "group3"));
         verify(identityIntegrationApi).updateUserById(realm, internalId, expectedUser);
     }
 
@@ -304,7 +307,7 @@ class UserServiceTest {
         final String mobileNumber = "123456";
         final String fullName = "someName";
 
-        when(identityManagementApi.createIdentity(any())).thenReturn(Mono.error(WebClientResponseException.create(500, "", new HttpHeaders(), "Error response".getBytes(StandardCharsets.UTF_8), null)));
+        when(identityManagementApi.createIdentity(any())).thenReturn(Mono.error(WebClientResponseException.create(500,"", new HttpHeaders(), "Error response".getBytes(StandardCharsets.UTF_8), null)));
 
         User user = new User().externalId(externalId).attributes(attributesMap)
                 .identityLinkStrategy(strategy).fullName(fullName)
@@ -359,10 +362,10 @@ class UserServiceTest {
         final String fullName = "someName";
         UserExternal userExternal = new UserExternal()
                 .externalId(externalId)
-                .fullName(fullName);
+                        .fullName(fullName);
 
 
-        when(usersApi.createUser(any())).thenReturn(Mono.just(new UserCreated().id(internalId)));
+        when(usersApi.createUser(any())).thenReturn(Mono.just(new UserCreated().id(internalId) ));
 
         User user = new User().externalId(externalId).attributes(attributesMap)
                 .identityLinkStrategy(strategy).fullName(fullName)
@@ -410,7 +413,7 @@ class UserServiceTest {
         GetUser getUser = new GetUser().externalId(externalId)
                 .fullName(fullName);
 
-        when(usersApi.updateUserInBatch(any())).thenReturn(Flux.error(WebClientResponseException.create(500, "", new HttpHeaders(), "Error response".getBytes(StandardCharsets.UTF_8), null)));
+        when(usersApi.updateUserInBatch(any())).thenReturn(Flux.error(WebClientResponseException.create(500,"", new HttpHeaders(), "Error response".getBytes(StandardCharsets.UTF_8), null)));
         when(usersApi.getUserByExternalId(externalId, true)).thenReturn(Mono.just(getUser));
 
         User user = new User().externalId(externalId).fullName("oldName");

--- a/stream-access-control/access-control-core/src/test/java/com/backbase/stream/service/UserServiceTest.java
+++ b/stream-access-control/access-control-core/src/test/java/com/backbase/stream/service/UserServiceTest.java
@@ -1,14 +1,5 @@
 package com.backbase.stream.service;
 
-import static com.backbase.stream.legalentity.model.IdentityUserLinkStrategy.CREATE_IN_IDENTITY;
-import static com.backbase.stream.legalentity.model.IdentityUserLinkStrategy.IMPORT_FROM_IDENTIY;
-import static com.backbase.stream.LambdaAssertions.assertEqualsTo;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.when;
-
 import com.backbase.dbs.user.api.service.v2.IdentityManagementApi;
 import com.backbase.dbs.user.api.service.v2.UserManagementApi;
 import com.backbase.dbs.user.api.service.v2.model.*;
@@ -19,13 +10,6 @@ import com.backbase.stream.legalentity.model.EmailAddress;
 import com.backbase.stream.legalentity.model.IdentityUserLinkStrategy;
 import com.backbase.stream.legalentity.model.PhoneNumber;
 import com.backbase.stream.legalentity.model.User;
-
-import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Map;
-import java.util.Optional;
-
 import com.backbase.stream.product.task.ProductGroupTask;
 import com.backbase.stream.worker.model.StreamTask;
 import org.junit.jupiter.api.Assertions;
@@ -39,6 +23,19 @@ import org.springframework.web.reactive.function.client.WebClientResponseExcepti
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.backbase.stream.LambdaAssertions.assertEqualsTo;
+import static com.backbase.stream.legalentity.model.IdentityUserLinkStrategy.CREATE_IN_IDENTITY;
+import static com.backbase.stream.legalentity.model.IdentityUserLinkStrategy.IMPORT_FROM_IDENTIY;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class UserServiceTest {
@@ -154,21 +151,21 @@ class UserServiceTest {
         String email = "some@email.com";
 
         EnhancedUserRepresentation enhancedUserRepresentation = new EnhancedUserRepresentation().id(internalId)
-            .email(email).addGroupsItem("group1").addGroupsItem("group2");
+                .email(email).addGroupsItem("group1").addGroupsItem("group2");
         when(identityIntegrationApi.getUserById(realm, internalId))
-            .thenReturn(Mono.just(enhancedUserRepresentation));
+                .thenReturn(Mono.just(enhancedUserRepresentation));
         when(identityIntegrationApi.updateUserById(eq(realm), eq(internalId), any(UserRequestBody.class)))
-            .thenReturn(Mono.empty());
+                .thenReturn(Mono.empty());
 
         User user = new User().internalId(internalId)
-            .additionalGroups(Arrays.asList("group2", "group3"));
+                .additionalGroups(Arrays.asList("group2", "group3"));
         Mono<User> result = subject.updateUserState(user, realm);
 
 
         result.subscribe(assertEqualsTo(user));
         verify(identityIntegrationApi).getUserById(realm, internalId);
         UserRequestBody expectedUser = new UserRequestBody().id(internalId).email(email)
-            .credentials(Collections.emptyList()).groups(Arrays.asList("group1", "group2", "group3"));
+                .credentials(Collections.emptyList()).groups(Arrays.asList("group1", "group2", "group3"));
         verify(identityIntegrationApi).updateUserById(realm, internalId, expectedUser);
     }
 
@@ -198,6 +195,31 @@ class UserServiceTest {
         verify(identityManagementApi).createIdentity(expectedCreateIdentityRequest);
         UpdateIdentityRequest expectedUpdateIdentityRequest = new UpdateIdentityRequest().attributes(attributesMap);
         verify(identityManagementApi).updateIdentity(internalId, expectedUpdateIdentityRequest);
+    }
+
+    @Test
+    void createOrImportIdentityUserUpdateAdditionsWhenIFIStrategy() {
+        final String internalId = "someInternalId";
+        final String externalId = "someExternalId";
+        final String legalEntityId = "someLegalEntityId";
+        final Map<String, String> additionsMap = Collections.singletonMap("someKey", "someValue");
+
+        CreateIdentityResponse response = new CreateIdentityResponse().externalId(externalId).internalId(internalId);
+        when(identityManagementApi.createIdentity(any())).thenReturn(Mono.just(response));
+        when(identityManagementApi.updateIdentity(eq(internalId), any())).thenReturn(Mono.empty().then());
+
+        User user = new User().externalId(externalId).additions(additionsMap).identityLinkStrategy(IMPORT_FROM_IDENTIY);
+        Mono<User> result = subject.createOrImportIdentityUser(user, legalEntityId, new ProductGroupTask());
+
+        result.subscribe(assertEqualsTo(user));
+        CreateIdentityRequest expectedCreateIdentityRequest =
+                new CreateIdentityRequest()
+                        .externalId(externalId)
+                        .additions(additionsMap)
+                        .legalEntityInternalId(legalEntityId);
+
+        verify(identityManagementApi).createIdentity(expectedCreateIdentityRequest);
+        verify(identityManagementApi).updateIdentity(internalId, new UpdateIdentityRequest().additions(additionsMap));
     }
 
     @Test
@@ -265,7 +287,7 @@ class UserServiceTest {
         final String mobileNumber = "123456";
         final String fullName = "someName";
 
-        when(identityManagementApi.createIdentity(any())).thenReturn(Mono.error(WebClientResponseException.create(500,"", new HttpHeaders(), "Error response".getBytes(StandardCharsets.UTF_8), null)));
+        when(identityManagementApi.createIdentity(any())).thenReturn(Mono.error(WebClientResponseException.create(500, "", new HttpHeaders(), "Error response".getBytes(StandardCharsets.UTF_8), null)));
 
         User user = new User().externalId(externalId).attributes(attributesMap)
                 .identityLinkStrategy(strategy).fullName(fullName)
@@ -320,10 +342,10 @@ class UserServiceTest {
         final String fullName = "someName";
         UserExternal userExternal = new UserExternal()
                 .externalId(externalId)
-                        .fullName(fullName);
+                .fullName(fullName);
 
 
-        when(usersApi.createUser(any())).thenReturn(Mono.just(new UserCreated().id(internalId) ));
+        when(usersApi.createUser(any())).thenReturn(Mono.just(new UserCreated().id(internalId)));
 
         User user = new User().externalId(externalId).attributes(attributesMap)
                 .identityLinkStrategy(strategy).fullName(fullName)
@@ -371,7 +393,7 @@ class UserServiceTest {
         GetUser getUser = new GetUser().externalId(externalId)
                 .fullName(fullName);
 
-        when(usersApi.updateUserInBatch(any())).thenReturn(Flux.error(WebClientResponseException.create(500,"", new HttpHeaders(), "Error response".getBytes(StandardCharsets.UTF_8), null)));
+        when(usersApi.updateUserInBatch(any())).thenReturn(Flux.error(WebClientResponseException.create(500, "", new HttpHeaders(), "Error response".getBytes(StandardCharsets.UTF_8), null)));
         when(usersApi.getUserByExternalId(externalId, true)).thenReturn(Mono.just(getUser));
 
         User user = new User().externalId(externalId).fullName("oldName");

--- a/stream-access-control/access-control-core/src/test/java/com/backbase/stream/service/UserServiceTest.java
+++ b/stream-access-control/access-control-core/src/test/java/com/backbase/stream/service/UserServiceTest.java
@@ -1,5 +1,14 @@
 package com.backbase.stream.service;
 
+import static com.backbase.stream.legalentity.model.IdentityUserLinkStrategy.CREATE_IN_IDENTITY;
+import static com.backbase.stream.legalentity.model.IdentityUserLinkStrategy.IMPORT_FROM_IDENTIY;
+import static com.backbase.stream.LambdaAssertions.assertEqualsTo;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
 import com.backbase.dbs.user.api.service.v2.IdentityManagementApi;
 import com.backbase.dbs.user.api.service.v2.UserManagementApi;
 import com.backbase.dbs.user.api.service.v2.model.*;
@@ -10,6 +19,13 @@ import com.backbase.stream.legalentity.model.EmailAddress;
 import com.backbase.stream.legalentity.model.IdentityUserLinkStrategy;
 import com.backbase.stream.legalentity.model.PhoneNumber;
 import com.backbase.stream.legalentity.model.User;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+
 import com.backbase.stream.product.task.ProductGroupTask;
 import com.backbase.stream.worker.model.StreamTask;
 import org.junit.jupiter.api.Assertions;
@@ -23,19 +39,6 @@ import org.springframework.web.reactive.function.client.WebClientResponseExcepti
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
-
-import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Map;
-import java.util.Optional;
-
-import static com.backbase.stream.LambdaAssertions.assertEqualsTo;
-import static com.backbase.stream.legalentity.model.IdentityUserLinkStrategy.CREATE_IN_IDENTITY;
-import static com.backbase.stream.legalentity.model.IdentityUserLinkStrategy.IMPORT_FROM_IDENTIY;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class UserServiceTest {
@@ -151,21 +154,21 @@ class UserServiceTest {
         String email = "some@email.com";
 
         EnhancedUserRepresentation enhancedUserRepresentation = new EnhancedUserRepresentation().id(internalId)
-                .email(email).addGroupsItem("group1").addGroupsItem("group2");
+            .email(email).addGroupsItem("group1").addGroupsItem("group2");
         when(identityIntegrationApi.getUserById(realm, internalId))
-                .thenReturn(Mono.just(enhancedUserRepresentation));
+            .thenReturn(Mono.just(enhancedUserRepresentation));
         when(identityIntegrationApi.updateUserById(eq(realm), eq(internalId), any(UserRequestBody.class)))
-                .thenReturn(Mono.empty());
+            .thenReturn(Mono.empty());
 
         User user = new User().internalId(internalId)
-                .additionalGroups(Arrays.asList("group2", "group3"));
+            .additionalGroups(Arrays.asList("group2", "group3"));
         Mono<User> result = subject.updateUserState(user, realm);
 
 
         result.subscribe(assertEqualsTo(user));
         verify(identityIntegrationApi).getUserById(realm, internalId);
         UserRequestBody expectedUser = new UserRequestBody().id(internalId).email(email)
-                .credentials(Collections.emptyList()).groups(Arrays.asList("group1", "group2", "group3"));
+            .credentials(Collections.emptyList()).groups(Arrays.asList("group1", "group2", "group3"));
         verify(identityIntegrationApi).updateUserById(realm, internalId, expectedUser);
     }
 
@@ -198,6 +201,29 @@ class UserServiceTest {
     }
 
     @Test
+    void createOrImportIdentityUserDontUpdateWhenNoAttributesPresent() {
+        final String internalId = "someInternalId";
+        final String externalId = "someExternalId";
+        final String legalEntityId = "someLegalEntityId";
+        final IdentityUserLinkStrategy strategy = IMPORT_FROM_IDENTIY;
+
+        CreateIdentityResponse response = new CreateIdentityResponse().externalId(externalId).internalId(internalId);
+        when(identityManagementApi.createIdentity(any())).thenReturn(Mono.just(response));
+
+        User user = new User().externalId(externalId).identityLinkStrategy(strategy);
+
+
+        Mono<User> result = subject.createOrImportIdentityUser(user, legalEntityId, new ProductGroupTask());
+
+
+        result.subscribe(assertEqualsTo(user));
+        CreateIdentityRequest expectedCreateIdentityRequest = new CreateIdentityRequest().externalId(externalId)
+                .legalEntityInternalId(legalEntityId);
+        verify(identityManagementApi).createIdentity(expectedCreateIdentityRequest);
+        verifyNoMoreInteractions(identityManagementApi);
+    }
+
+    @Test
     void createOrImportIdentityUserUpdateAdditionsWhenIFIStrategy() {
         final String internalId = "someInternalId";
         final String externalId = "someExternalId";
@@ -220,29 +246,6 @@ class UserServiceTest {
 
         verify(identityManagementApi).createIdentity(expectedCreateIdentityRequest);
         verify(identityManagementApi).updateIdentity(internalId, new UpdateIdentityRequest().additions(additionsMap));
-    }
-
-    @Test
-    void createOrImportIdentityUserDontUpdateWhenNoAttributesPresent() {
-        final String internalId = "someInternalId";
-        final String externalId = "someExternalId";
-        final String legalEntityId = "someLegalEntityId";
-        final IdentityUserLinkStrategy strategy = IMPORT_FROM_IDENTIY;
-
-        CreateIdentityResponse response = new CreateIdentityResponse().externalId(externalId).internalId(internalId);
-        when(identityManagementApi.createIdentity(any())).thenReturn(Mono.just(response));
-
-        User user = new User().externalId(externalId).identityLinkStrategy(strategy);
-
-
-        Mono<User> result = subject.createOrImportIdentityUser(user, legalEntityId, new ProductGroupTask());
-
-
-        result.subscribe(assertEqualsTo(user));
-        CreateIdentityRequest expectedCreateIdentityRequest = new CreateIdentityRequest().externalId(externalId)
-                .legalEntityInternalId(legalEntityId);
-        verify(identityManagementApi).createIdentity(expectedCreateIdentityRequest);
-        verifyNoMoreInteractions(identityManagementApi);
     }
 
     @Test
@@ -287,7 +290,7 @@ class UserServiceTest {
         final String mobileNumber = "123456";
         final String fullName = "someName";
 
-        when(identityManagementApi.createIdentity(any())).thenReturn(Mono.error(WebClientResponseException.create(500, "", new HttpHeaders(), "Error response".getBytes(StandardCharsets.UTF_8), null)));
+        when(identityManagementApi.createIdentity(any())).thenReturn(Mono.error(WebClientResponseException.create(500,"", new HttpHeaders(), "Error response".getBytes(StandardCharsets.UTF_8), null)));
 
         User user = new User().externalId(externalId).attributes(attributesMap)
                 .identityLinkStrategy(strategy).fullName(fullName)
@@ -342,10 +345,10 @@ class UserServiceTest {
         final String fullName = "someName";
         UserExternal userExternal = new UserExternal()
                 .externalId(externalId)
-                .fullName(fullName);
+                        .fullName(fullName);
 
 
-        when(usersApi.createUser(any())).thenReturn(Mono.just(new UserCreated().id(internalId)));
+        when(usersApi.createUser(any())).thenReturn(Mono.just(new UserCreated().id(internalId) ));
 
         User user = new User().externalId(externalId).attributes(attributesMap)
                 .identityLinkStrategy(strategy).fullName(fullName)
@@ -393,7 +396,7 @@ class UserServiceTest {
         GetUser getUser = new GetUser().externalId(externalId)
                 .fullName(fullName);
 
-        when(usersApi.updateUserInBatch(any())).thenReturn(Flux.error(WebClientResponseException.create(500, "", new HttpHeaders(), "Error response".getBytes(StandardCharsets.UTF_8), null)));
+        when(usersApi.updateUserInBatch(any())).thenReturn(Flux.error(WebClientResponseException.create(500,"", new HttpHeaders(), "Error response".getBytes(StandardCharsets.UTF_8), null)));
         when(usersApi.getUserByExternalId(externalId, true)).thenReturn(Mono.just(getUser));
 
         User user = new User().externalId(externalId).fullName("oldName");

--- a/stream-access-control/access-control-core/src/test/java/com/backbase/stream/service/UserServiceTest.java
+++ b/stream-access-control/access-control-core/src/test/java/com/backbase/stream/service/UserServiceTest.java
@@ -1,14 +1,5 @@
 package com.backbase.stream.service;
 
-import static com.backbase.stream.legalentity.model.IdentityUserLinkStrategy.CREATE_IN_IDENTITY;
-import static com.backbase.stream.legalentity.model.IdentityUserLinkStrategy.IMPORT_FROM_IDENTIY;
-import static com.backbase.stream.LambdaAssertions.assertEqualsTo;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.when;
-
 import com.backbase.dbs.user.api.service.v2.IdentityManagementApi;
 import com.backbase.dbs.user.api.service.v2.UserManagementApi;
 import com.backbase.dbs.user.api.service.v2.model.*;
@@ -19,14 +10,8 @@ import com.backbase.stream.legalentity.model.EmailAddress;
 import com.backbase.stream.legalentity.model.IdentityUserLinkStrategy;
 import com.backbase.stream.legalentity.model.PhoneNumber;
 import com.backbase.stream.legalentity.model.User;
-
-import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Map;
-import java.util.Optional;
-
 import com.backbase.stream.product.task.ProductGroupTask;
+import com.backbase.stream.worker.exception.StreamTaskException;
 import com.backbase.stream.worker.model.StreamTask;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -39,6 +24,19 @@ import org.springframework.web.reactive.function.client.WebClientResponseExcepti
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.backbase.stream.LambdaAssertions.assertEqualsTo;
+import static com.backbase.stream.legalentity.model.IdentityUserLinkStrategy.CREATE_IN_IDENTITY;
+import static com.backbase.stream.legalentity.model.IdentityUserLinkStrategy.IMPORT_FROM_IDENTIY;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class UserServiceTest {
@@ -154,21 +152,21 @@ class UserServiceTest {
         String email = "some@email.com";
 
         EnhancedUserRepresentation enhancedUserRepresentation = new EnhancedUserRepresentation().id(internalId)
-            .email(email).addGroupsItem("group1").addGroupsItem("group2");
+                .email(email).addGroupsItem("group1").addGroupsItem("group2");
         when(identityIntegrationApi.getUserById(realm, internalId))
-            .thenReturn(Mono.just(enhancedUserRepresentation));
+                .thenReturn(Mono.just(enhancedUserRepresentation));
         when(identityIntegrationApi.updateUserById(eq(realm), eq(internalId), any(UserRequestBody.class)))
-            .thenReturn(Mono.empty());
+                .thenReturn(Mono.empty());
 
         User user = new User().internalId(internalId)
-            .additionalGroups(Arrays.asList("group2", "group3"));
+                .additionalGroups(Arrays.asList("group2", "group3"));
         Mono<User> result = subject.updateUserState(user, realm);
 
 
         result.subscribe(assertEqualsTo(user));
         verify(identityIntegrationApi).getUserById(realm, internalId);
         UserRequestBody expectedUser = new UserRequestBody().id(internalId).email(email)
-            .credentials(Collections.emptyList()).groups(Arrays.asList("group1", "group2", "group3"));
+                .credentials(Collections.emptyList()).groups(Arrays.asList("group1", "group2", "group3"));
         verify(identityIntegrationApi).updateUserById(realm, internalId, expectedUser);
     }
 
@@ -249,6 +247,22 @@ class UserServiceTest {
     }
 
     @Test
+    void createOrImportIdentityUserUpdateAdditionsWithError() {
+        final String internalId = "someInternalId";
+        final String externalId = "someExternalId";
+        final String legalEntityId = "someLegalEntityId";
+        final Map<String, String> additionsMap = Collections.singletonMap("someKey", "someValue");
+
+        CreateIdentityResponse response = new CreateIdentityResponse().externalId(externalId).internalId(internalId);
+        when(identityManagementApi.createIdentity(any())).thenReturn(Mono.just(response));
+
+        User user = new User().externalId(externalId).additions(additionsMap).identityLinkStrategy(IMPORT_FROM_IDENTIY);
+
+        StepVerifier.create(subject.createOrImportIdentityUser(user, legalEntityId, new ProductGroupTask()))
+                .expectError(StreamTaskException.class);
+    }
+
+    @Test
     void createOrImportIdentityUserDoesNotUpdateUserWhenNoIFIStrategy() {
         final String internalId = "someInternalId";
         final String externalId = "someExternalId";
@@ -290,7 +304,7 @@ class UserServiceTest {
         final String mobileNumber = "123456";
         final String fullName = "someName";
 
-        when(identityManagementApi.createIdentity(any())).thenReturn(Mono.error(WebClientResponseException.create(500,"", new HttpHeaders(), "Error response".getBytes(StandardCharsets.UTF_8), null)));
+        when(identityManagementApi.createIdentity(any())).thenReturn(Mono.error(WebClientResponseException.create(500, "", new HttpHeaders(), "Error response".getBytes(StandardCharsets.UTF_8), null)));
 
         User user = new User().externalId(externalId).attributes(attributesMap)
                 .identityLinkStrategy(strategy).fullName(fullName)
@@ -345,10 +359,10 @@ class UserServiceTest {
         final String fullName = "someName";
         UserExternal userExternal = new UserExternal()
                 .externalId(externalId)
-                        .fullName(fullName);
+                .fullName(fullName);
 
 
-        when(usersApi.createUser(any())).thenReturn(Mono.just(new UserCreated().id(internalId) ));
+        when(usersApi.createUser(any())).thenReturn(Mono.just(new UserCreated().id(internalId)));
 
         User user = new User().externalId(externalId).attributes(attributesMap)
                 .identityLinkStrategy(strategy).fullName(fullName)
@@ -396,7 +410,7 @@ class UserServiceTest {
         GetUser getUser = new GetUser().externalId(externalId)
                 .fullName(fullName);
 
-        when(usersApi.updateUserInBatch(any())).thenReturn(Flux.error(WebClientResponseException.create(500,"", new HttpHeaders(), "Error response".getBytes(StandardCharsets.UTF_8), null)));
+        when(usersApi.updateUserInBatch(any())).thenReturn(Flux.error(WebClientResponseException.create(500, "", new HttpHeaders(), "Error response".getBytes(StandardCharsets.UTF_8), null)));
         when(usersApi.getUserByExternalId(externalId, true)).thenReturn(Mono.just(getUser));
 
         User user = new User().externalId(externalId).fullName("oldName");


### PR DESCRIPTION
Updated UserService.createOrImportIdentityUser to populate user's additions to DBS with IMPORT_FROM_IDENTITY linking strategy.

## Checklist
 - [x] I made sure, I read [CONTRIBUTING.md](CONTRIBUTING.md) to put right branch prefix as per my need.
 - [x] I made sure to update [CHANGELOG.md](CHANGELOG.md).
 - [ ] I made sure to update [Stream Wiki](https://github.com/Backbase/stream-services/wiki)(only valid in case of new stream module or architecture changes) ~ N/A.
 - [x] My changes are adequately tested.
 - [x] I made sure all the SonarCloud Quality Gate are passed.
