### PR TITLE
Feature/ingest arrangement id for pmts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -111,4 +111,4 @@ jobs:
 
       - name: Upload to Repo
         if: "contains(github.ref, 'master') || contains(github.ref, 'support/') || contains(github.ref, 'develop')" # In case of develop branch it will upload the snapshot version
-        run: mvn -B deploy -Pdocker-image,no-latest-tag -Dmaven.test.skip=true -Ddocker.default.tag=${{ env.DOCKER_TAG_VERSION }} -Ddocker.repo.url=repo.backbase.com -Ddocker.repo.project=backbase-stream-images -Djib.to.auth.username=${{ secrets.REPO_USERNAME }} -Djib.to.auth.password=${{ secrets.REPO_PASSWORD }} -DaltDeploymentRepository=backbase::default::https://repo.backbase.com/backbase-stream-releases/
+        run: mvn -B deploy -Pdocker-image,no-latest-tag,no-scs -Dmaven.test.skip=true -Ddocker.default.tag=${{ env.DOCKER_TAG_VERSION }} -Ddocker.repo.url=repo.backbase.com -Ddocker.repo.project=backbase-stream-images -Djib.to.auth.username=${{ secrets.REPO_USERNAME }} -Djib.to.auth.password=${{ secrets.REPO_PASSWORD }} -DaltDeploymentRepository=backbase::default::https://repo.backbase.com/backbase-stream-releases/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 All notable changes to this project will be documented in this file.
 
 ## [3.60.0](https://github.com/Backbase/stream-services/compare/3.59.0...3.60.0)
