### PR TITLE
Add: update identity user attributes in case it was already created

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [3.59.0](https://github.com/Backbase/stream-services/compare/3.58.2...3.59.0)
+### Added
+- Add update identity user attributes in case it's previously created.
 ## [3.58.2](https://github.com/Backbase/stream-services/compare/3.58.1...3.58.2)
 ### Changed
 - Avoiding race condition when assigning a realm to a legal entity when ingesting multiple subsidiaries at the same time.

--- a/stream-access-control/access-control-core/src/main/java/com/backbase/stream/mapper/UserMapper.java
+++ b/stream-access-control/access-control-core/src/main/java/com/backbase/stream/mapper/UserMapper.java
@@ -1,6 +1,7 @@
 package com.backbase.stream.mapper;
 
 import com.backbase.dbs.user.api.service.v2.model.GetUser;
+import com.backbase.dbs.user.api.service.v2.model.UpdateIdentityRequest;
 import com.backbase.dbs.user.api.service.v2.model.User;
 import com.backbase.dbs.user.api.service.v2.model.UserExternal;
 import com.backbase.identity.integration.api.service.v1.model.EnhancedUserRepresentation;
@@ -27,4 +28,8 @@ public interface UserMapper {
     @Mapping(source = "userProfile.preferredLanguage", target = "preferredLanguage")
     @Mapping(source = "additions", target = "additions")
     User toServiceUser(com.backbase.stream.legalentity.model.User user);
+
+    @Mapping(target = "emailAddress", source = "emailAddress.address")
+    @Mapping(target = "mobileNumber", source = "mobileNumber.number")
+    UpdateIdentityRequest mapUpdateIdentity(com.backbase.stream.legalentity.model.User user);
 }

--- a/stream-access-control/access-control-core/src/main/java/com/backbase/stream/mapper/UserMapper.java
+++ b/stream-access-control/access-control-core/src/main/java/com/backbase/stream/mapper/UserMapper.java
@@ -1,9 +1,6 @@
 package com.backbase.stream.mapper;
 
-import com.backbase.dbs.user.api.service.v2.model.GetUser;
-import com.backbase.dbs.user.api.service.v2.model.UpdateIdentityRequest;
-import com.backbase.dbs.user.api.service.v2.model.User;
-import com.backbase.dbs.user.api.service.v2.model.UserExternal;
+import com.backbase.dbs.user.api.service.v2.model.*;
 import com.backbase.identity.integration.api.service.v1.model.EnhancedUserRepresentation;
 import com.backbase.identity.integration.api.service.v1.model.UserRequestBody;
 import org.mapstruct.Mapper;
@@ -29,7 +26,5 @@ public interface UserMapper {
     @Mapping(source = "additions", target = "additions")
     User toServiceUser(com.backbase.stream.legalentity.model.User user);
 
-    @Mapping(target = "emailAddress", source = "emailAddress.address")
-    @Mapping(target = "mobileNumber", source = "mobileNumber.number")
-    UpdateIdentityRequest mapUpdateIdentity(com.backbase.stream.legalentity.model.User user);
+    UpdateIdentityRequest mapUpdateIdentity(GetIdentity user);
 }

--- a/stream-access-control/access-control-core/src/main/java/com/backbase/stream/service/UserService.java
+++ b/stream-access-control/access-control-core/src/main/java/com/backbase/stream/service/UserService.java
@@ -424,6 +424,25 @@ public class UserService {
         return updateRequired ? Optional.of(userRequestBody) : Optional.empty();
     }
 
+
+    /**
+     * Update Identity User, ex: emailAddress, mobileNumber, attributes, and additions
+     *
+     * @param user
+     * @return Mono<User>
+     */
+    public Mono<Void> updateIdentity(User user) {
+
+        Objects.requireNonNull(user.getInternalId(), "user internalId is required");
+        UpdateIdentityRequest updateIdentityRequest = mapper.mapUpdateIdentity(user);
+
+        return identityManagementApi.updateIdentity(user.getInternalId(), updateIdentityRequest)
+                .onErrorResume(WebClientResponseException.class, e -> {
+                    log.error("Failed to update identity: {}", e.getResponseBodyAsString(), e);
+                    return Mono.error(e);
+                });
+    }
+
     /**
      * Update user
      *

--- a/stream-access-control/access-control-core/src/main/java/com/backbase/stream/service/UserService.java
+++ b/stream-access-control/access-control-core/src/main/java/com/backbase/stream/service/UserService.java
@@ -29,6 +29,7 @@ import java.text.MessageFormat;
 import java.util.*;
 import java.util.stream.Collectors;
 
+import static java.util.Objects.requireNonNullElse;
 import static java.util.Optional.ofNullable;
 
 /**
@@ -429,18 +430,32 @@ public class UserService {
      * Update Identity User, ex: emailAddress, mobileNumber, attributes, and additions
      *
      * @param user
-     * @return Mono<Void>
+     * @return Mono<User>
      */
-    public Mono<Void> updateIdentity(User user) {
+    public Mono<User> updateIdentity(User user) {
 
         Objects.requireNonNull(user.getInternalId(), "user internalId is required");
-        UpdateIdentityRequest updateIdentityRequest = mapper.mapUpdateIdentity(user);
 
-        return identityManagementApi.updateIdentity(user.getInternalId(), updateIdentityRequest)
-                .onErrorResume(WebClientResponseException.class, e -> {
-                    log.error("Failed to update identity: {}", e.getResponseBodyAsString(), e);
-                    return Mono.error(e);
-                });
+        return identityManagementApi.getIdentity(user.getInternalId())
+                .map(mapper::mapUpdateIdentity)
+                .flatMap(updateIdentityRequest -> {
+                    log.debug("Trying to update identity attributes and additions, externalId [{}]", user.getExternalId());
+                        if (updateIdentityRequest.getAttributes() == null) {
+                            updateIdentityRequest.attributes(new HashMap<>());
+                        }
+                        if (updateIdentityRequest.getAdditions() == null) {
+                            updateIdentityRequest.additions(new HashMap<>());
+                        }
+                        updateIdentityRequest.getAttributes().putAll(requireNonNullElse(user.getAttributes(), Map.of()));
+                        updateIdentityRequest.getAdditions().putAll(requireNonNullElse(user.getAdditions(), Map.of()));
+
+                        return identityManagementApi.updateIdentity(user.getInternalId(), updateIdentityRequest)
+                                .onErrorResume(WebClientResponseException.class, e -> {
+                                    log.error("Failed to update identity: {}", e.getResponseBodyAsString(), e);
+                                    return Mono.error(e);
+                                });
+                        }
+                ).thenReturn(user);
     }
 
     /**

--- a/stream-access-control/access-control-core/src/main/java/com/backbase/stream/service/UserService.java
+++ b/stream-access-control/access-control-core/src/main/java/com/backbase/stream/service/UserService.java
@@ -429,7 +429,7 @@ public class UserService {
      * Update Identity User, ex: emailAddress, mobileNumber, attributes, and additions
      *
      * @param user
-     * @return Mono<User>
+     * @return Mono<Void>
      */
     public Mono<Void> updateIdentity(User user) {
 

--- a/stream-legal-entity/legal-entity-bootstrap-task/src/test/java/com/backbase/stream/SetupLegalEntityHierarchyTaskApplicationIT.java
+++ b/stream-legal-entity/legal-entity-bootstrap-task/src/test/java/com/backbase/stream/SetupLegalEntityHierarchyTaskApplicationIT.java
@@ -16,7 +16,7 @@ import org.springframework.util.Assert;
 
 @SpringBootTest
 @ActiveProfiles({"it", "moustache-bank", "moustache-bank-subsidiaries"})
-public class SetupLegalEntityHierarchyTaskApplicationIT {
+class SetupLegalEntityHierarchyTaskApplicationIT {
 
     @Autowired
     BootstrapConfigurationProperties configuration;

--- a/stream-legal-entity/legal-entity-bootstrap-task/src/test/resources/mappings/get-identity.json
+++ b/stream-legal-entity/legal-entity-bootstrap-task/src/test/resources/mappings/get-identity.json
@@ -1,0 +1,27 @@
+{
+  "request": {
+    "method": "GET",
+    "urlPathPattern": "/user-manager/service-api/v2/users/identities/([\\w-]+)",
+    "headers": {
+      "X-B3-TraceId": {
+        "matches": "[\\w-]+"
+      },
+      "X-B3-SpanId": {
+        "matches": "[\\w-]+"
+      },
+      "X-TID": {
+        "contains": "tenant1"
+      }
+    }
+  },
+  "response": {
+    "status": 200,
+    "jsonBody": {
+      "internalId": "internal-id",
+      "externalId": "external-id"
+    },
+    "headers": {
+      "Content-Type": "application/json"
+    }
+  }
+}

--- a/stream-legal-entity/legal-entity-bootstrap-task/src/test/resources/mappings/put-identity.json
+++ b/stream-legal-entity/legal-entity-bootstrap-task/src/test/resources/mappings/put-identity.json
@@ -1,0 +1,26 @@
+{
+  "request": {
+    "method": "PUT",
+    "urlPathPattern": "/user-manager/service-api/v2/users/identities/([\\w-]+)",
+    "headers": {
+      "X-B3-TraceId": {
+        "matches": "[\\w-]+"
+      },
+      "X-B3-SpanId": {
+        "matches": "[\\w-]+"
+      },
+      "X-TID": {
+        "contains": "tenant1"
+      }
+    }
+  },
+  "response": {
+    "status": 200,
+    "jsonBody": {
+
+    },
+    "headers": {
+      "Content-Type": "application/json"
+    }
+  }
+}

--- a/stream-legal-entity/legal-entity-core/src/main/java/com/backbase/stream/LegalEntitySaga.java
+++ b/stream-legal-entity/legal-entity-core/src/main/java/com/backbase/stream/LegalEntitySaga.java
@@ -801,7 +801,9 @@ public class LegalEntitySaga implements StreamTaskExecutor<LegalEntityTask> {
                 user.setInternalId(existingUser.getInternalId());
                 streamTask.info(IDENTITY_USER, UPSERT, EXISTS, user.getExternalId(), user.getInternalId(), "User %s already exists", existingUser.getExternalId());
                 return user;
-            });
+            })
+            .doOnNext(userService::updateIdentity);
+
         Mono<User> createNewIdentityUser =
             userService.createOrImportIdentityUser(user, legalEntity.getInternalId(), streamTask)
                 .flatMap(currentUser -> userService.updateUserState(currentUser, legalEntity.getRealmName()))

--- a/stream-legal-entity/legal-entity-core/src/main/java/com/backbase/stream/LegalEntitySaga.java
+++ b/stream-legal-entity/legal-entity-core/src/main/java/com/backbase/stream/LegalEntitySaga.java
@@ -802,7 +802,7 @@ public class LegalEntitySaga implements StreamTaskExecutor<LegalEntityTask> {
                 streamTask.info(IDENTITY_USER, UPSERT, EXISTS, user.getExternalId(), user.getInternalId(), "User %s already exists", existingUser.getExternalId());
                 return user;
             })
-            .doOnNext(userService::updateIdentity);
+            .flatMap(userService::updateIdentity);
 
         Mono<User> createNewIdentityUser =
             userService.createOrImportIdentityUser(user, legalEntity.getInternalId(), streamTask)

--- a/stream-legal-entity/legal-entity-core/src/test/java/com/backbase/stream/LegalEntitySagaTest.java
+++ b/stream-legal-entity/legal-entity-core/src/test/java/com/backbase/stream/LegalEntitySagaTest.java
@@ -442,6 +442,8 @@ class LegalEntitySagaTest {
             .thenReturn(Mono.empty());
         when(userService.linkLegalEntityToRealm(legalEntityTask.getLegalEntity()))
             .thenReturn(Mono.empty());
+        when(userService.updateIdentity(any()))
+                .thenReturn(Mono.empty());
         when(userService.getUserByExternalId("john.doe"))
             .thenReturn(Mono.just(new User().internalId("100").externalId("john.doe")));
         when(userService.createOrImportIdentityUser(any(), any(), any()))
@@ -479,7 +481,7 @@ class LegalEntitySagaTest {
 
         // When
         legalEntitySaga.executeTask(legalEntityTask)
-            .block(Duration.ofSeconds(10));
+            .block(Duration.ofSeconds(20));
 
         // Then
         Assertions.assertEquals(

--- a/stream-legal-entity/legal-entity-http/src/test/java/com/backbase/stream/it/LegalEntitySagaIT.java
+++ b/stream-legal-entity/legal-entity-http/src/test/java/com/backbase/stream/it/LegalEntitySagaIT.java
@@ -279,6 +279,18 @@ class LegalEntitySagaIT {
                     .withHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE)
                     .withBody("[{\"arrangementId\":\"arrId1\",\"resourceId\":\"resId1\"}]"))
         );
+        stubFor(
+                WireMock.get("/user-manager/service-api/v2/users/identities/9ac44fca")
+                        .willReturn(WireMock.aResponse().withStatus(HttpStatus.MULTI_STATUS.value())
+                                .withHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                                .withBody("{\"internalId\":\"9ac44fca\",\"externalId\":\"externalId\"}"))
+        );
+        stubFor(
+                WireMock.put("/user-manager/service-api/v2/users/identities/9ac44fca")
+                        .willReturn(WireMock.aResponse().withStatus(HttpStatus.MULTI_STATUS.value())
+                                .withHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                                .withBody(""))
+        );
     }
 
     /**


### PR DESCRIPTION
## Description

Add: update identity user attributes in case it was already created.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
  
  Add N/A to the task if they are not relevant to the current PR(validation will be skipped). 
  e.g. [ ] My changes are adequately tested ~ N/A
-->

 - [x] I made sure, I read [CONTRIBUTING.md](CONTRIBUTING.md) to put right branch prefix as per my need.
 - [x] I made sure to update [CHANGELOG.md](CHANGELOG.md).
 - [x] I made sure to update [Stream Wiki](https://github.com/Backbase/stream-services/wiki)(only valid in case of new stream module or architecture changes).
 - [x] My changes are adequately tested.
 - [x] I made sure all the SonarCloud Quality Gate are passed.
