### PR TITLE
Return error when transaction ingestion fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 All notable changes to this project will be documented in this file.
+## [3.33.7](https://github.com/Backbase/stream-services/compare/3.33.7...3.33.8)
+### Changed
+- Return error when transaction composition failed.
 ## [3.33.7](https://github.com/Backbase/stream-services/compare/3.33.6...3.33.7)
 ### Changed
 - Added Secondary Service Agreement update functionality.

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
         <codegen.generated-sources-dir>${project.build.directory}/generated-sources</codegen.generated-sources-dir>
         <annotations.generated-sources-dir>${codegen.generated-sources-dir}/annotations</annotations.generated-sources-dir>
         <openapi-generator-maven-plugin.output>${codegen.generated-sources-dir}/openapi</openapi-generator-maven-plugin.output>
-        <sonar.organization>backbase-technology-prototyping</sonar.organization>
+        <sonar.organization>backbase</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
 
         <japicmp.skip>true</japicmp.skip>

--- a/stream-compositions/services/product-composition-service/src/main/java/com/backbase/stream/compositions/product/core/service/impl/ProductPostIngestionServiceImpl.java
+++ b/stream-compositions/services/product-composition-service/src/main/java/com/backbase/stream/compositions/product/core/service/impl/ProductPostIngestionServiceImpl.java
@@ -47,7 +47,6 @@ public class ProductPostIngestionServiceImpl implements ProductPostIngestionServ
                 .doOnNext(r -> log.info("Product ingestion completed successfully for SA {}",
                         res.getServiceAgreementInternalId()))
                 .flatMap(this::processTransactionChains)
-                .onErrorResume(x -> Mono.just(res))
                 .flatMap(this::processPaymentOrderChains)
                 .doOnNext(this::processSuccessEvent)
                 .doOnNext(r -> {
@@ -172,7 +171,7 @@ public class ProductPostIngestionServiceImpl implements ProductPostIngestionServ
 
     private Mono<TransactionIngestionResponse> handleTransactionError(Throwable t) {
         log.error("Error while calling Transaction Composition: {}", t.getMessage());
-        return Mono.error(new InternalServerErrorException(t.getMessage()));
+        return Mono.just(new TransactionIngestionResponse());
     }
 
     private Mono<PaymentOrderIngestionResponse> handlePaymentOrderError(Throwable t) {

--- a/stream-compositions/services/product-composition-service/src/main/java/com/backbase/stream/compositions/product/core/service/impl/ProductPostIngestionServiceImpl.java
+++ b/stream-compositions/services/product-composition-service/src/main/java/com/backbase/stream/compositions/product/core/service/impl/ProductPostIngestionServiceImpl.java
@@ -47,6 +47,7 @@ public class ProductPostIngestionServiceImpl implements ProductPostIngestionServ
                 .doOnNext(r -> log.info("Product ingestion completed successfully for SA {}",
                         res.getServiceAgreementInternalId()))
                 .flatMap(this::processTransactionChains)
+                .onErrorResume(x -> Mono.just(res))
                 .flatMap(this::processPaymentOrderChains)
                 .doOnNext(this::processSuccessEvent)
                 .doOnNext(r -> {

--- a/stream-compositions/services/transaction-composition-service/src/main/java/com/backbase/stream/compositions/transaction/core/service/impl/TransactionPostIngestionServiceImpl.java
+++ b/stream-compositions/services/transaction-composition-service/src/main/java/com/backbase/stream/compositions/transaction/core/service/impl/TransactionPostIngestionServiceImpl.java
@@ -47,6 +47,6 @@ public class TransactionPostIngestionServiceImpl implements TransactionPostInges
             envelopedEvent.setEvent(event);
             eventBus.emitEvent(envelopedEvent);
         }
-        return Mono.empty();
+        return Mono.error(error);
     }
 }

--- a/stream-compositions/services/transaction-composition-service/src/test/java/com/backbase/stream/compositions/transaction/core/service/impl/TransactionIngestionServiceImplTest.java
+++ b/stream-compositions/services/transaction-composition-service/src/test/java/com/backbase/stream/compositions/transaction/core/service/impl/TransactionIngestionServiceImplTest.java
@@ -164,7 +164,7 @@ class TransactionIngestionServiceImplTest {
         Mono<TransactionIngestResponse> productIngestResponse = transactionIngestionService
                 .ingestPull(mockTransactionIngestPullRequest());
         StepVerifier.create(productIngestResponse)
-                .verifyComplete();
+                .verifyError();
     }
 
     @Test


### PR DESCRIPTION
## Description

When transaction ingestion fails return a failure response so the transaction composition consumer can handle it accordingly.


## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
  
  Add N/A to the task if they are not relevant to the current PR(validation will be skipped). 
  e.g. [ ] My changes are adequately tested ~ N/A
-->

 - [ x] I made sure, I read [CONTRIBUTING.md](CONTRIBUTING.md) to put right branch prefix as per my need.
 - [ x] I made sure to update [CHANGELOG.md](CHANGELOG.md).
 - [x] I made sure to update [Stream Wiki](https://github.com/Backbase/stream-services/wiki)(only valid in case of new stream module or architecture changes). ~ N/A
 - [ x] My changes are adequately tested.
 - [x ] I made sure all the SonarCloud Quality Gate are passed.