+### Added
+- Adding the ability to retrieve the arrangement a payment belongs to.
 ### Changed
 - updated application-local configurations to be aligned with the new Backbase Local env.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [3.60.0](https://github.com/Backbase/stream-services/compare/3.59.0...3.60.0)
+### Changed
+- updated application-local configurations to be aligned with the new Backbase Local env.
+
 ## [3.59.0](https://github.com/Backbase/stream-services/compare/3.58.2...3.59.0)
 ### Added
 - Add update identity user attributes in case it's previously created.

--- a/stream-compositions/services/legal-entity-composition-service/src/main/resources/application-local.yml
+++ b/stream-compositions/services/legal-entity-composition-service/src/main/resources/application-local.yml
@@ -11,28 +11,28 @@ spring:
 eureka:
   client:
     enabled: true
-    serviceUrl.defaultZone: http://localhost:8080/registry/eureka
+    serviceUrl.defaultZone: http://localhost:8761/eureka/
 
 backbase:
   communication:
     services:
       usermanager:
-        direct-uri: http://localhost:8086/user-manager
+        direct-uri: http://localhost:8060
       access-control:
-        direct-uri: http://localhost:8086/access-control
+        direct-uri: http://localhost:8040
       arrangement:
         manager:
-          direct-uri: http://localhost:8082/arrangement-manager
+          direct-uri: http://localhost:8050
       user:
         profile:
-          direct-uri: http://localhost:8086/user-profile-manager
+          direct-uri: http://localhost:8061
       identity:
         integration:
-          direct-uri: http://localhost:8181/identity-integration-service
+          direct-uri: http://localhost:8070
     http:
       client-secret: bb-secret
       client-id: bb-client
-      access-token-uri: "http://localhost:8181/oidc-token-converter-service/oauth/token"
+      access-token-uri: "http://localhost:7779/oauth/token"
   stream:
     legalentity:
       sink:
@@ -43,7 +43,7 @@ backbase:
         integration-base-url: http://localhost:7001
         chains:
           product-composition:
-            enabled: true
+            enabled: false
             base-url: http://localhost:9003
             async: false
         events:

--- a/stream-compositions/services/payment-order-composition-service/src/main/resources/application-local.yml
+++ b/stream-compositions/services/payment-order-composition-service/src/main/resources/application-local.yml
@@ -17,22 +17,22 @@ backbase:
   communication:
     services:
       usermanager:
-        direct-uri: http://localhost:8086/user-manager
+        direct-uri: http://localhost:8060
       access-control:
-        direct-uri: http://localhost:8086/access-control
+        direct-uri: http://localhost:8040
       arrangement:
         manager:
-          direct-uri: http://localhost:8082/arrangement-manager
+          direct-uri: http://localhost:8050
       payment:
         order:
-          direct-uri: http://localhost:8090/payment-order-service
+          direct-uri: http://localhost:8051
       transaction:
         manager:
-          direct-uri: http://localhost:8083/transaction-manager
+          direct-uri: http://localhost:8083
     http:
       client-secret: bb-secret
       client-id: bb-client
-      access-token-uri: http://localhost:8181/oidc-token-converter-service/oauth/token
+      access-token-uri: "http://localhost:7779/oauth/token"
   activemq:
     enabled: true
   stream:
@@ -50,7 +50,7 @@ eureka:
       role: live
   client:
     serviceUrl:
-      defaultZone: http://localhost:8080/registry/eureka/
+      defaultZone: http://localhost:8761/eureka/
 
 logging:
   level:

--- a/stream-compositions/services/product-catalog-composition-service/src/main/resources/application-local.yml
+++ b/stream-compositions/services/product-catalog-composition-service/src/main/resources/application-local.yml
@@ -10,16 +10,16 @@ backbase:
   communication:
     services:
       usermanager:
-        direct-uri: http://localhost:8086/user-manager
+        direct-uri: http://localhost:8060
       access-control:
-        direct-uri: http://localhost:8086/access-control
+        direct-uri: http://localhost:8040
       arrangement:
         manager:
-          direct-uri: http://localhost:8082/arrangement-manager
+          direct-uri: http://localhost:8050
     http:
       client-secret: bb-secret
       client-id: bb-client
-      access-token-uri: http://localhost:8181/oidc-token-converter-service/oauth/token
+      access-token-uri: "http://localhost:7779/oauth/token"
   stream:
     compositions:
       product-catalog:
@@ -37,7 +37,7 @@ eureka:
       role: live
   client:
     serviceUrl:
-      defaultZone: http://localhost:8080/registry/eureka/
+      defaultZone: http://localhost:8761/eureka/
 
 bootstrap:
   enabled: true

--- a/stream-compositions/services/product-composition-service/src/main/resources/application-local.yml
+++ b/stream-compositions/services/product-composition-service/src/main/resources/application-local.yml
@@ -20,29 +20,29 @@ sso:
 eureka:
   client:
     enabled: true
-    serviceUrl.defaultZone: http://localhost:8080/registry/eureka
+    serviceUrl.defaultZone: http://localhost:8761/eureka/
 
 backbase:
   communication:
     services:
       usermanager:
-        direct-uri: http://localhost:8086/user-manager
+        direct-uri: http://localhost:8060
       access-control:
-        direct-uri: http://localhost:8086/access-control
+        direct-uri: http://localhost:8040
       arrangement:
         manager:
-          direct-uri: http://localhost:8082/arrangement-manager
+          direct-uri: http://localhost:8050
     http:
       client-secret: bb-secret
       client-id: bb-client
-      access-token-uri: http://localhost:8181/oidc-token-converter-service/oauth/token
+      access-token-uri: "http://localhost:7779/oauth/token"
   stream:
     compositions:
       product:
         integration-base-url: http://localhost:7003
         chains:
           transaction-composition:
-            enabled: true
+            enabled: false
             base-url: http://localhost:9004
             async: false
             excludeProductTypeExternalIds:

--- a/stream-compositions/services/transaction-composition-service/src/main/resources/application-local.yml
+++ b/stream-compositions/services/transaction-composition-service/src/main/resources/application-local.yml
@@ -23,19 +23,19 @@ backbase:
   communication:
     services:
       usermanager:
-        direct-uri: http://localhost:8086/user-manager
+        direct-uri: http://localhost:8060
       access-control:
-        direct-uri: http://localhost:8086/access-control
+        direct-uri: http://localhost:8040
       arrangement:
         manager:
-          direct-uri: http://localhost:8082/arrangement-manager
+          direct-uri: http://localhost:8050
       transaction:
         manager:
-          direct-uri: http://localhost:8083/transaction-manager
+          direct-uri: http://localhost:8083
     http:
       client-secret: bb-secret
       client-id: bb-client
-      access-token-uri: http://localhost:8181/oidc-token-converter-service/oauth/token
+      access-token-uri: "http://localhost:7779/oauth/token"
   activemq:
     enabled: true
   stream:
@@ -58,7 +58,7 @@ eureka:
       role: live
   client:
     serviceUrl:
-      defaultZone: http://localhost:8080/registry/eureka/
+      defaultZone: http://localhost:8761/eureka/
 
 logging:
   level:

--- a/stream-payment-order/payment-order-core/src/main/java/com/backbase/stream/config/PaymentOrderServiceConfiguration.java
+++ b/stream-payment-order/payment-order-core/src/main/java/com/backbase/stream/config/PaymentOrderServiceConfiguration.java
@@ -34,10 +34,11 @@ public class PaymentOrderServiceConfiguration {
         PaymentOrderTaskExecutor paymentOrderTaskExecutor,
         PaymentOrderUnitOfWorkRepository paymentOrderUnitOfWorkRepository,
         PaymentOrderWorkerConfigurationProperties paymentOrderWorkerConfigurationProperties,
-        PaymentOrdersApi paymentOrdersApi) {
+        PaymentOrdersApi paymentOrdersApi,
+            ArrangementsApi arrangementsApi) {
 
         return new PaymentOrderUnitOfWorkExecutor(paymentOrderUnitOfWorkRepository, paymentOrderTaskExecutor,
-                paymentOrderWorkerConfigurationProperties, paymentOrdersApi, paymentOrderTypeMapper);
+                paymentOrderWorkerConfigurationProperties, paymentOrdersApi, arrangementsApi, paymentOrderTypeMapper);
     }
 
     @Bean

