### PR TITLE
Fixed issue with payment order ingestion, where it was not paging if the user had lots of objects in the same request.

### DIFF
--- a/stream-compositions/services/payment-order-composition-service/src/main/java/com/backbase/stream/compositions/paymentorders/core/service/impl/PaymentOrderPostIngestionServiceImpl.java
+++ b/stream-compositions/services/payment-order-composition-service/src/main/java/com/backbase/stream/compositions/paymentorders/core/service/impl/PaymentOrderPostIngestionServiceImpl.java
@@ -8,6 +8,7 @@ import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
 
 @Service
 @Slf4j
@@ -25,6 +26,7 @@ public class PaymentOrderPostIngestionServiceImpl implements PaymentOrderPostIng
     @Override
     public Mono<List<PaymentOrderIngestDbsResponse>> handleFailure(Throwable error) {
         // events can be handled here as part of a different ticket.
+        Schedulers.boundedElastic().schedule(()->log.error("error occurred with po ingestion",error));
         return Mono.empty();
     }
 }

--- a/stream-compositions/services/product-composition-service/src/main/java/com/backbase/stream/compositions/product/core/mapper/ProductRestMapper.java
+++ b/stream-compositions/services/product-composition-service/src/main/java/com/backbase/stream/compositions/product/core/mapper/ProductRestMapper.java
@@ -36,6 +36,8 @@ public class ProductRestMapper {
                 .membershipAccounts(request.getMembershipAccounts())
                 .additions(request.getAdditions())
                 .referenceJobRoleNames(request.getReferenceJobRoleNames())
+                .paymentOrderChainEnabled(request.getPaymentOrderChainEnabled())
+                .transactionChainEnabled(request.getTransactionChainEnabled())
                 .source(request.getSource())
                 .build();
     }

--- a/stream-payment-order/payment-order-core/src/main/java/com/backbase/stream/paymentorder/PaymentOrderUnitOfWorkExecutor.java
+++ b/stream-payment-order/payment-order-core/src/main/java/com/backbase/stream/paymentorder/PaymentOrderUnitOfWorkExecutor.java
@@ -159,7 +159,7 @@ public class PaymentOrderUnitOfWorkExecutor extends UnitOfWorkExecutor<PaymentOr
 
         List<PaymentOrderIngestRequest> paymentOrderIngestRequests = new ArrayList<>();
         final var userId = paymentOrderIngestContext.internalUserId();
-        if (userId == null || userId.isBlank()) {
+        if (isEmptyUserId(userId)) {
             return Flux.fromIterable(paymentOrderIngestRequests);
         }
         final List<PaymentOrderPostRequest> orders = paymentOrderIngestContext.corePaymentOrder() == null ? new ArrayList<>() : paymentOrderIngestContext.corePaymentOrder();
@@ -249,5 +249,9 @@ public class PaymentOrderUnitOfWorkExecutor extends UnitOfWorkExecutor<PaymentOr
                     final var total = resp.getTotalElements() == null ? new BigDecimal(0).intValue() : resp.getTotalElements().intValue();
                     return new DBSPaymentOrderPageResult(currentCount + results.size(), total, results);
                 });
+    }
+
+    private Boolean isEmptyUserId(String userId) {
+        return userId == null || userId.isBlank();
     }
 }

--- a/stream-payment-order/payment-order-core/src/main/java/com/backbase/stream/paymentorder/PaymentOrderUnitOfWorkExecutor.java
+++ b/stream-payment-order/payment-order-core/src/main/java/com/backbase/stream/paymentorder/PaymentOrderUnitOfWorkExecutor.java
@@ -6,11 +6,19 @@ import static com.backbase.dbs.paymentorder.api.service.v2.model.Status.CANCELLE
 import static com.backbase.dbs.paymentorder.api.service.v2.model.Status.PROCESSED;
 import static com.backbase.dbs.paymentorder.api.service.v2.model.Status.READY;
 import static com.backbase.dbs.paymentorder.api.service.v2.model.Status.REJECTED;
