### PR TITLE
Always check cursor and create if it does not exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 All notable changes to this project will be documented in this file.
+## [3.33.9](https://github.com/Backbase/stream-services/compare/3.33.9...3.33.9)
+### Changed
+- Always check cursor and create if it does not exist. 
+- If `DateRangeEnd` is passed in the composition request set that the lastTxnDate instead of system date.  
 ## [3.33.7](https://github.com/Backbase/stream-services/compare/3.33.7...3.33.8)
 ### Changed
 - Return error when transaction composition failed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 All notable changes to this project will be documented in this file.
-## [3.33.9](https://github.com/Backbase/stream-services/compare/3.33.9...3.33.9)
+## [3.33.9](https://github.com/Backbase/stream-services/compare/3.33.8...3.33.9)
 ### Changed
 - Always check cursor and create if it does not exist. 
 - If `DateRangeEnd` is passed in the composition request set that as lastTxnDate instead of system date.  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 ## [3.33.9](https://github.com/Backbase/stream-services/compare/3.33.9...3.33.9)
 ### Changed
 - Always check cursor and create if it does not exist. 
-- If `DateRangeEnd` is passed in the composition request set that the lastTxnDate instead of system date.  
+- If `DateRangeEnd` is passed in the composition request set that as lastTxnDate instead of system date.  
 ## [3.33.7](https://github.com/Backbase/stream-services/compare/3.33.7...3.33.8)
 ### Changed
 - Return error when transaction composition failed.

--- a/stream-compositions/services/transaction-composition-service/src/test/java/com/backbase/stream/compositions/transaction/core/service/impl/TransactionIngestionServiceImplTest.java
+++ b/stream-compositions/services/transaction-composition-service/src/test/java/com/backbase/stream/compositions/transaction/core/service/impl/TransactionIngestionServiceImplTest.java
@@ -172,8 +172,8 @@ class TransactionIngestionServiceImplTest {
 
         mockConfigForTransaction();
         mockTransactionService();
-        when(transactionCursorApi.patchByArrangementId(anyString(), any())).thenReturn(Mono.empty());
-
+        TransactionCursorResponse transactionCursorResponse = mockTransactionCursorResponse();
+        mockCursorApiForTransactions(transactionCursorResponse, false);
         TransactionIngestPullRequest transactionIngestPullRequest = mockTransactionIngestPullRequest();
         transactionIngestPullRequest.setDateRangeStart(OffsetDateTime.now());
 
@@ -247,5 +247,29 @@ class TransactionIngestionServiceImplTest {
                 .ingestPush(request);
         StepVerifier.create(productIngestResponse)
                 .assertNext(Assertions::assertNotNull).verifyComplete();
+    }
+
+    @Test
+    void ingestionInPullModePatchCursor_Success_withDates() {
+
+        mockConfigForTransaction();
+        mockTransactionService();
+        TransactionCursorResponse transactionCursorResponse = mockTransactionCursorResponse();
+        mockCursorApiForTransactions(transactionCursorResponse, false);
+
+        TransactionIngestPullRequest transactionIngestPullRequest = mockTransactionIngestPullRequest();
+        transactionIngestPullRequest.setDateRangeStart(OffsetDateTime.now().minusDays(10));
+        transactionIngestPullRequest.setDateRangeEnd(OffsetDateTime.now().minusDays(5));
+
+        when(transactionIntegrationService.pullTransactions(transactionIngestPullRequest))
+            .thenReturn(Flux.just(new TransactionsPostRequestBody().withType("type1").
+                withArrangementId("1234").withReference("ref")
+                .withExternalArrangementId("externalArrId")));
+
+        Mono<TransactionIngestResponse> productIngestResponse = transactionIngestionService
+            .ingestPull(transactionIngestPullRequest);
+        StepVerifier.create(productIngestResponse)
+            .assertNext(Assertions::assertNotNull)
+            .verifyComplete();
     }
 }


### PR DESCRIPTION

## Description

Check and create cursor if it does not exist even if the `dateRangeStart` is present in `TransactionIngestPullRequest `. If End Date is passed set the `lastTxnDate` to `TransactionIngestPullRequest.getDateRangeEnd()`

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
  
  Add N/A to the task if they are not relevant to the current PR(validation will be skipped). 
  e.g. [ ] My changes are adequately tested ~ N/A
-->

 - [ X] I made sure, I read [CONTRIBUTING.md](CONTRIBUTING.md) to put right branch prefix as per my need.
 - [ X] I made sure to update [CHANGELOG.md](CHANGELOG.md).
 - [ ] I made sure to update [Stream Wiki](https://github.com/Backbase/stream-services/wiki)(only valid in case of new stream module or architecture changes). ~ N/A
 - [ X ] My changes are adequately tested.
 - [ X] I made sure all the SonarCloud Quality Gate are passed.