--- a/stream-payment-order/payment-order-core/src/main/java/com/backbase/stream/config/PaymentOrderServiceConfiguration.java
+++ b/stream-payment-order/payment-order-core/src/main/java/com/backbase/stream/config/PaymentOrderServiceConfiguration.java
@@ -1,5 +1,6 @@
 package com.backbase.stream.config;
 
+import com.backbase.dbs.arrangement.api.service.v2.ArrangementsApi;
 import com.backbase.dbs.paymentorder.api.service.v2.PaymentOrdersApi;
 import com.backbase.stream.PaymentOrderService;
 import com.backbase.stream.PaymentOrderServiceImpl;

--- a/stream-payment-order/payment-order-core/src/main/java/com/backbase/stream/model/PaymentOrderIngestContext.java
+++ b/stream-payment-order/payment-order-core/src/main/java/com/backbase/stream/model/PaymentOrderIngestContext.java
@@ -16,5 +16,5 @@ public class PaymentOrderIngestContext {
     private String internalUserId;
     private List<PaymentOrderPostRequest> corePaymentOrder = new ArrayList<>();
     private List<GetPaymentOrderResponse> existingPaymentOrder = new ArrayList<>();
-
+    private List<AccountArrangementItems> arrangementIds = new ArrayList<>();
 }

--- a/stream-payment-order/payment-order-core/src/main/java/com/backbase/stream/model/PaymentOrderIngestContext.java
+++ b/stream-payment-order/payment-order-core/src/main/java/com/backbase/stream/model/PaymentOrderIngestContext.java
@@ -1,5 +1,6 @@
 package com.backbase.stream.model;
 
+import com.backbase.dbs.arrangement.api.service.v2.model.AccountArrangementItems;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/stream-payment-order/payment-order-core/src/main/java/com/backbase/stream/paymentorder/PaymentOrderUnitOfWorkExecutor.java
+++ b/stream-payment-order/payment-order-core/src/main/java/com/backbase/stream/paymentorder/PaymentOrderUnitOfWorkExecutor.java
@@ -11,16 +11,9 @@ import com.backbase.dbs.arrangement.api.service.v2.ArrangementsApi;
 import com.backbase.dbs.arrangement.api.service.v2.model.AccountArrangementItem;
 import com.backbase.dbs.arrangement.api.service.v2.model.AccountArrangementItems;
 import com.backbase.dbs.arrangement.api.service.v2.model.AccountArrangementsFilter;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Stream;
 
 import javax.validation.Valid;

--- a/stream-payment-order/payment-order-core/src/test/java/com/backbase/stream/task/PaymentOrderUnitOfWorkExecutorTest.java
+++ b/stream-payment-order/payment-order-core/src/test/java/com/backbase/stream/task/PaymentOrderUnitOfWorkExecutorTest.java
@@ -1,6 +1,8 @@
 package com.backbase.stream.task;
 
 import com.backbase.dbs.arrangement.api.service.v2.ArrangementsApi;
+import com.backbase.dbs.arrangement.api.service.v2.model.AccountArrangementItem;
+import com.backbase.dbs.arrangement.api.service.v2.model.AccountArrangementItems;
 import com.backbase.dbs.paymentorder.api.service.v2.PaymentOrdersApi;
 import com.backbase.dbs.paymentorder.api.service.v2.model.PaymentOrderPostRequest;
 import com.backbase.dbs.paymentorder.api.service.v2.model.PaymentOrderPostResponse;
