### PR TITLE
Fix formatting of StreamTask error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [3.60.2](https://github.com/Backbase/stream-services/compare/3.60.1...3.60.2)
+### Changed
+- Fix formatting of StreamTask error messages
+- Fix message placeholders of `AccessGroupService`
+
 ## [3.60.1](https://github.com/Backbase/stream-services/compare/3.60.0...3.60.1)
 ### Added
 - Add populating the user manager cache with user profile data.

--- a/stream-access-control/access-control-core/src/main/java/com/backbase/stream/service/AccessGroupService.java
+++ b/stream-access-control/access-control-core/src/main/java/com/backbase/stream/service/AccessGroupService.java
@@ -402,7 +402,7 @@ public class AccessGroupService {
                 resultList.stream().forEach(r -> {
                     if (r.getStatus() != HTTP_STATUS_OK) {
                         streamTask.error("participant", "update-participant", "failed", r.getResourceId(),
-                            null, "Error updating Participant {} for Service Agreement: {}", r.getResourceId(),
+                            null, "Error updating Participant %s for Service Agreement: %s", r.getResourceId(),
                             serviceAgreement.getExternalId());
                         log.error("Error updating Participant {} for Service Agreement: {}", r.getResourceId(),
                             serviceAgreement.getExternalId());
@@ -1347,7 +1347,7 @@ public class AccessGroupService {
                     if (!item.getStatus().equals(HTTP_STATUS_OK)) {
                         streamTask.error(JOB_ROLE, "ingest-reference-job-role", FAILED,
                                 item.getExternalServiceAgreementId(), item.getResourceId(),
-                                "Failed up setup Job Role - status: {}, errors: {}", item.getStatus(), item.getErrors());
+                                "Failed setting up Job Role - status: %s, errors: %s", item.getStatus(), item.getErrors());
                         return Mono.error(new StreamTaskException(streamTask, "Failed to setup Job Role - status: " + item.getStatus() + ", errors: " + item.getErrors()));
                     }
                     jobRole.setId(idItems.get(0).getResourceId());

--- a/stream-sdk/stream-parent/stream-worker/src/main/java/com/backbase/stream/worker/model/StreamTask.java
+++ b/stream-sdk/stream-parent/stream-worker/src/main/java/com/backbase/stream/worker/model/StreamTask.java
@@ -54,9 +54,11 @@ public abstract class StreamTask {
      */
     public void error(String entity, String operation, String result, String externalId, String internalId,
                       String message, Object... messageArgs) {
-        addHistory(entity, operation, result, externalId, internalId, String.format(message, messageArgs),
+        String formattedMessage = String.format(message, messageArgs);
+
+        addHistory(entity, operation, result, externalId, internalId, formattedMessage,
             TaskHistory.Severity.ERROR, null, null);
-        error = message;
+        error = formattedMessage;
     }
 
     /**
@@ -72,9 +74,11 @@ public abstract class StreamTask {
      */
     public void error(String entity, String operation, String result, String externalId, String internalId,
                       Throwable throwable, String errorMessage, String message, Object... messageArgs) {
-        addHistory(entity, operation, result, externalId, internalId, String.format(message, messageArgs),
+        String formattedMessage = String.format(message, messageArgs);
+
+        addHistory(entity, operation, result, externalId, internalId, formattedMessage,
             TaskHistory.Severity.ERROR, throwable, errorMessage);
-        error = message;
+        error = formattedMessage;
     }
 
     /**


### PR DESCRIPTION
## Description

Fix formatting of StreamTask error messages

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
  
  Add N/A to the task if they are not relevant to the current PR(validation will be skipped). 
  e.g. [ ] My changes are adequately tested ~ N/A
-->

 - [X] I made sure, I read [CONTRIBUTING.md](CONTRIBUTING.md) to put right branch prefix as per my need.
 - [X] I made sure to update [CHANGELOG.md](CHANGELOG.md).
 - [X] I made sure to update [Stream Wiki](https://github.com/Backbase/stream-services/wiki)(only valid in case of new stream module or architecture changes).
 - [X] My changes are adequately tested.
 - [X] I made sure all the SonarCloud Quality Gate are passed.
