### PR TITLE
added service agreement update to secondary service agreements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 All notable changes to this project will be documented in this file.
+## [3.30.7](https://github.com/Backbase/stream-services/compare/3.33.6...3.33.7)
+### Changed
+- Added Secondary Service Agreement update functionality.
+
 ## [3.33.4](https://github.com/Backbase/stream-services/compare/3.33.3...3.34.4)
 ### Changed
 - Updated Product Mapper to map panSuffix to all product types `panSuffix` to `number`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 All notable changes to this project will be documented in this file.
-## [3.30.7](https://github.com/Backbase/stream-services/compare/3.33.6...3.33.7)
+## [3.33.7](https://github.com/Backbase/stream-services/compare/3.33.6...3.33.7)
 ### Changed
 - Added Secondary Service Agreement update functionality.
 

--- a/stream-access-control/access-control-core/src/main/java/com/backbase/stream/service/AccessGroupService.java
+++ b/stream-access-control/access-control-core/src/main/java/com/backbase/stream/service/AccessGroupService.java
@@ -44,6 +44,7 @@ import com.backbase.dbs.accesscontrol.api.service.v2.model.PresentationServiceAg
 import com.backbase.dbs.accesscontrol.api.service.v2.model.PresentationServiceAgreementUserPair;
 import com.backbase.dbs.accesscontrol.api.service.v2.model.PresentationServiceAgreementUsersBatchUpdate;
 import com.backbase.dbs.accesscontrol.api.service.v2.model.ServiceAgreementParticipantsGetResponseBody;
+import com.backbase.dbs.accesscontrol.api.service.v2.model.ServiceAgreementPut;
 import com.backbase.dbs.accesscontrol.api.service.v2.model.ServiceAgreementUsersQuery;
 import com.backbase.dbs.accesscontrol.api.service.v2.model.ServicesAgreementIngest;
 import com.backbase.dbs.user.api.service.v2.UserManagementApi;
@@ -99,6 +100,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.mapstruct.factory.Mappers;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.StringUtils;
+import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -186,6 +188,17 @@ public class AccessGroupService {
                 return Mono.empty();
             })
             .map(accessGroupMapper::toStream);
