### PR TITLE
Added a flag to skip identity updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [3.70.1](https://github.com/Backbase/stream-services/compare/3.70.0...3.70.1)
+### Added
+- A flag to skip updates to user in Identity `backbase.stream.user.management.update-identity`.
+
 ## [3.70.0](https://github.com/Backbase/stream-services/compare/3.69.0...3.70.0)
 ### Added
 - Support to Events via Azure Service Bus for the Stream Composition Services

--- a/stream-access-control/access-control-core/src/main/java/com/backbase/stream/configuration/AccessControlConfiguration.java
+++ b/stream-access-control/access-control-core/src/main/java/com/backbase/stream/configuration/AccessControlConfiguration.java
@@ -30,7 +30,7 @@ import org.springframework.context.annotation.Import;
 @Configuration
 @Import(ProductConfiguration.class)
 @Slf4j
-@EnableConfigurationProperties(DeletionProperties.class)
+@EnableConfigurationProperties({DeletionProperties.class,UserManagementProperties.class})
 public class AccessControlConfiguration {
 
     @Bean
@@ -57,8 +57,10 @@ public class AccessControlConfiguration {
     public UserService userService(Optional<IdentityIntegrationServiceApi> identityApi,
         UserManagementApi usersApi,
         IdentityManagementApi identityManagementApi,
-        com.backbase.dbs.user.api.service.v2.UserProfileManagementApi userProfileManagementApi) {
-        return new UserService(usersApi, identityManagementApi, identityApi, userProfileManagementApi);
+        com.backbase.dbs.user.api.service.v2.UserProfileManagementApi userProfileManagementApi,
+                                   UserManagementProperties userManagementProperties) {
+        return new UserService(usersApi, identityManagementApi, identityApi,
+            userProfileManagementApi, userManagementProperties);
     }
 
     @Bean

--- a/stream-access-control/access-control-core/src/main/java/com/backbase/stream/configuration/UserManagementProperties.java
+++ b/stream-access-control/access-control-core/src/main/java/com/backbase/stream/configuration/UserManagementProperties.java
@@ -1,0 +1,14 @@
+package com.backbase.stream.configuration;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Setter
+@Getter
+@ConfigurationProperties("backbase.stream.user.management")
+public class UserManagementProperties {
+
+    private boolean updateIdentity = true;
+
+}

--- a/stream-access-control/access-control-core/src/main/java/com/backbase/stream/service/UserService.java
+++ b/stream-access-control/access-control-core/src/main/java/com/backbase/stream/service/UserService.java
@@ -336,6 +336,7 @@ public class UserService {
                 })
                 .then(Mono.just(user));
         }
+        log.debug("The identity: {} update call is skipped as the specified update conditions are not met.", user.getExternalId());
         return Mono.just(user);
     }
 
@@ -462,6 +463,7 @@ public class UserService {
                                     return Mono.error(e);
                                 });
                         }
+                        log.debug("The identity: {} update call is skipped because Update Identity flag is set to: {} ", user.getExternalId(), userManagementProperties.isUpdateIdentity());
                         return Mono.just(updateIdentityRequest);
                         }
                 ).thenReturn(user);

--- a/stream-compositions/services/legal-entity-composition-service/src/main/resources/application-local.yml
+++ b/stream-compositions/services/legal-entity-composition-service/src/main/resources/application-local.yml
@@ -61,7 +61,9 @@ backbase:
           enableFailed: false
         cursor:
           enabled: false
-
+    user:
+      management:
+        update-identity: false
 bootstrap:
   enabled: true
   # This is an Backbase OOTB Configuration. Please update as per project requirements

--- a/stream-compositions/services/legal-entity-composition-service/src/main/resources/application-local.yml
+++ b/stream-compositions/services/legal-entity-composition-service/src/main/resources/application-local.yml
@@ -63,7 +63,7 @@ backbase:
           enabled: false
     user:
       management:
-        update-identity: false
+        update-identity: true
 bootstrap:
   enabled: true
   # This is an Backbase OOTB Configuration. Please update as per project requirements

--- a/stream-compositions/services/legal-entity-composition-service/src/main/resources/application.yml
+++ b/stream-compositions/services/legal-entity-composition-service/src/main/resources/application.yml
@@ -29,6 +29,9 @@ backbase:
           enableFailed: true
         cursor:
           enabled: false
+    user:
+      management:
+        update-identity: true
 bootstrap:
   enabled: false
   # This is just an example. Replace it with data corresponding to your bank


### PR DESCRIPTION
## Description

This PR contains add a flag to skip updates to User in Identity. After the recent Identity and Core Service Upgrade (`2023.09-LTS`) simultaneously updates to the Identity User often results in `HTTP 409 Conflict` this happens in the scenarios where there are more than 1 service agreements for a single user (i.e. one for Retail and other for Business). To make the change seamless for existing consumers the default value is set to true. 

Reference ISD ticket: https://backbase.atlassian.net/servicedesk/customer/portal/27/ISD-318
## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
  
  Add N/A to the task if they are not relevant to the current PR(validation will be skipped). 
  e.g. [ ] My changes are adequately tested ~ N/A
-->

 - [ x] I made sure, I read [CONTRIBUTING.md](CONTRIBUTING.md) to put right branch prefix as per my need.
 - [ x] I made sure to update [CHANGELOG.md](CHANGELOG.md).
 - [ N/A] I made sure to update [Stream Wiki](https://github.com/Backbase/stream-services/wiki)(only valid in case of new stream module or architecture changes).
 - [ x] My changes are adequately tested.
 - [ x] I made sure all the SonarCloud Quality Gate are passed.
