### PR TITLE
Update transaction cursor mapper bean name to a name that does not cl…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [3.72.1](https://github.com/Backbase/stream-services/compare/3.72.0...3.72.1)
+### Added
+- Change name of transaction cursor mapper bean so that it does not clash with dependencies.
+
 ## [3.72.0](https://github.com/Backbase/stream-services/compare/3.71.0...3.72.0)
 ### Added
 - A flag to skip updates to user in Identity `backbase.stream.user.management.update-identity`.
@@ -16,7 +20,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 - Support to Events via Azure Service Bus for the Stream Composition Services
 - Product Composition now supports transaction-manager's out-of-the-box pulling mechanism, via the `transaction-pull-integration-service`. A separate chain was created for that, enabled via: `backbase.stream.compositions.product.chains.transaction-manager.enabled`
-  - Only one of the transaction chains can be enabled, either the `transaction-manager` or `transaction-composition`.
+  - Only one of [CHANGELOG.md](CHANGELOG.md)the transaction chains can be enabled, either the `transaction-manager` or `transaction-composition`.
   - The purpose of this new chain is to create better support for the OOTB implementation and enable ModelBank projects.
   - The refresh supports fine graining the pulling requests per arrangement, or a bulk request for all arrangements at once via configuring `splitPerArrangement` and `concurrency` properties.
 - Multi-tenancy support to SSDK message broker Events

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 - Support to Events via Azure Service Bus for the Stream Composition Services
 - Product Composition now supports transaction-manager's out-of-the-box pulling mechanism, via the `transaction-pull-integration-service`. A separate chain was created for that, enabled via: `backbase.stream.compositions.product.chains.transaction-manager.enabled`
-  - Only one of [CHANGELOG.md](CHANGELOG.md)the transaction chains can be enabled, either the `transaction-manager` or `transaction-composition`.
+  - Only one of the transaction chains can be enabled, either the `transaction-manager` or `transaction-composition`.
   - The purpose of this new chain is to create better support for the OOTB implementation and enable ModelBank projects.
   - The refresh supports fine graining the pulling requests per arrangement, or a bulk request for all arrangements at once via configuring `splitPerArrangement` and `concurrency` properties.
 - Multi-tenancy support to SSDK message broker Events

--- a/stream-compositions/cursors/transaction-cursor/src/main/java/com/backbase/stream/compositions/transaction/cursor/core/config/TransactionCursorConfiguration.java
+++ b/stream-compositions/cursors/transaction-cursor/src/main/java/com/backbase/stream/compositions/transaction/cursor/core/config/TransactionCursorConfiguration.java
@@ -16,7 +16,7 @@ import org.springframework.security.web.server.SecurityWebFilterChain;
 public class TransactionCursorConfiguration {
 
     @Bean
-    public TransactionCursorMapper mapper() {
+    public TransactionCursorMapper transactionCursorMapper() {
         return Mappers.getMapper(TransactionCursorMapper.class);
     }
 


### PR DESCRIPTION

## Description

Change the transaction cursor mapper bean name so it does not clash with dependencies.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
  
  Add N/A to the task if they are not relevant to the current PR(validation will be skipped). 
  e.g. [ ] My changes are adequately tested ~ N/A
-->

 - [X] I made sure, I read [CONTRIBUTING.md](CONTRIBUTING.md) to put right branch prefix as per my need.
 - [X] I made sure to update [CHANGELOG.md](CHANGELOG.md).
 - [X] I made sure to update [Stream Wiki](https://github.com/Backbase/stream-services/wiki)(only valid in case of new stream module or architecture changes).
 - [X] My changes are adequately tested.
 - [X] I made sure all the SonarCloud Quality Gate are passed.