+    }
+    public Mono<ServiceAgreement> updateServiceAgreementItem(StreamTask streamTask, ServiceAgreement serviceAgreement) {
+        log.info("Updating Service Agreement with external Id: {}", serviceAgreement.getExternalId());
+        ServiceAgreementPut serviceAgreementPut = accessGroupMapper.toPresentationPut(serviceAgreement);
+        return serviceAgreementApi.putServiceAgreementItem(serviceAgreement.getInternalId(), serviceAgreementPut)
+            .onErrorResume(HttpClientErrorException.class, throwable -> {
+                log.error(SERVICE_AGREEMENT, "update", "failed", serviceAgreement.getExternalId(),
+                    "", throwable, throwable.getResponseBodyAsString(), "Failed to update Service Agreement");
+                return Mono.error(new StreamTaskException(streamTask, throwable, "Failed to update Service Agreement"));
+            })
+            .thenReturn(serviceAgreement);
     }
 
     /**

--- a/stream-compositions/services/legal-entity-composition-service/src/main/resources/application-local.yml
+++ b/stream-compositions/services/legal-entity-composition-service/src/main/resources/application-local.yml
@@ -38,6 +38,7 @@ backbase:
       sink:
         useIdentityIntegration: true
         userProfileEnabled: true
+        serviceAgreementUpdateEnabled: false
     compositions:
       legal-entity:
         integration-base-url: http://localhost:7001
@@ -444,4 +445,5 @@ bootstrap:
 
 logging:
   level:
+    com.backbase.stream: INFO
     com.backbase.stream.compositions: DEBUG

--- a/stream-compositions/services/legal-entity-composition-service/src/main/resources/application.yml
+++ b/stream-compositions/services/legal-entity-composition-service/src/main/resources/application.yml
@@ -21,6 +21,7 @@ backbase:
       sink:
         useIdentityIntegration: true
         userProfileEnabled: true
+        serviceAgreementUpdateEnabled: false
     compositions:
       legal-entity:
         integration-base-url: http://legal-entity-integration:8080

--- a/stream-legal-entity/legal-entity-core/src/main/java/com/backbase/stream/LegalEntitySaga.java
+++ b/stream-legal-entity/legal-entity-core/src/main/java/com/backbase/stream/LegalEntitySaga.java
@@ -833,7 +833,8 @@ public class LegalEntitySaga implements StreamTaskExecutor<LegalEntityTask> {
                 streamTask.info(SERVICE_AGREEMENT, SETUP_SERVICE_AGREEMENT, EXISTS, sa.getExternalId(), sa.getInternalId(),
                     "Existing Service Agreement: %s found for Legal Entity: %s", sa.getExternalId(),
                     legalEntity.getExternalId());
-                return accessGroupService.updateServiceAgreementAssociations(streamTask, newSa, userActions)
+                return accessGroupService.updateServiceAgreementItem(streamTask, newSa)
+                    .then(accessGroupService.updateServiceAgreementAssociations(streamTask, newSa, userActions))
                     .thenReturn(streamTask);
             });
         // As creatorLegalEntity doesnt accept external ID

--- a/stream-legal-entity/legal-entity-core/src/main/java/com/backbase/stream/LegalEntitySaga.java
+++ b/stream-legal-entity/legal-entity-core/src/main/java/com/backbase/stream/LegalEntitySaga.java
@@ -833,9 +833,14 @@ public class LegalEntitySaga implements StreamTaskExecutor<LegalEntityTask> {
                 streamTask.info(SERVICE_AGREEMENT, SETUP_SERVICE_AGREEMENT, EXISTS, sa.getExternalId(), sa.getInternalId(),
                     "Existing Service Agreement: %s found for Legal Entity: %s", sa.getExternalId(),
                     legalEntity.getExternalId());
-                return accessGroupService.updateServiceAgreementItem(streamTask, newSa)
-                    .then(accessGroupService.updateServiceAgreementAssociations(streamTask, newSa, userActions))
-                    .thenReturn(streamTask);
+                if (legalEntitySagaConfigurationProperties.isServiceAgreementUpdateEnabled()) {
+                    return accessGroupService.updateServiceAgreementItem(streamTask, newSa)
+                        .then(accessGroupService.updateServiceAgreementAssociations(streamTask, newSa, userActions))
+                        .thenReturn(streamTask);
+                } else {
+                    return accessGroupService.updateServiceAgreementAssociations(streamTask, newSa, userActions)
+                        .thenReturn(streamTask);
+                }
             });
         // As creatorLegalEntity doesnt accept external ID
         // If creatorLegalEntity property is specified and equals to LE's parentExternalId then setup the

--- a/stream-legal-entity/legal-entity-core/src/main/java/com/backbase/stream/configuration/LegalEntitySagaConfigurationProperties.java
+++ b/stream-legal-entity/legal-entity-core/src/main/java/com/backbase/stream/configuration/LegalEntitySagaConfigurationProperties.java
@@ -20,4 +20,9 @@ public class LegalEntitySagaConfigurationProperties extends StreamWorkerConfigur
      */
     private boolean userProfileEnabled = false;
 
+    /**
+     * Enable service agreement update
+     */
+    private boolean serviceAgreementUpdateEnabled = false;
+
 }

