### PR TITLE
Hotfix/pmt mapping w arr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [3.65.0](https://github.com/Backbase/stream-services/compare/3.65.0...3.65.1)
+### Changed
+- Query for existing payments by using arrangement IDs instead of user IDs. This will eliminate duplicate payments from being ingested when joint owners are added.
+
 ## [3.65.0](https://github.com/Backbase/stream-services/compare/3.64.0...3.65.0)
 ### Changed
 - Move call to processAudiencesSegmentation after setupUsers 

--- a/stream-compositions/services/payment-order-composition-service/src/main/java/com/backbase/stream/compositions/paymentorders/core/mapper/PaymentOrderMapper.java
+++ b/stream-compositions/services/payment-order-composition-service/src/main/java/com/backbase/stream/compositions/paymentorders/core/mapper/PaymentOrderMapper.java
@@ -10,7 +10,6 @@ import org.springframework.stereotype.Component;
 
 import com.backbase.dbs.paymentorder.api.service.v2.model.PaymentOrderPostRequest;
 import com.backbase.dbs.paymentorder.api.service.v2.model.PaymentOrderPostResponse;
-import com.backbase.dbs.paymentorder.api.service.v2.model.UpdateStatusPut;
 import com.backbase.stream.compositions.paymentorder.api.model.PaymentOrderIngestionResponse;
 import com.backbase.stream.compositions.paymentorder.api.model.PaymentOrderPullIngestionRequest;
 import com.backbase.stream.compositions.paymentorder.api.model.PaymentOrderPushIngestionRequest;

--- a/stream-compositions/services/payment-order-composition-service/src/main/resources/application-local.yml
+++ b/stream-compositions/services/payment-order-composition-service/src/main/resources/application-local.yml
@@ -53,4 +53,4 @@ eureka:
 
 logging:
   level:
-    com.backbase.stream: DEBUG
+    com.backbase.stream.compositions: DEBUG

--- a/stream-compositions/services/payment-order-composition-service/src/main/resources/application-local.yml
+++ b/stream-compositions/services/payment-order-composition-service/src/main/resources/application-local.yml
@@ -40,7 +40,8 @@ backbase:
     enabled: true
   stream:
     paymentorder:
-      types: "INT_TRANS_CLOSED"
+      types:
+        - INT_TRANS_CLOSED
       worker:
         deletePaymentOrder: false
 
@@ -54,3 +55,4 @@ eureka:
 logging:
   level:
     com.backbase.stream.compositions: DEBUG
+

--- a/stream-compositions/services/payment-order-composition-service/src/main/resources/application-local.yml
+++ b/stream-compositions/services/payment-order-composition-service/src/main/resources/application-local.yml
@@ -2,14 +2,13 @@ server:
   port: 9005
 
 spring:
+  cloud:
+    loadbalancer:
+      enabled: false
   activemq:
     broker-url: tcp://localhost:61616
   zipkin:
     enabled: false
-  main:
-    allow-bean-definition-overriding: true
-  codec:
-    max-in-memory-size: 10MB
 sso.jwt.internal.signature.key:
   type: VALUE
   value: JWTSecretKeyDontUseInProduction!
@@ -25,7 +24,7 @@ backbase:
           direct-uri: http://localhost:8050
       payment:
         order:
-          direct-uri: http://localhost:8051
+          direct-uri: http://localhost:8090
       transaction:
         manager:
           direct-uri: http://localhost:8083
@@ -41,19 +40,17 @@ backbase:
     enabled: true
   stream:
     paymentorder:
+      types: "INT_TRANS_CLOSED"
       worker:
         deletePaymentOrder: false
 
 eureka:
   instance:
-    metadata-map:
-      public: true
-      role: live
+    hostname: host.docker.internal
   client:
     serviceUrl:
       defaultZone: http://localhost:8761/eureka/
 
 logging:
   level:
-    com.backbase.stream.compositions: DEBUG
-
+    com.backbase.stream: DEBUG

--- a/stream-compositions/services/payment-order-composition-service/src/main/resources/application.yml
+++ b/stream-compositions/services/payment-order-composition-service/src/main/resources/application.yml
@@ -32,5 +32,7 @@ backbase:
         required-scope: api:service
   stream:
     paymentorder:
+      types:
+        - INT_TRANS_CLOSED
       worker:
         deletePaymentOrder: false

--- a/stream-compositions/services/payment-order-composition-service/src/test/java/com/backbase/stream/compositions/paymentorders/http/PaymentOrderControllerIT.java
+++ b/stream-compositions/services/payment-order-composition-service/src/test/java/com/backbase/stream/compositions/paymentorders/http/PaymentOrderControllerIT.java
@@ -46,7 +46,9 @@ import static org.mockserver.model.HttpRequest.request;
 import static org.mockserver.model.HttpResponse.response;
 
 @DirtiesContext
-@SpringBootTest
+@SpringBootTest(properties = {
+        "backbase.stream.paymentorder.types=type1,type2,type3"
+})
 @AutoConfigureWebTestClient
 @ExtendWith({SpringExtension.class})
 @Slf4j

--- a/stream-compositions/services/payment-order-composition-service/src/test/resources/application.yml
+++ b/stream-compositions/services/payment-order-composition-service/src/test/resources/application.yml
@@ -42,6 +42,8 @@ backbase:
           direct-uri: http://localhost:8083/transaction-manager
       stream:
         payment-order:
+          types:
+            - INT_TRANS_CLOSED
           integration:
             direct-uri: http://localhost:18000
     http:

--- a/stream-payment-order/payment-order-core/src/main/java/com/backbase/stream/config/PaymentOrderServiceConfiguration.java
+++ b/stream-payment-order/payment-order-core/src/main/java/com/backbase/stream/config/PaymentOrderServiceConfiguration.java
@@ -17,13 +17,15 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @EnableConfigurationProperties({
-    PaymentOrderWorkerConfigurationProperties.class
+    PaymentOrderWorkerConfigurationProperties.class,
+    PaymentOrderTypeConfiguration.class
 })
 @AllArgsConstructor
 @Configuration
 public class PaymentOrderServiceConfiguration {
 
     private final PaymentOrderTypeMapper paymentOrderTypeMapper;
+    private final PaymentOrderTypeConfiguration paymentOrderTypeConfiguration;
 
     @Bean
     public PaymentOrderTaskExecutor paymentOrderTaskExecutor(PaymentOrdersApi paymentOrdersApi) {
@@ -39,7 +41,8 @@ public class PaymentOrderServiceConfiguration {
             ArrangementsApi arrangementsApi) {
 
         return new PaymentOrderUnitOfWorkExecutor(paymentOrderUnitOfWorkRepository, paymentOrderTaskExecutor,
-                paymentOrderWorkerConfigurationProperties, paymentOrdersApi, arrangementsApi, paymentOrderTypeMapper);
+                paymentOrderWorkerConfigurationProperties, paymentOrdersApi, arrangementsApi, paymentOrderTypeMapper,
+                paymentOrderTypeConfiguration);
     }
 
     @Bean

--- a/stream-payment-order/payment-order-core/src/main/java/com/backbase/stream/config/PaymentOrderTypeConfiguration.java
+++ b/stream-payment-order/payment-order-core/src/main/java/com/backbase/stream/config/PaymentOrderTypeConfiguration.java
@@ -1,14 +1,18 @@
 package com.backbase.stream.config;
 
 import java.util.List;
+import javax.validation.constraints.NotNull;
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
 
 @ConfigurationProperties(prefix = "backbase.stream.paymentorder")
+@Validated
 @Slf4j
 @Data
 public class PaymentOrderTypeConfiguration {
 
+    @NotNull
     private List<String> types;
 }

--- a/stream-payment-order/payment-order-core/src/main/java/com/backbase/stream/config/PaymentOrderTypeConfiguration.java
+++ b/stream-payment-order/payment-order-core/src/main/java/com/backbase/stream/config/PaymentOrderTypeConfiguration.java
@@ -1,0 +1,14 @@
+package com.backbase.stream.config;
+
+import java.util.List;
+import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "backbase.stream.paymentorder")
+@Slf4j
+@Data
+public class PaymentOrderTypeConfiguration {
+
+    private List<String> types;
+}

--- a/stream-payment-order/payment-order-core/src/main/java/com/backbase/stream/mappers/PaymentOrderTypeMapper.java
+++ b/stream-payment-order/payment-order-core/src/main/java/com/backbase/stream/mappers/PaymentOrderTypeMapper.java
@@ -12,6 +12,7 @@ import java.util.List;
 public interface PaymentOrderTypeMapper {
 
     @Mapping(source = "schedule.nextExecutionDate", target = "nextExecutionDate")
+    @Mapping(source = "schedule.remainingOccurrences", target = "remainingOccurrences")
     PaymentOrderPutRequest mapPaymentOrderPostRequest(PaymentOrderPostRequest paymentOrderPostRequest);
 
     List<PaymentOrderPostRequest> mapPaymentOrderPostRequest(List<GetPaymentOrderResponse> paymentOrderPostRequest);

--- a/stream-payment-order/payment-order-core/src/main/java/com/backbase/stream/paymentorder/PaymentOrderUnitOfWorkExecutor.java
+++ b/stream-payment-order/payment-order-core/src/main/java/com/backbase/stream/paymentorder/PaymentOrderUnitOfWorkExecutor.java
@@ -144,16 +144,18 @@ public class PaymentOrderUnitOfWorkExecutor extends UnitOfWorkExecutor<PaymentOr
 
         List<String> paymentTypes = paymentOrderTypeConfiguration.getTypes();
         var paymentOrderPostFilterRequest = new PaymentOrderPostFilterRequest();
-        List<AccessFilter> accessFilters = new ArrayList<>();
-        for (String paymentType : paymentTypes) {
-            AccessFilter accessFilter = new AccessFilter();
-            accessFilter.setPaymentType(paymentType);
-            accessFilter.setArrangementIds(allArrangementIds);
-            accessFilters.add(accessFilter);
-        }
+
+        List<AccessFilter> accessFilters = paymentTypes.stream()
+                .map(paymentType -> new AccessFilter()
+                        .paymentType(paymentType)
+                        .arrangementIds(allArrangementIds))
+                .collect(Collectors.toList());
+
         paymentOrderPostFilterRequest.setAccessFilters(accessFilters);
         paymentOrderPostFilterRequest.setStatuses(
                 List.of(READY, ACCEPTED, PROCESSED, CANCELLED, REJECTED, CANCELLATION_PENDING));
+        
+        log.debug("request POJO: {}", paymentOrderPostFilterRequest);
 
         return paymentOrdersApi.postFilterPaymentOrders(
                 null, null, null, null, null, null, null, null, null, null, null,

--- a/stream-payment-order/payment-order-core/src/main/java/com/backbase/stream/paymentorder/PaymentOrderUnitOfWorkExecutor.java
+++ b/stream-payment-order/payment-order-core/src/main/java/com/backbase/stream/paymentorder/PaymentOrderUnitOfWorkExecutor.java
@@ -155,8 +155,6 @@ public class PaymentOrderUnitOfWorkExecutor extends UnitOfWorkExecutor<PaymentOr
         paymentOrderPostFilterRequest.setStatuses(
                 List.of(READY, ACCEPTED, PROCESSED, CANCELLED, REJECTED, CANCELLATION_PENDING));
         
-        log.debug("request POJO: {}", paymentOrderPostFilterRequest);
-
         return paymentOrdersApi.postFilterPaymentOrders(
                 null, null, null, null, null, null, null, null, null, null, null,
                 null, null, null, null, Integer.MAX_VALUE,

--- a/stream-payment-order/payment-order-core/src/main/java/com/backbase/stream/paymentorder/PaymentOrderUnitOfWorkExecutor.java
+++ b/stream-payment-order/payment-order-core/src/main/java/com/backbase/stream/paymentorder/PaymentOrderUnitOfWorkExecutor.java
@@ -12,7 +12,6 @@ import com.backbase.dbs.arrangement.api.service.v2.model.AccountArrangementItem;
 import com.backbase.dbs.arrangement.api.service.v2.model.AccountArrangementItems;
 import com.backbase.dbs.arrangement.api.service.v2.model.AccountArrangementsFilter;
 import com.backbase.dbs.paymentorder.api.service.v2.model.AccessFilter;
-import com.backbase.dbs.transaction.api.service.v2.model.ArrangementItem;
 import com.backbase.stream.config.PaymentOrderTypeConfiguration;
 import java.util.ArrayList;
 import java.util.Collections;

--- a/stream-payment-order/payment-order-core/src/main/java/com/backbase/stream/paymentorder/PaymentOrderUnitOfWorkExecutor.java
+++ b/stream-payment-order/payment-order-core/src/main/java/com/backbase/stream/paymentorder/PaymentOrderUnitOfWorkExecutor.java
@@ -11,9 +11,13 @@ import com.backbase.dbs.arrangement.api.service.v2.ArrangementsApi;
 import com.backbase.dbs.arrangement.api.service.v2.model.AccountArrangementItem;
 import com.backbase.dbs.arrangement.api.service.v2.model.AccountArrangementItems;
 import com.backbase.dbs.arrangement.api.service.v2.model.AccountArrangementsFilter;
+import com.backbase.dbs.paymentorder.api.service.v2.model.AccessFilter;
+import com.backbase.dbs.transaction.api.service.v2.model.ArrangementItem;
+import com.backbase.stream.config.PaymentOrderTypeConfiguration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import javax.validation.Valid;
@@ -47,17 +51,20 @@ public class PaymentOrderUnitOfWorkExecutor extends UnitOfWorkExecutor<PaymentOr
     private final PaymentOrdersApi paymentOrdersApi;
     private final ArrangementsApi arrangementsApi;
     private final PaymentOrderTypeMapper paymentOrderTypeMapper;
+    private final PaymentOrderTypeConfiguration paymentOrderTypeConfiguration;
 
     public PaymentOrderUnitOfWorkExecutor(UnitOfWorkRepository<PaymentOrderTask, String> repository,
             StreamTaskExecutor<PaymentOrderTask> streamTaskExecutor,
             StreamWorkerConfiguration streamWorkerConfiguration,
             PaymentOrdersApi paymentOrdersApi,
             ArrangementsApi arrangementsApi,
-            PaymentOrderTypeMapper paymentOrderTypeMapper) {
+            PaymentOrderTypeMapper paymentOrderTypeMapper,
+            PaymentOrderTypeConfiguration paymentOrderTypeConfiguration) {
         super(repository, streamTaskExecutor, streamWorkerConfiguration);
         this.paymentOrdersApi = paymentOrdersApi;
         this.arrangementsApi = arrangementsApi;
         this.paymentOrderTypeMapper = paymentOrderTypeMapper;
+        this.paymentOrderTypeConfiguration = paymentOrderTypeConfiguration;
     }
 
     public Flux<UnitOfWork<PaymentOrderTask>> prepareUnitOfWork(List<PaymentOrderIngestRequest> items) {
@@ -90,19 +97,19 @@ public class PaymentOrderUnitOfWorkExecutor extends UnitOfWorkExecutor<PaymentOr
      * Gets the list of payments that are persisted in DBS for a specific user.
      * The transfers have been divided by destination product type.
      *
-     * @param paymentOrderIngestContext2 Holds all the Ingestion details.
+     * @param paymentOrderIngestContext Holds all the Ingestion details.
      * @return A Mono of List of GetPaymentOrderResponse.
      */
-    private @NotNull @Valid Mono<PaymentOrderIngestContext> getPersistedScheduledTransfers(PaymentOrderIngestContext paymentOrderIngestContext2) {
+    private @NotNull @Valid Mono<PaymentOrderIngestContext> getPersistedScheduledTransfers(PaymentOrderIngestContext paymentOrderIngestContext) {
 
         List<GetPaymentOrderResponse> listOfPayments = new ArrayList<>();
 
-        return getPayments(paymentOrderIngestContext2.internalUserId())
+        return getPayments(paymentOrderIngestContext.arrangementIds())
                 .map(response -> {
                     listOfPayments.addAll(response.getPaymentOrders());
                     return listOfPayments;
                 })
-                .map(getPaymentOrderResponses -> paymentOrderIngestContext2.existingPaymentOrder(getPaymentOrderResponses))
+                .map(getPaymentOrderResponses -> paymentOrderIngestContext.existingPaymentOrder(getPaymentOrderResponses))
                 .doOnSuccess(result ->
                         log.debug("Successfully fetched dbs scheduled payment orders"));
     }
@@ -125,18 +132,33 @@ public class PaymentOrderUnitOfWorkExecutor extends UnitOfWorkExecutor<PaymentOr
     /**
      * Calls the payment order service to retrieve existing payments.
      *
-     * @param internalUserId   The user's internal id that came with the Payments.
+     * @param arrangementIds   Check for all the arrangements that belong to this PMT.
      * @return A Mono with the response from the service api.
      */
-    private Mono<PaymentOrderPostFilterResponse> getPayments(String internalUserId) {
+    private Mono<PaymentOrderPostFilterResponse> getPayments(List<AccountArrangementItems> arrangementIds) {
 
+        List<String> allArrangementIds = arrangementIds
+                .stream().flatMap(accountArrangementItems ->
+                        accountArrangementItems.getArrangementElements().stream())
+                .map(AccountArrangementItem::getId)
+                .collect(Collectors.toList());
+
+        List<String> paymentTypes = paymentOrderTypeConfiguration.getTypes();
         var paymentOrderPostFilterRequest = new PaymentOrderPostFilterRequest();
+        List<AccessFilter> accessFilters = new ArrayList<>();
+        for (String paymentType : paymentTypes) {
+            AccessFilter accessFilter = new AccessFilter();
+            accessFilter.setPaymentType(paymentType);
+            accessFilter.setArrangementIds(allArrangementIds);
+            accessFilters.add(accessFilter);
+        }
+        paymentOrderPostFilterRequest.setAccessFilters(accessFilters);
         paymentOrderPostFilterRequest.setStatuses(
                 List.of(READY, ACCEPTED, PROCESSED, CANCELLED, REJECTED, CANCELLATION_PENDING));
 
         return paymentOrdersApi.postFilterPaymentOrders(
                 null, null, null, null, null, null, null, null, null, null, null,
-                internalUserId, null, null, null, Integer.MAX_VALUE,
+                null, null, null, null, Integer.MAX_VALUE,
                 null, null, paymentOrderPostFilterRequest);
     }
 

--- a/stream-payment-order/payment-order-core/src/test/java/com/backbase/stream/config/PaymentOrderServiceConfigurationTest.java
+++ b/stream-payment-order/payment-order-core/src/test/java/com/backbase/stream/config/PaymentOrderServiceConfigurationTest.java
@@ -24,6 +24,7 @@ class PaymentOrderServiceConfigurationTest {
             .withBean(DbsApiClientsAutoConfiguration.class)
             .withBean(InterServiceWebClientConfiguration.class)
             .withUserConfiguration(PaymentOrderServiceConfiguration.class)
+            .withUserConfiguration(PaymentOrderTypeConfiguration.class)
             .run(context -> {
                 assertThat(context).hasSingleBean(PaymentOrderTaskExecutor.class);
             });

--- a/stream-payment-order/payment-order-core/src/test/java/com/backbase/stream/config/PaymentOrderServiceConfigurationTest.java
+++ b/stream-payment-order/payment-order-core/src/test/java/com/backbase/stream/config/PaymentOrderServiceConfigurationTest.java
@@ -25,6 +25,9 @@ class PaymentOrderServiceConfigurationTest {
             .withBean(InterServiceWebClientConfiguration.class)
             .withUserConfiguration(PaymentOrderServiceConfiguration.class)
             .withUserConfiguration(PaymentOrderTypeConfiguration.class)
+            .withPropertyValues(
+                    "backbase.stream.paymentorder.types=type1,type2,type3"
+            )
             .run(context -> {
                 assertThat(context).hasSingleBean(PaymentOrderTaskExecutor.class);
             });

--- a/stream-payment-order/payment-order-core/src/test/java/com/backbase/stream/task/PaymentOrderUnitOfWorkExecutorTest.java
+++ b/stream-payment-order/payment-order-core/src/test/java/com/backbase/stream/task/PaymentOrderUnitOfWorkExecutorTest.java
@@ -14,6 +14,7 @@ import com.backbase.dbs.paymentorder.api.service.v2.model.PaymentOrderPostFilter
 import com.backbase.dbs.paymentorder.api.service.v2.model.PaymentOrderPostRequest;
 import com.backbase.dbs.paymentorder.api.service.v2.model.PaymentOrderPostResponse;
 import com.backbase.stream.common.PaymentOrderBaseTest;
+import com.backbase.stream.config.PaymentOrderTypeConfiguration;
 import com.backbase.stream.config.PaymentOrderWorkerConfigurationProperties;
 import com.backbase.stream.model.request.NewPaymentOrderIngestRequest;
 import com.backbase.stream.model.request.PaymentOrderIngestRequest;
@@ -23,6 +24,7 @@ import com.backbase.stream.paymentorder.PaymentOrderUnitOfWorkExecutor;
 import com.backbase.stream.worker.model.UnitOfWork;
 import com.backbase.stream.worker.repository.UnitOfWorkRepository;
 import java.math.BigDecimal;
+import java.util.ArrayList;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -30,6 +32,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -49,6 +52,8 @@ public class PaymentOrderUnitOfWorkExecutorTest extends PaymentOrderBaseTest {
     @Mock
     private UnitOfWorkRepository<PaymentOrderTask, String> repository;
 
+    private PaymentOrderTypeConfiguration paymentOrderTypeConfiguration = new PaymentOrderTypeConfiguration();
+
     private final PaymentOrderTaskExecutor streamTaskExecutor = new PaymentOrderTaskExecutor(paymentOrdersApi);
 
     private final PaymentOrderWorkerConfigurationProperties streamWorkerConfiguration = new PaymentOrderWorkerConfigurationProperties();
@@ -58,9 +63,13 @@ public class PaymentOrderUnitOfWorkExecutorTest extends PaymentOrderBaseTest {
 
     @BeforeEach
     void setup() {
+        List<String> pmtTypes = new ArrayList<>();
+        pmtTypes.add("INTRA_PMT");
+        paymentOrderTypeConfiguration.setTypes(pmtTypes);
         paymentOrderUnitOfWorkExecutor = new PaymentOrderUnitOfWorkExecutor(
                 repository, streamTaskExecutor, streamWorkerConfiguration,
-                paymentOrdersApi, arrangementsApi, paymentOrderTypeMapper);
+                paymentOrdersApi, arrangementsApi, paymentOrderTypeMapper,
+                paymentOrderTypeConfiguration);
     }
 
     @Test

--- a/stream-payment-order/payment-order-core/src/test/java/com/backbase/stream/task/PaymentOrderUnitOfWorkExecutorTest.java
+++ b/stream-payment-order/payment-order-core/src/test/java/com/backbase/stream/task/PaymentOrderUnitOfWorkExecutorTest.java
@@ -1,9 +1,7 @@
 package com.backbase.stream.task;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.verify;
 
 import com.backbase.dbs.arrangement.api.service.v2.ArrangementsApi;
 import com.backbase.dbs.arrangement.api.service.v2.model.AccountArrangementItem;
@@ -29,10 +27,8 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;


### PR DESCRIPTION
## Description

Currently, during pmt ingestion, we query the payment-order-service to retrieve a list of existing pmts. That way we can see what needs to be updated and what is new. We query these pmts by using the user's id. 
Unfortunately, as soon as we introduce joint users, then not all the payments will come up. This results in duplicates being created. 

This update will query the payment-order-service by using the arrangement ids associated with the payment. This way should eliminate any duplicates. 

## Checklist


 - [x] I made sure, I read [CONTRIBUTING.md](CONTRIBUTING.md) to put right branch prefix as per my need.
 - [x] I made sure to update [CHANGELOG.md](CHANGELOG.md).
 - [x] I made sure to update [Stream Wiki](https://github.com/Backbase/stream-services/wiki)(only valid in case of new stream module or architecture changes).
 - [x] My changes are adequately tested.
 - [x] I made sure all the SonarCloud Quality Gate are passed.
