### PR TITLE
transaction-cursor: fix dependency issue - fix local config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [3.67.0](https://github.com/Backbase/stream-services/compare/3.66.0...3.67.0)
+### Changed
+- Fix transaction-cursor k8 deployment failure issue: `org.springframework.beans.factory.NoSuchBeanDefinitionException: No qualifying bean of type 'com.backbase.stream.compositions.transaction.cursor.core.mapper.TransactionCursorMapper' available`
+- Fix transaction-cursor `application-local.yaml` config
+
 ## [3.66.0](https://github.com/Backbase/stream-services/compare/3.65.0...3.66.0)
 ### Changed
 - Always check cursor and create if it does not exist.

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>com.backbase.stream</groupId>
     <artifactId>stream-services</artifactId>
-    <version>3.67.0</version>
+    <version>3.66.0</version>
 
     <packaging>pom</packaging>
     <name>Stream :: Services</name>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>com.backbase.stream</groupId>
     <artifactId>stream-services</artifactId>
-    <version>3.66.0</version>
+    <version>3.67.0</version>
 
     <packaging>pom</packaging>
     <name>Stream :: Services</name>

--- a/stream-compositions/cursors/transaction-cursor/pom.xml
+++ b/stream-compositions/cursors/transaction-cursor/pom.xml
@@ -37,6 +37,11 @@
       <artifactId>mysql-connector-j</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>com.backbase.buildingblocks</groupId>
+      <artifactId>service-sdk-starter-mapping</artifactId>
+    </dependency>
+
     <!-- Spring dependencies -->
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/stream-compositions/cursors/transaction-cursor/src/main/resources/application-local.yml
+++ b/stream-compositions/cursors/transaction-cursor/src/main/resources/application-local.yml
@@ -22,19 +22,19 @@ backbase:
   communication:
     services:
       usermanager:
-        direct-uri: http://localhost:8086/user-manager
+        direct-uri: http://localhost:8060
       access-control:
-        direct-uri: http://localhost:8086/access-control
+        direct-uri: http://localhost:8040
       arrangement:
         manager:
-          direct-uri: http://localhost:8082/arrangement-manager
+          direct-uri: http://localhost:8061
       user:
         profile:
           direct-uri: http://localhost:8086/user-profile-manager
     http:
       client-secret: bb-secret
       client-id: bb-client
-      access-token-uri: http://localhost:8181/oidc-token-converter-service/oauth/token
+      access-token-uri: "http://localhost:7779/oauth/token"
 
 logging:
   level:
@@ -50,7 +50,7 @@ eureka:
       role: live
   client:
     serviceUrl:
-      defaultZone: http://localhost:8080/registry/eureka/
+      defaultZone: http://localhost:8761/eureka/
 
 sso:
   jwt:


### PR DESCRIPTION
## Description

With the change to use `spring-cloud-starter-kubernetes-fabric8`, we needed to also add the `service-sdk-starter-mapping` dependency to transaction-cursor. 

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
  
  Add N/A to the task if they are not relevant to the current PR(validation will be skipped). 
  e.g. [ ] My changes are adequately tested ~ N/A
-->

 - [ x] I made sure, I read [CONTRIBUTING.md](CONTRIBUTING.md) to put right branch prefix as per my need.
 - [ x] I made sure to update [CHANGELOG.md](CHANGELOG.md).
 - [ N/A] I made sure to update [Stream Wiki](https://github.com/Backbase/stream-services/wiki)(only valid in case of new stream module or architecture changes).
 - [x ] My changes are adequately tested.
 - [x ] I made sure all the SonarCloud Quality Gate are passed.