--- a/stream-legal-entity/legal-entity-core/src/test/java/com/backbase/stream/LegalEntitySagaTest.java
+++ b/stream-legal-entity/legal-entity-core/src/test/java/com/backbase/stream/LegalEntitySagaTest.java
@@ -435,6 +435,8 @@ class LegalEntitySagaTest {
             .thenReturn(Mono.empty());
         when(accessGroupService.getServiceAgreementByExternalId("Service_Agreement_Id"))
             .thenReturn(Mono.just(new ServiceAgreement().internalId("101").externalId("Service_Agreement_Id")));
+        when(accessGroupService.updateServiceAgreementItem(any(), any()))
+            .thenReturn(Mono.just(new ServiceAgreement().internalId("101").externalId("Service_Agreement_Id")));
         when(accessGroupService.updateServiceAgreementAssociations(any(), any(), any()))
             .thenReturn(Mono.just(new ServiceAgreement().internalId("101").externalId("Service_Agreement_Id")));
         when(accessGroupService.createServiceAgreement(any(), any()))

--- a/stream-legal-entity/legal-entity-core/src/test/java/com/backbase/stream/LegalEntitySagaTest.java
+++ b/stream-legal-entity/legal-entity-core/src/test/java/com/backbase/stream/LegalEntitySagaTest.java
@@ -426,6 +426,8 @@ class LegalEntitySagaTest {
         when(legalEntityService.putLegalEntity(any())).thenReturn(Mono.just(legalEntityTask.getLegalEntity()));
         when(legalEntitySagaConfigurationProperties.isUseIdentityIntegration())
             .thenReturn(true);
+        when(legalEntitySagaConfigurationProperties.isServiceAgreementUpdateEnabled())
+            .thenReturn(true);
         when(userService.setupRealm(legalEntityTask.getLegalEntity()))
             .thenReturn(Mono.empty());
         when(userService.linkLegalEntityToRealm(legalEntityTask.getLegalEntity()))

--- a/stream-legal-entity/legal-entity-core/src/test/java/com/backbase/stream/LegalEntitySagaTest.java
+++ b/stream-legal-entity/legal-entity-core/src/test/java/com/backbase/stream/LegalEntitySagaTest.java
@@ -70,6 +70,7 @@ import static java.util.Collections.singletonList;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -435,7 +436,7 @@ class LegalEntitySagaTest {
             .thenReturn(Mono.empty());
         when(accessGroupService.getServiceAgreementByExternalId("Service_Agreement_Id"))
             .thenReturn(Mono.just(new ServiceAgreement().internalId("101").externalId("Service_Agreement_Id")));
-        when(accessGroupService.updateServiceAgreementItem(any(), any()))
+        lenient().when(accessGroupService.updateServiceAgreementItem(any(), any()))
             .thenReturn(Mono.just(new ServiceAgreement().internalId("101").externalId("Service_Agreement_Id")));
         when(accessGroupService.updateServiceAgreementAssociations(any(), any(), any()))
             .thenReturn(Mono.just(new ServiceAgreement().internalId("101").externalId("Service_Agreement_Id")));

--- a/stream-legal-entity/legal-entity-http/src/test/java/com/backbase/stream/it/LegalEntitySagaIT.java
+++ b/stream-legal-entity/legal-entity-http/src/test/java/com/backbase/stream/it/LegalEntitySagaIT.java
@@ -258,6 +258,11 @@ class LegalEntitySagaIT {
             WireMock.put("/access-control/service-api/v2/accessgroups/data-groups/batch/update/data-items")
                 .willReturn(WireMock.aResponse().withStatus(HttpStatus.ACCEPTED.value()))
         );
+
+        stubFor(
+            WireMock.put("/access-control/service-api/v2/accessgroups/serviceagreements/500001")
+                .willReturn(WireMock.aResponse().withStatus(HttpStatus.OK.value()))
+        );
     }
 
     /**


### PR DESCRIPTION
## Description

At the moment once a secondary service agreement is created it can not be updated via streams. This PR allows updates to secondary service agreement. The change is specifically needed to allow Service Agreement `additions` modifications along with the rest of the SSA attributes. 
The feature is configurable and can be enabled or disables by the following flag `backbase.stream.legalentity.sink.serviceAgreementUpdateEnabled`

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
  
  Add N/A to the task if they are not relevant to the current PR(validation will be skipped). 
  e.g. [ ] My changes are adequately tested ~ N/A
-->

 - [x ] I made sure, I read [CONTRIBUTING.md](CONTRIBUTING.md) to put right branch prefix as per my need.
 - [ x] I made sure to update [CHANGELOG.md](CHANGELOG.md).
 - [x] I made sure to update [Stream Wiki](https://github.com/Backbase/stream-services/wiki)(only valid in case of new stream module or architecture changes). N/A
 - [x] My changes are adequately tested.
 - [x ] I made sure all the SonarCloud Quality Gate are passed.
