### PR TITLE
Secondary Service Agreement update functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [3.62.0](https://github.com/Backbase/stream-services/compare/3.61.0...3.62.0)
+### Added
+- Secondary Service Agreement update
+
 ## [3.60.2](https://github.com/Backbase/stream-services/compare/3.60.1...3.60.2)
 ### Changed
 - Fix formatting of StreamTask error messages

--- a/stream-compositions/services/legal-entity-composition-service/src/main/resources/application-local.yml
+++ b/stream-compositions/services/legal-entity-composition-service/src/main/resources/application-local.yml
@@ -38,6 +38,7 @@ backbase:
       sink:
         useIdentityIntegration: true
         userProfileEnabled: true
+        serviceAgreementUpdateEnabled: false
     compositions:
       legal-entity:
         integration-base-url: http://localhost:7001
@@ -444,4 +445,5 @@ bootstrap:
 
 logging:
   level:
+    com.backbase.stream: INFO
     com.backbase.stream.compositions: DEBUG

--- a/stream-compositions/services/legal-entity-composition-service/src/main/resources/application.yml
+++ b/stream-compositions/services/legal-entity-composition-service/src/main/resources/application.yml
@@ -21,6 +21,7 @@ backbase:
       sink:
         useIdentityIntegration: true
         userProfileEnabled: true
+        serviceAgreementUpdateEnabled: false
     compositions:
       legal-entity:
         integration-base-url: http://legal-entity-integration:8080

--- a/stream-legal-entity/legal-entity-core/src/main/java/com/backbase/stream/LegalEntitySaga.java
+++ b/stream-legal-entity/legal-entity-core/src/main/java/com/backbase/stream/LegalEntitySaga.java
@@ -882,8 +882,14 @@ public class LegalEntitySaga implements StreamTaskExecutor<LegalEntityTask> {
                 streamTask.info(SERVICE_AGREEMENT, SETUP_SERVICE_AGREEMENT, EXISTS, sa.getExternalId(), sa.getInternalId(),
                     "Existing Service Agreement: %s found for Legal Entity: %s", sa.getExternalId(),
                     legalEntity.getExternalId());
-                return accessGroupService.updateServiceAgreementAssociations(streamTask, newSa, userActions)
-                    .thenReturn(streamTask);
+                if (legalEntitySagaConfigurationProperties.isServiceAgreementUpdateEnabled()) {
+                    return accessGroupService.updateServiceAgreementItem(streamTask, newSa)
+                            .then(accessGroupService.updateServiceAgreementAssociations(streamTask, newSa, userActions))
+                            .thenReturn(streamTask);
+                } else {
+                    return accessGroupService.updateServiceAgreementAssociations(streamTask, newSa, userActions)
+                            .thenReturn(streamTask);
+                }
             });
         // As creatorLegalEntity doesnt accept external ID
         // If creatorLegalEntity property is specified and equals to LE's parentExternalId then setup the

--- a/stream-legal-entity/legal-entity-core/src/main/java/com/backbase/stream/configuration/LegalEntitySagaConfigurationProperties.java
+++ b/stream-legal-entity/legal-entity-core/src/main/java/com/backbase/stream/configuration/LegalEntitySagaConfigurationProperties.java
@@ -20,4 +20,8 @@ public class LegalEntitySagaConfigurationProperties extends StreamWorkerConfigur
      */
     private boolean userProfileEnabled = false;
 
+    /**
+     * Enable service agreement update
+     */
+    private boolean serviceAgreementUpdateEnabled = false;
 }

--- a/stream-legal-entity/legal-entity-core/src/test/java/com/backbase/stream/LegalEntitySagaTest.java
+++ b/stream-legal-entity/legal-entity-core/src/test/java/com/backbase/stream/LegalEntitySagaTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.lenient;
 
 import com.backbase.dbs.accesscontrol.api.service.v3.model.ServiceAgreementParticipantsGetResponseBody;
 import com.backbase.dbs.contact.api.service.v2.model.AccessContextScope;
@@ -441,6 +442,8 @@ class LegalEntitySagaTest {
         when(legalEntityService.putLegalEntity(any())).thenReturn(Mono.just(legalEntityTask.getLegalEntity()));
         when(legalEntitySagaConfigurationProperties.isUseIdentityIntegration())
             .thenReturn(true);
+        when(legalEntitySagaConfigurationProperties.isServiceAgreementUpdateEnabled())
+                .thenReturn(true);
         when(userService.setupRealm(legalEntityTask.getLegalEntity()))
             .thenReturn(Mono.empty());
         when(userService.linkLegalEntityToRealm(legalEntityTask.getLegalEntity()))
@@ -453,6 +456,8 @@ class LegalEntitySagaTest {
             .thenReturn(Mono.empty());
         when(accessGroupService.getServiceAgreementByExternalId("Service_Agreement_Id"))
             .thenReturn(Mono.just(new ServiceAgreement().internalId("101").externalId("Service_Agreement_Id")));
+        lenient().when(accessGroupService.updateServiceAgreementItem(any(), any()))
+                .thenReturn(Mono.just(new ServiceAgreement().internalId("101").externalId("Service_Agreement_Id")));
         when(accessGroupService.updateServiceAgreementAssociations(any(), any(), any()))
             .thenReturn(Mono.just(new ServiceAgreement().internalId("101").externalId("Service_Agreement_Id")));
         when(accessGroupService.createServiceAgreement(any(), any()))

--- a/stream-legal-entity/legal-entity-http/src/test/java/com/backbase/stream/it/LegalEntitySagaIT.java
+++ b/stream-legal-entity/legal-entity-http/src/test/java/com/backbase/stream/it/LegalEntitySagaIT.java
@@ -274,6 +274,10 @@ class LegalEntitySagaIT {
                 .willReturn(WireMock.aResponse().withStatus(HttpStatus.ACCEPTED.value()))
         );
         stubFor(
+                WireMock.put("/access-control/service-api/v3/accesscontrol/service-agreements/500001")
+                        .willReturn(WireMock.aResponse().withStatus(HttpStatus.OK.value()))
+        );
+        stubFor(
             WireMock.post("/loan/service-api/v1/loans/batch")
                 .willReturn(WireMock.aResponse().withStatus(HttpStatus.MULTI_STATUS.value())
                     .withHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE)


### PR DESCRIPTION

## Description

At the moment once a secondary service agreement is created it can not be updated via streams. This PR allows updates to secondary service agreement. The change is specifically needed to allow Service Agreement additions modifications along with the rest of the SSA attributes.
The feature is configurable and can be enabled or disables by the following flag `backbase.stream.legalentity.sink.serviceAgreementUpdateEnabled`

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
  
  Add N/A to the task if they are not relevant to the current PR(validation will be skipped). 
  e.g. [ ] My changes are adequately tested ~ N/A
-->

 - [x] I made sure, I read [CONTRIBUTING.md](CONTRIBUTING.md) to put right branch prefix as per my need.
 - [x] I made sure to update [CHANGELOG.md](CHANGELOG.md).
 - [] I made sure to update [Stream Wiki](https://github.com/Backbase/stream-services/wiki)(only valid in case of new stream module or architecture changes). ~ N/A
 - [x] My changes are adequately tested.
 - [x] I made sure all the SonarCloud Quality Gate are passed.
