### PR TITLE
BatchProductIngestionSaga: updated the user comparison to ignore the …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [3.72.4](https://github.com/Backbase/stream-services/compare/3.72.1...3.72.3)
+### Added
+- Update BatchProductIngestion saga to ignore the user external ID case when getting products for specified user.
+
 ## [3.72.3](https://github.com/Backbase/stream-services/compare/3.72.1...3.72.3)
 ### Added
 - Update payments to be in line with latest Banking Services

--- a/stream-product/product-ingestion-saga/src/main/java/com/backbase/stream/product/BatchProductIngestionSaga.java
+++ b/stream-product/product-ingestion-saga/src/main/java/com/backbase/stream/product/BatchProductIngestionSaga.java
@@ -370,7 +370,7 @@ public class BatchProductIngestionSaga extends ProductIngestionSaga {
                 .filter(group ->
                         group.getUsers().stream()
                                 // get only products for specified user.
-                                .filter(u -> u.getUser().getExternalId().equals(user.getExternalId()))
+                                .filter(u -> u.getUser().getExternalId().equalsIgnoreCase(user.getExternalId()))
                                 .map(JobProfileUser::getBusinessFunctionGroups)
                                 .flatMap(Collection::stream)
                                 .anyMatch(bfg -> bfg.getName().equals(functionGroup.getName()))


### PR DESCRIPTION
…case on the `externalUserId`

## Description

When getting a user's specific products, the user external ID case should not matter.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
  
  Add N/A to the task if they are not relevant to the current PR(validation will be skipped). 
  e.g. [ ] My changes are adequately tested ~ N/A
-->

 - [x] I made sure, I read [CONTRIBUTING.md](CONTRIBUTING.md) to put right branch prefix as per my need.
 - [x] I made sure to update [CHANGELOG.md](CHANGELOG.md).
 - [x] I made sure to update [Stream Wiki](https://github.com/Backbase/stream-services/wiki)(only valid in case of new stream module or architecture changes).
 - [x] My changes are adequately tested.
 - [x] I made sure all the SonarCloud Quality Gate are passed.
