### PR TITLE
MAINT-29996 - fix reference job roles creation only for master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [5.4.0](https://github.com/Backbase/stream-services/compare/5.3.0...5.4.0)
+### Changed
+- Fix the logic for creating Template type job roles only for MSA
+
 ## [5.3.0](https://github.com/Backbase/stream-services/compare/5.2.0...5.3.0)
 ### Added
 - Add CUSTOMERS product group type to OpenAPI contract

--- a/stream-access-control/access-control-core/src/main/java/com/backbase/stream/service/AccessGroupService.java
+++ b/stream-access-control/access-control-core/src/main/java/com/backbase/stream/service/AccessGroupService.java
@@ -1225,7 +1225,9 @@ public class AccessGroupService {
         presentationIngestFunctionGroup.setExternalServiceAgreementId(serviceAgreement.getExternalId());
         presentationIngestFunctionGroup.setMetadata(jobRole.getMetadata());
 
-        if(jobRole instanceof JobRole) {
+        //since ReferenceJobRole class was removed, now all job roles have the same class, and
+        //reference job role can be created only for MSA, for CSA it failed
+        if(serviceAgreement.getIsMaster()) {
             log.debug("Creating a Reference Job Role.");
             presentationIngestFunctionGroup.setType(PresentationIngestFunctionGroup.TypeEnum.TEMPLATE);
         }

--- a/stream-access-control/access-control-core/src/main/java/com/backbase/stream/service/AccessGroupService.java
+++ b/stream-access-control/access-control-core/src/main/java/com/backbase/stream/service/AccessGroupService.java
@@ -91,6 +91,7 @@ import java.util.stream.Stream;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.BooleanUtils;
 import org.mapstruct.factory.Mappers;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.StringUtils;
@@ -1227,7 +1228,7 @@ public class AccessGroupService {
 
         //since ReferenceJobRole class was removed, now all job roles have the same class, and
         //reference job role can be created only for MSA, for CSA it failed
-        if(serviceAgreement.getIsMaster()) {
+        if(BooleanUtils.isTrue(serviceAgreement.getIsMaster())) {
             log.debug("Creating a Reference Job Role.");
             presentationIngestFunctionGroup.setType(PresentationIngestFunctionGroup.TypeEnum.TEMPLATE);
         }

--- a/stream-access-control/access-control-core/src/test/java/com/backbase/stream/service/AccessGroupServiceUpdateFunctionGroupsTest.java
+++ b/stream-access-control/access-control-core/src/test/java/com/backbase/stream/service/AccessGroupServiceUpdateFunctionGroupsTest.java
@@ -96,6 +96,8 @@ class AccessGroupServiceUpdateFunctionGroupsTest {
             .addParticipantsItem(new LegalEntityParticipant().externalId("p3").sharingAccounts(false)
                 .sharingUsers(false).action(LegalEntityParticipant.ActionEnum.ADD));
 
+        serviceAgreement.setIsMaster(true);
+
         Mockito.when(functionGroupsApi.getFunctionGroups(saInternalId))
             .thenReturn(Flux.fromIterable(Collections.singletonList(new FunctionGroupItem()
                 .name("jobRoleOld").id("2")


### PR DESCRIPTION
## Description

Fix the issue with creating job roles in CSA as template by default

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
  
  Add N/A to the task if they are not relevant to the current PR(validation will be skipped). 
  e.g. [ ] My changes are adequately tested ~ N/A
-->

 - [x] I made sure, I read [CONTRIBUTING.md](CONTRIBUTING.md) to put right branch prefix as per my need.
 - [x] I made sure to update [CHANGELOG.md](CHANGELOG.md).
 - [x] I made sure to update [Stream Wiki](https://github.com/Backbase/stream-services/wiki)(only valid in case of new stream module or architecture changes).
 - [x] My changes are adequately tested.
 - [x] I made sure all the SonarCloud Quality Gate are passed.