+import static java.time.temporal.ChronoUnit.MILLIS;
+import static java.util.Collections.emptyList;
+import static reactor.core.publisher.Flux.defer;
+import static reactor.core.publisher.Flux.empty;
+import static reactor.util.retry.Retry.fixedDelay;
 
 import com.backbase.dbs.arrangement.api.service.v2.ArrangementsApi;
 import com.backbase.dbs.arrangement.api.service.v2.model.AccountArrangementItem;
 import com.backbase.dbs.arrangement.api.service.v2.model.AccountArrangementItems;
 import com.backbase.dbs.arrangement.api.service.v2.model.AccountArrangementsFilter;
+
+import java.math.BigDecimal;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -38,11 +46,17 @@ import com.backbase.stream.worker.model.UnitOfWork;
 import com.backbase.stream.worker.repository.UnitOfWorkRepository;
 
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.reactive.function.client.WebClientRequestException;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 @Slf4j
 public class PaymentOrderUnitOfWorkExecutor extends UnitOfWorkExecutor<PaymentOrderTask> {
+
+    private static final PaymentOrderPostFilterRequest FILTER = new PaymentOrderPostFilterRequest().statuses(List.of(READY, ACCEPTED, PROCESSED, CANCELLED, REJECTED, CANCELLATION_PENDING));
+
+    private static final int PAGE_SIZE = 1000;
 
     private final PaymentOrdersApi paymentOrdersApi;
     private final ArrangementsApi arrangementsApi;
@@ -81,8 +95,8 @@ public class PaymentOrderUnitOfWorkExecutor extends UnitOfWorkExecutor<PaymentOr
 
     private PaymentOrderIngestContext createPaymentOrderIngestContext(List<PaymentOrderPostRequest> paymentOrderPostRequests) {
         PaymentOrderIngestContext paymentOrderIngestContext = new PaymentOrderIngestContext();
-        paymentOrderIngestContext.corePaymentOrder(paymentOrderPostRequests);
-        paymentOrderIngestContext.internalUserId(paymentOrderPostRequests.get(0).getInternalUserId());
+        paymentOrderIngestContext.corePaymentOrder(paymentOrderPostRequests == null ? emptyList() : paymentOrderPostRequests);
+        paymentOrderIngestContext.internalUserId(paymentOrderPostRequests == null ? null : paymentOrderPostRequests.isEmpty() ? null : paymentOrderPostRequests.get(0).getInternalUserId());
         return paymentOrderIngestContext;
     }
 
@@ -130,23 +144,29 @@ public class PaymentOrderUnitOfWorkExecutor extends UnitOfWorkExecutor<PaymentOr
      */
     private Mono<PaymentOrderPostFilterResponse> getPayments(String internalUserId) {
 
-        var paymentOrderPostFilterRequest = new PaymentOrderPostFilterRequest();
-        paymentOrderPostFilterRequest.setStatuses(
-                List.of(READY, ACCEPTED, PROCESSED, CANCELLED, REJECTED, CANCELLATION_PENDING));
-
-        return paymentOrdersApi.postFilterPaymentOrders(
-                null, null, null, null, null, null, null, null, null, null, null,
-                internalUserId, null, null, null, Integer.MAX_VALUE,
-                null, null, paymentOrderPostFilterRequest);
+        if (internalUserId == null || internalUserId.isBlank()) {
+            return Mono.just(new PaymentOrderPostFilterResponse().paymentOrders(emptyList()).totalElements(new BigDecimal(0)));
+        }
+        return pullFromDBS(internalUserId).map(result -> {
+            final var response = new PaymentOrderPostFilterResponse();
+            response.setPaymentOrders(result);
+            response.setTotalElements(new BigDecimal(result.size()));
+            return response;
+        });
     }
 
     private Flux<PaymentOrderIngestRequest> getPaymentOrderIngestRequest(PaymentOrderIngestContext paymentOrderIngestContext) {
 
         List<PaymentOrderIngestRequest> paymentOrderIngestRequests = new ArrayList<>();
+        final var userId = paymentOrderIngestContext.internalUserId();
+        if (userId == null || userId.isBlank()) {
+            return Flux.fromIterable(paymentOrderIngestRequests);
+        }
+        final List<PaymentOrderPostRequest> orders = paymentOrderIngestContext.corePaymentOrder() == null ? new ArrayList<>() : paymentOrderIngestContext.corePaymentOrder();
 
         // list of all the bank ref ids in core
         List<String> coreBankRefIds = new ArrayList<>();
-        for (PaymentOrderPostRequest coreBankRefId : paymentOrderIngestContext.corePaymentOrder() ) {
+        for (PaymentOrderPostRequest coreBankRefId : orders) {
             coreBankRefIds.add(coreBankRefId.getBankReferenceId());
         }
 
@@ -156,8 +176,10 @@ public class PaymentOrderUnitOfWorkExecutor extends UnitOfWorkExecutor<PaymentOr
             existingBankRefIds.add(existingBankRefId.getBankReferenceId());
         }
 
+        final List<GetPaymentOrderResponse> existing = paymentOrderIngestContext.existingPaymentOrder() == null ? new ArrayList<>() : paymentOrderIngestContext.existingPaymentOrder();
+
         // build new payment list (Bank ref is in core, but not in DBS)
-        paymentOrderIngestContext.corePaymentOrder().forEach(corePaymentOrder -> {
+        orders.forEach(corePaymentOrder -> {
             if(!existingBankRefIds.contains(corePaymentOrder.getBankReferenceId())) {
                 AccountArrangementItem accountArrangementItem = getInternalArrangementId(paymentOrderIngestContext.arrangementIds(),
                         corePaymentOrder.getOriginatorAccount().getExternalArrangementId());
@@ -169,7 +191,7 @@ public class PaymentOrderUnitOfWorkExecutor extends UnitOfWorkExecutor<PaymentOr
         });
 
         // build update payment list (Bank ref is in core and DBS)
-        paymentOrderIngestContext.corePaymentOrder().forEach(corePaymentOrder -> {
+        orders.forEach(corePaymentOrder -> {
             if(existingBankRefIds.contains(corePaymentOrder.getBankReferenceId())) {
                 UpdatePaymentOrderIngestRequest updatePaymentOrderIngestRequest = new UpdatePaymentOrderIngestRequest(paymentOrderTypeMapper.mapPaymentOrderPostRequest(corePaymentOrder));
                 paymentOrderIngestRequests.add(updatePaymentOrderIngestRequest);
@@ -178,7 +200,7 @@ public class PaymentOrderUnitOfWorkExecutor extends UnitOfWorkExecutor<PaymentOr
 
         // build delete payment list (Bank ref is in DBS, but not in core)
         if (((PaymentOrderWorkerConfigurationProperties) streamWorkerConfiguration).isDeletePaymentOrder()) {
-            paymentOrderIngestContext.existingPaymentOrder().forEach(existingPaymentOrder -> {
+            existing.forEach(existingPaymentOrder -> {
                 if(!coreBankRefIds.contains(existingPaymentOrder.getBankReferenceId())) {
                     paymentOrderIngestRequests.add(new DeletePaymentOrderIngestRequest(existingPaymentOrder.getId(), existingPaymentOrder.getBankReferenceId()));
                 }
@@ -195,5 +217,37 @@ public class PaymentOrderUnitOfWorkExecutor extends UnitOfWorkExecutor<PaymentOr
                 .filter(b -> b.getExternalArrangementId().equalsIgnoreCase(externalArrangementId))
                 .findFirst()
                 .orElse(null);
+    }
+
+    private record DBSPaymentOrderPageResult(int next, int total, List<GetPaymentOrderResponse> requests) {
+
+    }
+
+    private Mono<List<GetPaymentOrderResponse>> pullFromDBS(final @NotNull String userid) {
+        return defer(() -> retrieveNextPage(0, userid)
+                .expand(page -> {
+                    // If there are no more pages, return an empty flux.
+                    if (page.next >= page.total || page.requests.isEmpty()) {
+                        return empty();
+                    } else {
+                        return retrieveNextPage(page.next, userid);
+                    }
+                }))
+                .collectList()
+                .map(pages -> pages.stream().flatMap(page -> page.requests.stream()).toList());
+    }
+
+    private Mono<DBSPaymentOrderPageResult> retrieveNextPage(int currentCount, final @NotNull String userId) {
+        return paymentOrdersApi.postFilterPaymentOrders(null, null, null, null, null, null, null, null,
+                        null, null, null, userId, null, null, currentCount / PAGE_SIZE, PAGE_SIZE, null,
+                        null, FILTER)
+                .retryWhen(fixedDelay(3, Duration.of(2000, MILLIS)).filter(
+                        t -> t instanceof WebClientRequestException
+                                || t instanceof WebClientResponseException.ServiceUnavailable))
+                .map(resp -> {
+                    final List<GetPaymentOrderResponse> results = resp.getPaymentOrders() == null ? emptyList() : resp.getPaymentOrders();
+                    final var total = resp.getTotalElements() == null ? new BigDecimal(0).intValue() : resp.getTotalElements().intValue();
+                    return new DBSPaymentOrderPageResult(currentCount + results.size(), total, results);
+                });
     }
 }

--- a/stream-payment-order/payment-order-core/src/main/java/com/backbase/stream/paymentorder/PaymentOrderUnitOfWorkExecutor.java
+++ b/stream-payment-order/payment-order-core/src/main/java/com/backbase/stream/paymentorder/PaymentOrderUnitOfWorkExecutor.java
@@ -255,11 +255,15 @@ public class PaymentOrderUnitOfWorkExecutor extends UnitOfWorkExecutor<PaymentOr
                 });
     }
 
-    private Boolean isEmptyUserId(String userId) {
+    private boolean isEmptyUserId(String userId) {
         return userId == null || userId.isBlank();
     }
 
     private String getInternalUserId(List<PaymentOrderPostRequest> paymentOrderPostRequests) {
-        return paymentOrderPostRequests == null ? null : paymentOrderPostRequests.isEmpty() ? null : paymentOrderPostRequests.get(0).getInternalUserId();
+        if (paymentOrderPostRequests == null || paymentOrderPostRequests.isEmpty()) {
+            return null;
+        } else {
+            return paymentOrderPostRequests.get(0).getInternalUserId();
+        }
     }
 }

--- a/stream-payment-order/payment-order-core/src/test/java/com/backbase/stream/common/PaymentOrderBaseTest.java
+++ b/stream-payment-order/payment-order-core/src/test/java/com/backbase/stream/common/PaymentOrderBaseTest.java
@@ -14,9 +14,7 @@ public abstract class PaymentOrderBaseTest {
     protected final PaymentOrderTypeMapper paymentOrderTypeMapper = Mappers.getMapper(PaymentOrderTypeMapper.class);
 
     protected final List<GetPaymentOrderResponse> getPaymentOrderResponse = buildGetPaymentOrderResponse();
-    protected final List<GetPaymentOrderResponse> getPaymentOrderResponseWithEmptyUserId = buildGetPaymentOrderResponseWithEmptyUserId();
     protected final List<PaymentOrderPostRequest> paymentOrderPostRequest = paymentOrderTypeMapper.mapPaymentOrderPostRequest(getPaymentOrderResponse);
-    protected final List<PaymentOrderPostRequest> paymentOrderPostRequestWithEmptyUserId = paymentOrderTypeMapper.mapPaymentOrderPostRequest(getPaymentOrderResponseWithEmptyUserId);
 
     protected PaymentOrderPutRequest buildPaymentOrderPutRequest(PaymentOrderPostRequest source) {
         return paymentOrderTypeMapper.mapPaymentOrderPostRequest(source);
@@ -47,64 +45,6 @@ public abstract class PaymentOrderBaseTest {
                     .bankReferenceId("bankReferenceId_" + idx)
                     .bankReferenceId("bankReferenceId_" + idx)
                     .internalUserId("internalUserId" + idx)
-                    .paymentSetupId("paymentSetupId_" + idx)
-                    .approvalId("approvalId_" + idx)
-                    .bankStatus("bankStatus_" + idx)
-                    .reasonCode("reasonCode_" + idx)
-                    .reasonText("reasonText_" + idx)
-                    .errorDescription("errorDescription_" + idx)
-                    .originator(involvedParty)
-                    .originatorAccount(originatorAccount)
-                    .totalAmount(new Currency().amount(String.valueOf(idx)))
-                    .batchBooking(true)
-                    .instructionPriority(InstructionPriority.NORM)
-                    .status(Status.ACCEPTED)
-                    .requestedExecutionDate(LocalDate.of(2023, 3, idx))
-                    .paymentMode(PaymentMode.SINGLE)
-                    .paymentType("paymentType_" + idx)
-                    .entryClass("entryClass_" + idx)
-                    .schedule(schedule)
-                    .transferTransactionInformation(new SimpleTransaction().transferFee(new Currency().amount(String.valueOf(idx))))
-                    .createdBy("createdBy_" + idx)
-                    .createdAt("createdAt_" + idx)
-                    .updatedBy("updatedBy_" + idx)
-                    .updatedAt("updatedAt_" + idx)
-                    .intraLegalEntity(true)
-                    .serviceAgreementId("serviceAgreementId_" + idx)
-                    .originatorAccountCurrency("originatorAccountCurrency_" + idx)
-                    .confirmationId("confirmationId_" + idx)
-                    .putAdditionsItem("key_" + idx, "value_" + idx);
-
-            getPaymentOrderResponseList.add(getPaymentOrderResponse);
-        }
-        return getPaymentOrderResponseList;
-    }
-
-    List<GetPaymentOrderResponse> buildGetPaymentOrderResponseWithEmptyUserId() {
-        List<GetPaymentOrderResponse> getPaymentOrderResponseList = new ArrayList<>();
-        for(int idx=1; idx<=2; idx++) {
-            SimpleInvolvedParty involvedParty = new SimpleInvolvedParty()
-                    .name("name_" + idx)
-                    .recipientId("recipientId_" + idx)
-                    .role(InvolvedPartyRole.CREDITOR);
-
-            SimpleOriginatorAccount originatorAccount = new SimpleOriginatorAccount()
-                    .arrangementId("arrangementId_" + idx)
-                    .externalArrangementId("externalArrangementId_" + idx)
-                    .identification(new Identification().identification("identification_" + idx));
-
-            SimpleSchedule schedule = new SimpleSchedule()
-                    .on(idx)
-                    .startDate(LocalDate.of(2023, 3, idx))
-                    .endDate(LocalDate.of(2023, 3, idx))
-                    .nextExecutionDate(LocalDate.of(2023, 3, idx))
-                    .transferFrequency(SimpleSchedule.TransferFrequencyEnum.ONCE);
-
-            GetPaymentOrderResponse getPaymentOrderResponse = new GetPaymentOrderResponse()
-                    .id("id_" + idx)
-                    .bankReferenceId("bankReferenceId_" + idx)
-                    .bankReferenceId("bankReferenceId_" + idx)
-                    .internalUserId(null)
                     .paymentSetupId("paymentSetupId_" + idx)
                     .approvalId("approvalId_" + idx)
                     .bankStatus("bankStatus_" + idx)

--- a/stream-payment-order/payment-order-core/src/test/java/com/backbase/stream/common/PaymentOrderBaseTest.java
+++ b/stream-payment-order/payment-order-core/src/test/java/com/backbase/stream/common/PaymentOrderBaseTest.java
@@ -14,7 +14,9 @@ public abstract class PaymentOrderBaseTest {
     protected final PaymentOrderTypeMapper paymentOrderTypeMapper = Mappers.getMapper(PaymentOrderTypeMapper.class);
 
     protected final List<GetPaymentOrderResponse> getPaymentOrderResponse = buildGetPaymentOrderResponse();
+    protected final List<GetPaymentOrderResponse> getPaymentOrderResponseWithEmptyUserId = buildGetPaymentOrderResponseWithEmptyUserId();
     protected final List<PaymentOrderPostRequest> paymentOrderPostRequest = paymentOrderTypeMapper.mapPaymentOrderPostRequest(getPaymentOrderResponse);
+    protected final List<PaymentOrderPostRequest> paymentOrderPostRequestWithEmptyUserId = paymentOrderTypeMapper.mapPaymentOrderPostRequest(getPaymentOrderResponseWithEmptyUserId);
 
     protected PaymentOrderPutRequest buildPaymentOrderPutRequest(PaymentOrderPostRequest source) {
         return paymentOrderTypeMapper.mapPaymentOrderPostRequest(source);
@@ -45,6 +47,64 @@ public abstract class PaymentOrderBaseTest {
                     .bankReferenceId("bankReferenceId_" + idx)
                     .bankReferenceId("bankReferenceId_" + idx)
                     .internalUserId("internalUserId" + idx)
+                    .paymentSetupId("paymentSetupId_" + idx)
+                    .approvalId("approvalId_" + idx)
+                    .bankStatus("bankStatus_" + idx)
+                    .reasonCode("reasonCode_" + idx)
+                    .reasonText("reasonText_" + idx)
+                    .errorDescription("errorDescription_" + idx)
+                    .originator(involvedParty)
+                    .originatorAccount(originatorAccount)
+                    .totalAmount(new Currency().amount(String.valueOf(idx)))
+                    .batchBooking(true)
+                    .instructionPriority(InstructionPriority.NORM)
+                    .status(Status.ACCEPTED)
+                    .requestedExecutionDate(LocalDate.of(2023, 3, idx))
+                    .paymentMode(PaymentMode.SINGLE)
+                    .paymentType("paymentType_" + idx)
+                    .entryClass("entryClass_" + idx)
+                    .schedule(schedule)
+                    .transferTransactionInformation(new SimpleTransaction().transferFee(new Currency().amount(String.valueOf(idx))))
+                    .createdBy("createdBy_" + idx)
+                    .createdAt("createdAt_" + idx)
+                    .updatedBy("updatedBy_" + idx)
+                    .updatedAt("updatedAt_" + idx)
+                    .intraLegalEntity(true)
+                    .serviceAgreementId("serviceAgreementId_" + idx)
+                    .originatorAccountCurrency("originatorAccountCurrency_" + idx)
+                    .confirmationId("confirmationId_" + idx)
+                    .putAdditionsItem("key_" + idx, "value_" + idx);
+
+            getPaymentOrderResponseList.add(getPaymentOrderResponse);
+        }
+        return getPaymentOrderResponseList;
+    }
+
+    List<GetPaymentOrderResponse> buildGetPaymentOrderResponseWithEmptyUserId() {
+        List<GetPaymentOrderResponse> getPaymentOrderResponseList = new ArrayList<>();
+        for(int idx=1; idx<=2; idx++) {
+            SimpleInvolvedParty involvedParty = new SimpleInvolvedParty()
+                    .name("name_" + idx)
+                    .recipientId("recipientId_" + idx)
+                    .role(InvolvedPartyRole.CREDITOR);
+
+            SimpleOriginatorAccount originatorAccount = new SimpleOriginatorAccount()
+                    .arrangementId("arrangementId_" + idx)
+                    .externalArrangementId("externalArrangementId_" + idx)
+                    .identification(new Identification().identification("identification_" + idx));
+
+            SimpleSchedule schedule = new SimpleSchedule()
+                    .on(idx)
+                    .startDate(LocalDate.of(2023, 3, idx))
+                    .endDate(LocalDate.of(2023, 3, idx))
+                    .nextExecutionDate(LocalDate.of(2023, 3, idx))
+                    .transferFrequency(SimpleSchedule.TransferFrequencyEnum.ONCE);
+
+            GetPaymentOrderResponse getPaymentOrderResponse = new GetPaymentOrderResponse()
+                    .id("id_" + idx)
+                    .bankReferenceId("bankReferenceId_" + idx)
+                    .bankReferenceId("bankReferenceId_" + idx)
+                    .internalUserId(null)
                     .paymentSetupId("paymentSetupId_" + idx)
                     .approvalId("approvalId_" + idx)
                     .bankStatus("bankStatus_" + idx)

--- a/stream-payment-order/payment-order-core/src/test/java/com/backbase/stream/task/PaymentOrderUnitOfWorkExecutorTest.java
+++ b/stream-payment-order/payment-order-core/src/test/java/com/backbase/stream/task/PaymentOrderUnitOfWorkExecutorTest.java
@@ -4,6 +4,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.lenient;
 
 import com.backbase.dbs.arrangement.api.service.v2.ArrangementsApi;
 import com.backbase.dbs.arrangement.api.service.v2.model.AccountArrangementItem;
@@ -74,7 +75,7 @@ public class PaymentOrderUnitOfWorkExecutorTest extends PaymentOrderBaseTest {
                 .id("po_post_resp_id")
                 .putAdditionsItem("key", "val");
 
-        Mockito.lenient().when(paymentOrdersApi.postPaymentOrder(Mockito.any()))
+        lenient().when(paymentOrdersApi.postPaymentOrder(Mockito.any()))
                 .thenReturn(Mono.just(paymentOrderPostResponse));
 
         AccountArrangementItem accountArrangementItem = new AccountArrangementItem()
@@ -84,7 +85,7 @@ public class PaymentOrderUnitOfWorkExecutorTest extends PaymentOrderBaseTest {
         AccountArrangementItems accountArrangementItems = new AccountArrangementItems()
                 .addArrangementElementsItem(accountArrangementItem);
 
-        Mockito.lenient().when(arrangementsApi.postFilter(Mockito.any()))
+        lenient().when(arrangementsApi.postFilter(Mockito.any()))
                 .thenReturn(Mono.just(accountArrangementItems));
 
         StepVerifier.create(paymentOrderUnitOfWorkExecutor.prepareUnitOfWork(paymentOrderIngestRequestList))
@@ -105,7 +106,7 @@ public class PaymentOrderUnitOfWorkExecutorTest extends PaymentOrderBaseTest {
                 .id("po_post_resp_id")
                 .putAdditionsItem("key", "val");
 
-        Mockito.lenient().when(paymentOrdersApi.postPaymentOrder(any()))
+        lenient().when(paymentOrdersApi.postPaymentOrder(any()))
                 .thenReturn(Mono.just(paymentOrderPostResponse));
 
         GetPaymentOrderResponse getPaymentOrderResponse = new GetPaymentOrderResponse()
@@ -133,6 +134,39 @@ public class PaymentOrderUnitOfWorkExecutorTest extends PaymentOrderBaseTest {
                 Assertions.assertEquals(paymentOrderPostRequest.size(), unitOfWork.getStreamTasks().get(0).getData().size());
             })
             .verifyComplete();
+    }
+
+    @Test
+    void test_prepareunitofwork_blankuserid() {
+
+        paymentOrderUnitOfWorkExecutor = new PaymentOrderUnitOfWorkExecutor(
+                repository, streamTaskExecutor, streamWorkerConfiguration,
+                paymentOrdersApi, arrangementsApi, null);
+
+        Flux<PaymentOrderPostRequest> paymentOrderPostRequestFlux = Flux.fromIterable(paymentOrderPostRequestWithEmptyUserId);
+
+        AccountArrangementItem accountArrangementItem = new AccountArrangementItem()
+                .id("arrangementId_1")
+                .externalArrangementId("externalArrangementId_1");
+        AccountArrangementItems accountArrangementItems = new AccountArrangementItems()
+                .addArrangementElementsItem(accountArrangementItem);
+
+        lenient().when(arrangementsApi.postFilter(Mockito.any()))
+                .thenReturn(Mono.just(accountArrangementItems));
+
+        GetPaymentOrderResponse getPaymentOrderResponseWithEmptyUserId = new GetPaymentOrderResponse()
+                .id("arrangementId_1");
+
+        PaymentOrderPostFilterResponse paymentOrderPostFilterResponse = new PaymentOrderPostFilterResponse()
+                .addPaymentOrdersItem(getPaymentOrderResponseWithEmptyUserId)
+                .totalElements(new BigDecimal(1));
+
+        lenient().doReturn(Mono.just(paymentOrderPostFilterResponse)).when(paymentOrdersApi).postFilterPaymentOrders(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any());
+
+        StepVerifier
+                .create(paymentOrderUnitOfWorkExecutor.prepareUnitOfWork(paymentOrderPostRequestFlux))
+                .expectNextCount(0)
+                .verifyComplete();
     }
 
 }

--- a/stream-payment-order/payment-order-core/src/test/java/com/backbase/stream/task/PaymentOrderUnitOfWorkExecutorTest.java
+++ b/stream-payment-order/payment-order-core/src/test/java/com/backbase/stream/task/PaymentOrderUnitOfWorkExecutorTest.java
@@ -24,6 +24,8 @@ import com.backbase.stream.paymentorder.PaymentOrderUnitOfWorkExecutor;
 import com.backbase.stream.worker.model.UnitOfWork;
 import com.backbase.stream.worker.repository.UnitOfWorkRepository;
 import java.math.BigDecimal;
+
+import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -144,7 +146,10 @@ public class PaymentOrderUnitOfWorkExecutorTest extends PaymentOrderBaseTest {
                 repository, streamTaskExecutor, streamWorkerConfiguration,
                 paymentOrdersApi, arrangementsApi, null);
 
-        Flux<PaymentOrderPostRequest> paymentOrderPostRequestFlux = Flux.fromIterable(paymentOrderPostRequestWithEmptyUserId);
+        paymentOrderPostRequest.get(0).setInternalUserId(StringUtils.EMPTY);
+        paymentOrderPostRequest.get(1).setInternalUserId(null);
+
+        Flux<PaymentOrderPostRequest> paymentOrderPostRequestFlux = Flux.fromIterable(paymentOrderPostRequest);
 
         AccountArrangementItem accountArrangementItem = new AccountArrangementItem()
                 .id("arrangementId_1")

--- a/stream-payment-order/payment-order-core/src/test/java/com/backbase/stream/task/PaymentOrderUnitOfWorkExecutorTest.java
+++ b/stream-payment-order/payment-order-core/src/test/java/com/backbase/stream/task/PaymentOrderUnitOfWorkExecutorTest.java
@@ -110,7 +110,8 @@ public class PaymentOrderUnitOfWorkExecutorTest extends PaymentOrderBaseTest {
                 .thenReturn(Mono.just(paymentOrderPostResponse));
 
         GetPaymentOrderResponse getPaymentOrderResponse = new GetPaymentOrderResponse()
-                .id("arrangementId_1");
+                .id("arrangementId_1")
+                .bankReferenceId("bankReferenceId_1");
         PaymentOrderPostFilterResponse paymentOrderPostFilterResponse = new PaymentOrderPostFilterResponse()
                 .addPaymentOrdersItem(getPaymentOrderResponse)
                 .totalElements(new BigDecimal(1));


### PR DESCRIPTION
## Description

1. Fixed issue with payment order ingestion error, where it was not paging if the user had lots of objects in the same request.
2. Added changes to show error in case of error while payment order ingestion.
3. Fixed issue in down stream request where chaining was not being propogated in product-composition-service.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
  
  Add N/A to the task if they are not relevant to the current PR(validation will be skipped). 
  e.g. [ ] My changes are adequately tested ~ N/A
-->

 - [x] I made sure, I read [CONTRIBUTING.md](CONTRIBUTING.md) to put right branch prefix as per my need.
 - [x] I made sure to update [CHANGELOG.md](CHANGELOG.md).
 - [x] I made sure to update [Stream Wiki](https://github.com/Backbase/stream-services/wiki)(only valid in case of new stream module or architecture changes).
 - [x] My changes are adequately tested.
 - [x] I made sure all the SonarCloud Quality Gate are passed.
