### PR TITLE
add populating user manager cache with ingested user profile data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [3.60.1](https://github.com/Backbase/stream-services/compare/3.60.0...3.60.1)
+### Added
+- Add populating the user manager cache with user profile data.
+
 ## [3.60.0](https://github.com/Backbase/stream-services/compare/3.59.0...3.60.0)
 ### Added
 - Adding the ability to retrieve the arrangement a payment belongs to.

--- a/stream-access-control/access-control-core/src/main/java/com/backbase/stream/configuration/AccessControlConfiguration.java
+++ b/stream-access-control/access-control-core/src/main/java/com/backbase/stream/configuration/AccessControlConfiguration.java
@@ -56,8 +56,9 @@ public class AccessControlConfiguration {
     @Bean
     public UserService userService(Optional<IdentityIntegrationServiceApi> identityApi,
         UserManagementApi usersApi,
-        IdentityManagementApi identityManagementApi) {
-        return new UserService(usersApi, identityManagementApi, identityApi);
+        IdentityManagementApi identityManagementApi,
+        com.backbase.dbs.user.api.service.v2.UserProfileManagementApi userProfileManagementApi) {
+        return new UserService(usersApi, identityManagementApi, identityApi, userProfileManagementApi);
     }
 
     @Bean

--- a/stream-access-control/access-control-core/src/main/java/com/backbase/stream/service/UserService.java
+++ b/stream-access-control/access-control-core/src/main/java/com/backbase/stream/service/UserService.java
@@ -2,7 +2,9 @@ package com.backbase.stream.service;
 
 import com.backbase.dbs.user.api.service.v2.IdentityManagementApi;
 import com.backbase.dbs.user.api.service.v2.UserManagementApi;
+import com.backbase.dbs.user.api.service.v2.UserProfileManagementApi;
 import com.backbase.dbs.user.api.service.v2.model.*;
+import com.backbase.dbs.user.api.service.v2.model.UserProfile;
 import com.backbase.identity.integration.api.service.v1.IdentityIntegrationServiceApi;
 import com.backbase.identity.integration.api.service.v1.model.EnhancedUserRepresentation;
 import com.backbase.identity.integration.api.service.v1.model.UserRequestBody;
@@ -49,6 +51,7 @@ public class UserService {
     private final UserManagementApi usersApi;
     private final IdentityManagementApi identityManagementApi;
     private final Optional<IdentityIntegrationServiceApi> identityIntegrationApi;
+    private final UserProfileManagementApi userManagerProfileApi;
 
     /**
      * Get User by external ID.
@@ -487,4 +490,22 @@ public class UserService {
                 .then(getUserByExternalId(user.getExternalId()));
     }
 
+    /**
+     * Return user profile.
+     *
+     * @param userId user internal id.
+     * @return User profile if exists. Empty if not.
+     */
+    public Mono<UserProfile> getUserProfile(String userId) {
+        if (userId == null) {
+            return Mono.empty();
+        }
+
+        return userManagerProfileApi.getUserProfile(userId)
+            .doOnNext(userProfile -> log.info("Found user profile for internalId {}", userId))
+            .onErrorResume(WebClientResponseException.NotFound.class, notFound -> {
+                log.info("User profile with id: {} does not exist: {}", userId, notFound.getResponseBodyAsString());
+                return Mono.empty();
+            });
+    }
 }

--- a/stream-dbs-clients/src/main/java/com/backbase/stream/clients/config/UserManagerClientConfig.java
+++ b/stream-dbs-clients/src/main/java/com/backbase/stream/clients/config/UserManagerClientConfig.java
@@ -3,6 +3,7 @@ package com.backbase.stream.clients.config;
 import com.backbase.dbs.user.api.service.ApiClient;
 import com.backbase.dbs.user.api.service.v2.IdentityManagementApi;
 import com.backbase.dbs.user.api.service.v2.UserManagementApi;
+import com.backbase.dbs.user.api.service.v2.UserProfileManagementApi;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.text.DateFormat;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -37,6 +38,12 @@ public class UserManagerClientConfig extends CompositeApiClientConfig {
     @ConditionalOnMissingBean
     public IdentityManagementApi identityManagementApi(ApiClient userManagerClient) {
         return new IdentityManagementApi(userManagerClient);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public UserProfileManagementApi userManagerProfileApi(ApiClient userManagerClient) {
+        return new UserProfileManagementApi(userManagerClient);
     }
 
 }


### PR DESCRIPTION
## Description

Implemented the retrieval of user profile data from the user manager to populate the user manager cache with profile information.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
  
  Add N/A to the task if they are not relevant to the current PR(validation will be skipped). 
  e.g. [ ] My changes are adequately tested ~ N/A
-->

 - [x] I made sure, I read [CONTRIBUTING.md](CONTRIBUTING.md) to put right branch prefix as per my need.
 - [x] I made sure to update [CHANGELOG.md](CHANGELOG.md).
 - [ ] I made sure to update [Stream Wiki](https://github.com/Backbase/stream-services/wiki)(only valid in case of new stream module or architecture changes). ~ N/A
 - [x] My changes are adequately tested.
 - [x] I made sure all the SonarCloud Quality Gate are passed.
