### PR TITLE
Check if LE users is null or empty for audiences segmentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
+## [3.52.0](https://github.com/Backbase/stream-services/compare/3.51.0...3.52.0)
+### Changed
+- Fixed two small bugs caused by introduction of UserKindSegmentationSage
+  add check for LE not having users before processing. (should fix error when LE is empty)
+  add AudiencesSegmentationConfiguration to LegalEntitySagaConfiguration
 
 ## [3.51.0](https://github.com/Backbase/stream-services/compare/3.50.0...3.51.0)
 ### Changed

--- a/stream-legal-entity/legal-entity-core/src/main/java/com/backbase/stream/LegalEntitySaga.java
+++ b/stream-legal-entity/legal-entity-core/src/main/java/com/backbase/stream/LegalEntitySaga.java
@@ -219,11 +219,9 @@ public class LegalEntitySaga implements StreamTaskExecutor<LegalEntityTask> {
             return Mono.just(streamTask);
         }
 
-        if (!le.getUsers().isEmpty()) {
-            log.info("Ingesting customers of LE into UserKind segment customerCategory: " + customerCategory);
-        }
+        log.info("Ingesting customers of LE into UserKind segment customerCategory: " + customerCategory);
 
-        return Flux.fromIterable(le.getUsers())
+        return Flux.fromStream(StreamUtils.nullableCollectionToStream(le.getUsers()))
             .map(user -> {
                 var task = new UserKindSegmentationTask();
                 task.setCustomerOnboardedRequest(

--- a/stream-legal-entity/legal-entity-core/src/main/java/com/backbase/stream/configuration/LegalEntitySagaConfiguration.java
+++ b/stream-legal-entity/legal-entity-core/src/main/java/com/backbase/stream/configuration/LegalEntitySagaConfiguration.java
@@ -30,7 +30,8 @@ import org.springframework.context.annotation.Import;
     ProductIngestionSagaConfiguration.class,
     LimitsServiceConfiguration.class,
     ContactsServiceConfiguration.class,
-    LoansServiceConfiguration.class
+    LoansServiceConfiguration.class,
+    AudiencesSegmentationConfiguration.class
 })
 @EnableConfigurationProperties(
     {LegalEntitySagaConfigurationProperties.class}


### PR DESCRIPTION
## Description

- add check for LE not having users before processing. (should fix error when LE is empty)
- add AudiencesSegmentationConfiguration to LegalEntitySagaConfiguration

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
  
  Add N/A to the task if they are not relevant to the current PR(validation will be skipped). 
  e.g. [ ] My changes are adequately tested ~ N/A
-->

 - [x] I made sure, I read [CONTRIBUTING.md](CONTRIBUTING.md) to put right branch prefix as per my need.
 - [x] I made sure to update [CHANGELOG.md](CHANGELOG.md).
 - [x] I made sure to update [Stream Wiki](https://github.com/Backbase/stream-services/wiki)(only valid in case of new stream module or architecture changes).
 - [x] My changes are adequately tested.
 - [x] I made sure all the SonarCloud Quality Gate are passed.