@@ -61,6 +63,16 @@ public class PaymentOrderUnitOfWorkExecutorTest extends PaymentOrderBaseTest {
         Mockito.lenient().when(paymentOrdersApi.postPaymentOrder(Mockito.any()))
                 .thenReturn(Mono.just(paymentOrderPostResponse));
 
+        AccountArrangementItem accountArrangementItem = new AccountArrangementItem()
+                .id("arrangementId_1")
+                .externalArrangementId("externalArrangementId_1");
+
+        AccountArrangementItems accountArrangementItems = new AccountArrangementItems()
+                .addArrangementElementsItem(accountArrangementItem);
+
+        Mockito.lenient().when(arrangementsApi.postFilter(Mockito.any()))
+                .thenReturn(Mono.just(accountArrangementItems));
+
         StepVerifier.create(paymentOrderUnitOfWorkExecutor.prepareUnitOfWork(paymentOrderIngestRequestList))
                 .assertNext(unitOfWork -> {
                     Assertions.assertTrue(unitOfWork.getUnitOfOWorkId().startsWith("payment-orders-mixed-"));
@@ -80,6 +92,16 @@ public class PaymentOrderUnitOfWorkExecutorTest extends PaymentOrderBaseTest {
 
         Mockito.lenient().when(paymentOrdersApi.postPaymentOrder(Mockito.any()))
                 .thenReturn(Mono.just(paymentOrderPostResponse));
+
+        AccountArrangementItem accountArrangementItem = new AccountArrangementItem()
+                .id("arrangementId_1")
+                .externalArrangementId("externalArrangementId_1");
+
+        AccountArrangementItems accountArrangementItems = new AccountArrangementItems()
+                .addArrangementElementsItem(accountArrangementItem);
+
+        Mockito.lenient().when(arrangementsApi.postFilter(Mockito.any()))
+                .thenReturn(Mono.just(accountArrangementItems));
 
         StepVerifier.create(paymentOrderUnitOfWorkExecutor.prepareUnitOfWork(paymentOrderPostRequestFlux))
                 .assertNext(unitOfWork -> {

--- a/stream-payment-order/payment-order-core/src/test/java/com/backbase/stream/task/PaymentOrderUnitOfWorkExecutorTest.java
+++ b/stream-payment-order/payment-order-core/src/test/java/com/backbase/stream/task/PaymentOrderUnitOfWorkExecutorTest.java
@@ -1,5 +1,6 @@
 package com.backbase.stream.task;
 
+import com.backbase.dbs.arrangement.api.service.v2.ArrangementsApi;
 import com.backbase.dbs.paymentorder.api.service.v2.PaymentOrdersApi;
 import com.backbase.dbs.paymentorder.api.service.v2.model.PaymentOrderPostRequest;
 import com.backbase.dbs.paymentorder.api.service.v2.model.PaymentOrderPostResponse;
@@ -32,6 +33,9 @@ public class PaymentOrderUnitOfWorkExecutorTest extends PaymentOrderBaseTest {
     private PaymentOrdersApi paymentOrdersApi;
 
     @Mock
+    private ArrangementsApi arrangementsApi;
+
+    @Mock
     private UnitOfWorkRepository<PaymentOrderTask, String> repository;
 
     private final PaymentOrderTaskExecutor streamTaskExecutor = new PaymentOrderTaskExecutor(paymentOrdersApi);
@@ -41,7 +45,7 @@ public class PaymentOrderUnitOfWorkExecutorTest extends PaymentOrderBaseTest {
     @InjectMocks
     private PaymentOrderUnitOfWorkExecutor paymentOrderUnitOfWorkExecutor = new PaymentOrderUnitOfWorkExecutor(
             repository, streamTaskExecutor, streamWorkerConfiguration,
-            paymentOrdersApi, paymentOrderTypeMapper);;
+            paymentOrdersApi, arrangementsApi, paymentOrderTypeMapper);;
 
     @Test
     void test_prepareUnitOfWork_paymentOrderIngestRequestList() {


### PR DESCRIPTION
## Description

1. This change will allow the payments to ingest the arrangement Id they are associated with it without the need to pass the ID in the request. The payment composition service will use the external arrangement ID (from the core) to retrieve the internal ID. 

2. Added back the no-scs tag back because we were unable to get these images to run on a Baas env without it.

3. Updated the application-local.yml files to be in line with the new BE local env instead of the old Blade setup.

4. There was a bug which occurred because the newer versions of DBS pulls only 10 pmts from the DB by default. I now specify the maximum size that needs to be pulled.

## Checklist

 - [ x] I made sure, I read [CONTRIBUTING.md](CONTRIBUTING.md) to put right branch prefix as per my need.
 - [x ] I made sure to update [CHANGELOG.md](CHANGELOG.md).
 - [x ] I made sure to update [Stream Wiki](https://github.com/Backbase/stream-services/wiki)(only valid in case of new stream module or architecture changes).
 - [ x] My changes are adequately tested.
 - [ x] I made sure all the SonarCloud Quality Gate are passed.
