### PR TITLE
Update ArrangementIntegrationServiceImpl.java

### DIFF
--- a/stream-compositions/services/product-composition-service/src/main/java/com/backbase/stream/compositions/product/core/service/impl/ArrangementIntegrationServiceImpl.java
+++ b/stream-compositions/services/product-composition-service/src/main/java/com/backbase/stream/compositions/product/core/service/impl/ArrangementIntegrationServiceImpl.java
@@ -28,6 +28,7 @@ public class ArrangementIntegrationServiceImpl implements ArrangementIntegration
                                 .arrangementExternalId(ingestionRequest.getExternalArrangementId()))
                 .map(item -> arrangementMapper.mapIntegrationToStream(item.getArrangement()))
                 .map(item -> ArrangementIngestResponse.builder()
+                        .arrangementInternalId(ingestionRequest.getArrangementId())
                         .arrangement(item)
                         .build())
                 .onErrorResume(this::handleIntegrationError)


### PR DESCRIPTION
Added missing `arrangementInternalId` parameter to be used in the downstream composition services (e.g. transaction-composition)
