### PR TITLE
Add feature flag for limits ingestion default is true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 All notable changes to this project will be documented in this file.
-## [3.56.0](https://github.com/Backbase/stream-services/compare/3.54.0...3.55.0)
+## [3.57.0](https://github.com/Backbase/stream-services/compare/3.56.0...3.57.0)
+### Added
+- Add feature flag for limits ingestion default is true, `backbase.stream.limits.worker.enabled`
+## [3.56.0](https://github.com/Backbase/stream-services/compare/3.55.0...3.56.0)
 ### Changed
 - Fix missing portfolio aggregation model attribute `externalId`
 ## [3.55.0](https://github.com/Backbase/stream-services/compare/3.54.0...3.55.0)

--- a/stream-limits/limits-core/src/main/java/com/backbase/stream/configuration/LimitsServiceConfiguration.java
+++ b/stream-limits/limits-core/src/main/java/com/backbase/stream/configuration/LimitsServiceConfiguration.java
@@ -19,9 +19,11 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class LimitsServiceConfiguration {
 
+    private final LimitsWorkerConfigurationProperties limitsWorkerConfigurationProperties;
+
     @Bean
     public LimitsSaga limitsSaga(LimitsServiceApi limitsServiceApi) {
-        return new LimitsSaga(limitsServiceApi);
+        return new LimitsSaga(limitsServiceApi,limitsWorkerConfigurationProperties);
     }
 
     public static class InMemoryLimitsUnitOfWorkRepository extends

--- a/stream-limits/limits-core/src/main/java/com/backbase/stream/configuration/LimitsWorkerConfigurationProperties.java
+++ b/stream-limits/limits-core/src/main/java/com/backbase/stream/configuration/LimitsWorkerConfigurationProperties.java
@@ -10,4 +10,5 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @Data
 public class LimitsWorkerConfigurationProperties extends StreamWorkerConfiguration {
     private boolean continueOnError;
+    private boolean enabled = true;
 }

--- a/stream-limits/limits-core/src/main/java/com/backbase/stream/limit/LimitsSaga.java
+++ b/stream-limits/limits-core/src/main/java/com/backbase/stream/limit/LimitsSaga.java
@@ -42,7 +42,7 @@ public class LimitsSaga implements StreamTaskExecutor<LimitsTask> {
         CreateLimitRequestBody item = limitsTask.getData();
 
         if (!limitsWorkerConfigurationProperties.isEnabled()) {
-            log.info("backbase.stream.limits.worker.limitsEnabled is false, Skipping limits ingestion");
+            log.info("backbase.stream.limits.worker.enabled is false, Skipping limits ingestion");
             return Mono.just(limitsTask);
         }
 

--- a/stream-limits/limits-core/src/test/java/com/backbase/stream/limit/LimitsSagaTest.java
+++ b/stream-limits/limits-core/src/test/java/com/backbase/stream/limit/LimitsSagaTest.java
@@ -1,16 +1,9 @@
 package com.backbase.stream.limit;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
 import com.backbase.dbs.limit.api.service.v2.LimitsServiceApi;
-import com.backbase.dbs.limit.api.service.v2.model.CreateLimitRequestBody;
-import com.backbase.dbs.limit.api.service.v2.model.Entity;
-import com.backbase.dbs.limit.api.service.v2.model.LimitByUuidPutResponseBody;
-import com.backbase.dbs.limit.api.service.v2.model.LimitsPostResponseBody;
-import com.backbase.dbs.limit.api.service.v2.model.LimitsRetrievalPostResponseBody;
-import java.util.List;
+import com.backbase.dbs.limit.api.service.v2.model.*;
+import com.backbase.stream.configuration.LimitsWorkerConfigurationProperties;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -18,6 +11,12 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class LimitsSagaTest {
@@ -27,6 +26,14 @@ class LimitsSagaTest {
 
     @Mock
     private LimitsServiceApi limitsApi;
+
+    @Mock
+    private LimitsWorkerConfigurationProperties limitsWorkerConfigurationProperties;
+
+    @BeforeEach
+    public void init() {
+        when(limitsWorkerConfigurationProperties.isEnabled()).thenReturn(Boolean.TRUE);
+    }
 
     @Test
     void createLimits() {


### PR DESCRIPTION
## Description

- Add feature flag for limits ingestion default is true, `backbase.stream.limits.worker.enabled`

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
  
  Add N/A to the task if they are not relevant to the current PR(validation will be skipped). 
  e.g. [ ] My changes are adequately tested ~ N/A
-->

 - [x] I made sure, I read [CONTRIBUTING.md](CONTRIBUTING.md) to put right branch prefix as per my need.
 - [x] I made sure to update [CHANGELOG.md](CHANGELOG.md).
 - [x] I made sure to update [Stream Wiki](https://github.com/Backbase/stream-services/wiki)(only valid in case of new stream module or architecture changes).
 - [x] My changes are adequately tested.
 - [x] I made sure all the SonarCloud Quality Gate are passed.
