### PR TITLE
Hotfix/existing pmt mapping

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,13 +12,13 @@ jobs:
     if: "!contains(github.event.head_commit.message, '[skip bump]') && !contains(github.event.head_commit.message, 'nobump/')"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           persist-credentials: false # otherwise, the token used is the GITHUB_TOKEN, instead of your personal access token.
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of sonar analysis
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: 17
           distribution: adopt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [4.1.3](https://github.com/Backbase/stream-services/compare/4.1.3...4.1.4)
+### Changed
+- Query for existing payments by using arrangement IDs instead of user IDs. This will eliminate duplicate payments from being ingested when joint owners are added.
+
 ## [4.1.2](https://github.com/Backbase/stream-services/compare/4.1.2...4.1.3)
 ### Added
 - Added Payment order Page size to fix an issue with payment order ingestion.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,9 @@ All notable changes to this project will be documented in this file.
 ### Changed
 - Always check cursor and create if it does not exist.
 - If `DateRangeEnd` is passed in the composition request set that as lastTxnDate instead of system date.
+## [3.65.0](https://github.com/Backbase/stream-services/compare/3.65.0...3.65.1)
+### Changed
+- Query for existing payments by using arrangement IDs instead of user IDs. This will eliminate duplicate payments from being ingested when joint owners are added.
 
 ## [3.65.0](https://github.com/Backbase/stream-services/compare/3.64.0...3.65.0)
 ### Changed

--- a/pom.xml
+++ b/pom.xml
@@ -82,6 +82,11 @@
         <pluginManagement>
             <plugins>
                 <plugin>
+                    <groupId>com.backbase.buildingblocks</groupId>
+                    <artifactId>service-sdk-build-utils-maven-plugin</artifactId>
+                    <version>16.1.7</version>
+                </plugin>
+                <plugin>
                     <groupId>com.backbase.oss</groupId>
                     <artifactId>boat-maven-plugin</artifactId>
                     <version>${boat-maven-plugin.version}</version>

--- a/stream-compositions/pom.xml
+++ b/stream-compositions/pom.xml
@@ -67,6 +67,11 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>com.backbase.buildingblocks</groupId>
+                <artifactId>service-sdk-build-utils-maven-plugin</artifactId>
+                <version>16.1.7</version>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <configuration>

--- a/stream-compositions/services/payment-order-composition-service/src/main/resources/application-local.yml
+++ b/stream-compositions/services/payment-order-composition-service/src/main/resources/application-local.yml
@@ -9,6 +9,7 @@ spring:
       enabled: false
   activemq:
     broker-url: tcp://localhost:61616
+
 sso.jwt.internal.signature.key:
   type: VALUE
   value: JWTSecretKeyDontUseInProduction!
@@ -24,7 +25,7 @@ backbase:
           direct-uri: http://localhost:8050
       payment:
         order:
-          direct-uri: http://localhost:8051
+          direct-uri: http://localhost:8090
       transaction:
         manager:
           direct-uri: http://localhost:8083
@@ -39,6 +40,8 @@ backbase:
     enabled: true
   stream:
     paymentorder:
+      types:
+        - INT_TRANS_CLOSED
       worker:
         deletePaymentOrder: false
 

--- a/stream-compositions/services/payment-order-composition-service/src/main/resources/application.yml
+++ b/stream-compositions/services/payment-order-composition-service/src/main/resources/application.yml
@@ -29,5 +29,7 @@ backbase:
         required-scope: api:service
   stream:
     paymentorder:
+      types:
+        - INT_TRANS_CLOSED
       worker:
         deletePaymentOrder: false

--- a/stream-compositions/services/payment-order-composition-service/src/test/java/com/backbase/stream/compositions/paymentorders/http/PaymentOrderControllerIT.java
+++ b/stream-compositions/services/payment-order-composition-service/src/test/java/com/backbase/stream/compositions/paymentorders/http/PaymentOrderControllerIT.java
@@ -46,7 +46,9 @@ import static org.mockserver.model.HttpRequest.request;
 import static org.mockserver.model.HttpResponse.response;
 
 @DirtiesContext
-@SpringBootTest
+@SpringBootTest(properties = {
+        "backbase.stream.paymentorder.types=type1,type2,type3"
+})
 @AutoConfigureWebTestClient
 @ExtendWith({SpringExtension.class})
 @Slf4j

--- a/stream-compositions/services/payment-order-composition-service/src/test/resources/application.yml
+++ b/stream-compositions/services/payment-order-composition-service/src/test/resources/application.yml
@@ -42,6 +42,8 @@ backbase:
           direct-uri: http://localhost:8083/transaction-manager
       stream:
         payment-order:
+          types:
+            - INT_TRANS_CLOSED
           integration:
             direct-uri: http://localhost:18000
     http:

--- a/stream-payment-order/payment-order-core/src/main/java/com/backbase/stream/config/PaymentOrderServiceConfiguration.java
+++ b/stream-payment-order/payment-order-core/src/main/java/com/backbase/stream/config/PaymentOrderServiceConfiguration.java
@@ -17,13 +17,15 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @EnableConfigurationProperties({
-    PaymentOrderWorkerConfigurationProperties.class
+    PaymentOrderWorkerConfigurationProperties.class,
+    PaymentOrderTypeConfiguration.class
 })
 @AllArgsConstructor
 @Configuration
 public class PaymentOrderServiceConfiguration {
 
     private final PaymentOrderTypeMapper paymentOrderTypeMapper;
+    private final PaymentOrderTypeConfiguration paymentOrderTypeConfiguration;
 
     @Bean
     public PaymentOrderTaskExecutor paymentOrderTaskExecutor(PaymentOrdersApi paymentOrdersApi) {
@@ -39,7 +41,8 @@ public class PaymentOrderServiceConfiguration {
             ArrangementsApi arrangementsApi) {
 
         return new PaymentOrderUnitOfWorkExecutor(paymentOrderUnitOfWorkRepository, paymentOrderTaskExecutor,
-                paymentOrderWorkerConfigurationProperties, paymentOrdersApi, arrangementsApi, paymentOrderTypeMapper);
+                paymentOrderWorkerConfigurationProperties, paymentOrdersApi, arrangementsApi, paymentOrderTypeMapper,
+                paymentOrderTypeConfiguration);
     }
 
     @Bean

--- a/stream-payment-order/payment-order-core/src/main/java/com/backbase/stream/config/PaymentOrderTypeConfiguration.java
+++ b/stream-payment-order/payment-order-core/src/main/java/com/backbase/stream/config/PaymentOrderTypeConfiguration.java
@@ -1,0 +1,18 @@
+package com.backbase.stream.config;
+
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+@ConfigurationProperties(prefix = "backbase.stream.paymentorder")
+@Slf4j
+@Data
+@Validated
+public class PaymentOrderTypeConfiguration {
+
+    @NotNull
+    private List<String> types;
+}

--- a/stream-payment-order/payment-order-core/src/main/java/com/backbase/stream/mappers/PaymentOrderTypeMapper.java
+++ b/stream-payment-order/payment-order-core/src/main/java/com/backbase/stream/mappers/PaymentOrderTypeMapper.java
@@ -12,6 +12,7 @@ import java.util.List;
 public interface PaymentOrderTypeMapper {
 
     @Mapping(source = "schedule.nextExecutionDate", target = "nextExecutionDate")
+    @Mapping(source = "schedule.remainingOccurrences", target = "remainingOccurrences")
     PaymentOrderPutRequest mapPaymentOrderPostRequest(PaymentOrderPostRequest paymentOrderPostRequest);
 
     List<PaymentOrderPostRequest> mapPaymentOrderPostRequest(List<GetPaymentOrderResponse> paymentOrderPostRequest);

--- a/stream-payment-order/payment-order-core/src/main/java/com/backbase/stream/paymentorder/PaymentOrderUnitOfWorkExecutor.java
+++ b/stream-payment-order/payment-order-core/src/main/java/com/backbase/stream/paymentorder/PaymentOrderUnitOfWorkExecutor.java
@@ -256,13 +256,11 @@ public class PaymentOrderUnitOfWorkExecutor extends UnitOfWorkExecutor<PaymentOr
     private Mono<DBSPaymentOrderPageResult> retrieveNextPage(int currentCount, final @NotNull List<String> arrangementIds) {
         List<String> paymentTypes = paymentOrderTypeConfiguration.getTypes();
         var paymentOrderPostFilterRequest = new PaymentOrderPostFilterRequest();
-        List<AccessFilter> accessFilters = new ArrayList<>();
-        for (String paymentType : paymentTypes) {
-            AccessFilter accessFilter = new AccessFilter();
-            accessFilter.setPaymentType(paymentType);
-            accessFilter.setArrangementIds(arrangementIds);
-            accessFilters.add(accessFilter);
-        }
+        List<AccessFilter> accessFilters = paymentTypes.stream()
+                .map(paymentType -> new AccessFilter()
+                        .paymentType(paymentType)
+                        .arrangementIds(arrangementIds))
+                .collect(Collectors.toList());
         paymentOrderPostFilterRequest.setAccessFilters(accessFilters);
         paymentOrderPostFilterRequest.setStatuses(FILTER);
 

--- a/stream-payment-order/payment-order-core/src/main/java/com/backbase/stream/paymentorder/PaymentOrderUnitOfWorkExecutor.java
+++ b/stream-payment-order/payment-order-core/src/main/java/com/backbase/stream/paymentorder/PaymentOrderUnitOfWorkExecutor.java
@@ -19,9 +19,11 @@ import com.backbase.dbs.arrangement.api.service.v2.model.AccountArrangementsFilt
 
 import java.math.BigDecimal;
 import java.time.Duration;
+import com.backbase.dbs.paymentorder.api.service.v2.model.AccessFilter;
+import com.backbase.stream.config.PaymentOrderTypeConfiguration;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import jakarta.validation.Valid;
@@ -61,17 +63,20 @@ public class PaymentOrderUnitOfWorkExecutor extends UnitOfWorkExecutor<PaymentOr
     private final PaymentOrdersApi paymentOrdersApi;
     private final ArrangementsApi arrangementsApi;
     private final PaymentOrderTypeMapper paymentOrderTypeMapper;
+    private final PaymentOrderTypeConfiguration paymentOrderTypeConfiguration;
 
     public PaymentOrderUnitOfWorkExecutor(UnitOfWorkRepository<PaymentOrderTask, String> repository,
-                                          StreamTaskExecutor<PaymentOrderTask> streamTaskExecutor,
-                                          StreamWorkerConfiguration streamWorkerConfiguration,
-                                          PaymentOrdersApi paymentOrdersApi,
-                                          ArrangementsApi arrangementsApi,
-                                          PaymentOrderTypeMapper paymentOrderTypeMapper) {
+            StreamTaskExecutor<PaymentOrderTask> streamTaskExecutor,
+            StreamWorkerConfiguration streamWorkerConfiguration,
+            PaymentOrdersApi paymentOrdersApi,
+            ArrangementsApi arrangementsApi,
+            PaymentOrderTypeMapper paymentOrderTypeMapper,
+            PaymentOrderTypeConfiguration paymentOrderTypeConfiguration) {
         super(repository, streamTaskExecutor, streamWorkerConfiguration);
         this.paymentOrdersApi = paymentOrdersApi;
         this.arrangementsApi = arrangementsApi;
         this.paymentOrderTypeMapper = paymentOrderTypeMapper;
+        this.paymentOrderTypeConfiguration = paymentOrderTypeConfiguration;
     }
 
     public Flux<UnitOfWork<PaymentOrderTask>> prepareUnitOfWork(List<PaymentOrderIngestRequest> items) {
@@ -104,21 +109,21 @@ public class PaymentOrderUnitOfWorkExecutor extends UnitOfWorkExecutor<PaymentOr
      * Gets the list of payments that are persisted in DBS for a specific user.
      * The transfers have been divided by destination product type.
      *
-     * @param paymentOrderIngestContext2 Holds all the Ingestion details.
+     * @param paymentOrderIngestContext Holds all the Ingestion details.
      * @return A Mono of List of GetPaymentOrderResponse.
      */
-    private @NotNull @Valid Mono<PaymentOrderIngestContext> getPersistedScheduledTransfers(PaymentOrderIngestContext paymentOrderIngestContext2) {
+    private @NotNull @Valid Mono<PaymentOrderIngestContext> getPersistedScheduledTransfers(PaymentOrderIngestContext paymentOrderIngestContext) {
 
         List<GetPaymentOrderResponse> listOfPayments = new ArrayList<>();
 
-        return getPayments(paymentOrderIngestContext2.internalUserId())
-            .map(response -> {
-                listOfPayments.addAll(response.getPaymentOrders());
-                return listOfPayments;
-            })
-            .map(getPaymentOrderResponses -> paymentOrderIngestContext2.existingPaymentOrder(getPaymentOrderResponses))
-            .doOnSuccess(result ->
-                log.debug("Successfully fetched dbs scheduled payment orders"));
+        return getPayments(paymentOrderIngestContext.arrangementIds())
+                .map(response -> {
+                    listOfPayments.addAll(response.getPaymentOrders());
+                    return listOfPayments;
+                })
+                .map(getPaymentOrderResponses -> paymentOrderIngestContext.existingPaymentOrder(getPaymentOrderResponses))
+                .doOnSuccess(result ->
+                        log.debug("Successfully fetched dbs scheduled payment orders"));
     }
 
     private @NotNull @Valid Mono<PaymentOrderIngestContext> addArrangementIdMap(PaymentOrderIngestContext paymentOrderIngestContext) {
@@ -139,15 +144,21 @@ public class PaymentOrderUnitOfWorkExecutor extends UnitOfWorkExecutor<PaymentOr
     /**
      * Calls the payment order service to retrieve existing payments.
      *
-     * @param internalUserId   The user's internal id that came with the Payments.
+     * @param arrangementIds   Check for all the arrangements that belong to this PMT.
      * @return A Mono with the response from the service api.
      */
-    private Mono<PaymentOrderPostFilterResponse> getPayments(String internalUserId) {
+    private Mono<PaymentOrderPostFilterResponse> getPayments(List<AccountArrangementItems> arrangementIds) {
 
-        if (isEmptyUserId(internalUserId)) {
+        if (isEmptyArrangmetIds(arrangementIds)) {
             return Mono.just(new PaymentOrderPostFilterResponse().paymentOrders(emptyList()).totalElements(new BigDecimal(0)));
         }
-        return pullFromDBS(internalUserId).map(result -> {
+        List<String> allArrangementIds = arrangementIds
+                .stream().flatMap(accountArrangementItems ->
+                        accountArrangementItems.getArrangementElements().stream())
+                .map(AccountArrangementItem::getId)
+                .collect(Collectors.toList());
+
+        return pullFromDBS(allArrangementIds).map(result -> {
             final var response = new PaymentOrderPostFilterResponse();
             response.setPaymentOrders(result);
             response.setTotalElements(new BigDecimal(result.size()));
@@ -227,23 +238,34 @@ public class PaymentOrderUnitOfWorkExecutor extends UnitOfWorkExecutor<PaymentOr
 
     }
 
-    private Mono<List<GetPaymentOrderResponse>> pullFromDBS(final @NotNull String userid) {
-        return defer(() -> retrieveNextPage(0, userid)
+    private Mono<List<GetPaymentOrderResponse>> pullFromDBS(final @NotNull List<String> arrangementIds) {
+        return defer(() -> retrieveNextPage(0, arrangementIds)
             .expand(page -> {
                 // If there are no more pages, return an empty flux.
                 if (page.next >= page.total || page.requests.isEmpty()) {
                     return empty();
                 } else {
-                    return retrieveNextPage(page.next, userid);
+                    return retrieveNextPage(page.next, arrangementIds);
                 }
             }))
             .collectList()
             .map(pages -> pages.stream().flatMap(page -> page.requests.stream()).toList());
     }
 
-    private Mono<DBSPaymentOrderPageResult> retrieveNextPage(int currentCount, final @NotNull String userId) {
+    private Mono<DBSPaymentOrderPageResult> retrieveNextPage(int currentCount, final @NotNull List<String> arrangementIds) {
+        List<String> paymentTypes = paymentOrderTypeConfiguration.getTypes();
+        var paymentOrderPostFilterRequest = new PaymentOrderPostFilterRequest();
+        List<AccessFilter> accessFilters = new ArrayList<>();
+        for (String paymentType : paymentTypes) {
+            AccessFilter accessFilter = new AccessFilter();
+            accessFilter.setPaymentType(paymentType);
+            accessFilter.setArrangementIds(arrangementIds);
+            accessFilters.add(accessFilter);
+        }
+        paymentOrderPostFilterRequest.setAccessFilters(accessFilters);
+
         return paymentOrdersApi.postFilterPaymentOrders(null, null, null, null, null, null, null, null,
-                null, null, null, userId, null, null, currentCount / PAGE_SIZE, PAGE_SIZE, null,
+                null, null, null, null, null, null, currentCount / PAGE_SIZE, PAGE_SIZE, null,
                 null, FILTER)
             .retryWhen(fixedDelay(3, Duration.of(2000, MILLIS)).filter(
                 t -> t instanceof WebClientRequestException
@@ -253,6 +275,10 @@ public class PaymentOrderUnitOfWorkExecutor extends UnitOfWorkExecutor<PaymentOr
                 final var total = resp.getTotalElements() == null ? new BigDecimal(0).intValue() : resp.getTotalElements().intValue();
                 return new DBSPaymentOrderPageResult(currentCount + results.size(), total, results);
             });
+    }
+
+    private boolean isEmptyArrangmetIds(List<AccountArrangementItems> arrangementItems) {
+        return arrangementItems == null || arrangementItems.isEmpty();
     }
 
     private boolean isEmptyUserId(String userId) {

--- a/stream-payment-order/payment-order-core/src/main/java/com/backbase/stream/paymentorder/PaymentOrderUnitOfWorkExecutor.java
+++ b/stream-payment-order/payment-order-core/src/main/java/com/backbase/stream/paymentorder/PaymentOrderUnitOfWorkExecutor.java
@@ -17,6 +17,7 @@ import com.backbase.dbs.arrangement.api.service.v2.model.AccountArrangementItem;
 import com.backbase.dbs.arrangement.api.service.v2.model.AccountArrangementItems;
 import com.backbase.dbs.arrangement.api.service.v2.model.AccountArrangementsFilter;
 
+import com.backbase.dbs.paymentorder.api.service.v2.model.Status;
 import java.math.BigDecimal;
 import java.time.Duration;
 import com.backbase.dbs.paymentorder.api.service.v2.model.AccessFilter;
@@ -56,7 +57,7 @@ import reactor.core.publisher.Mono;
 @Slf4j
 public class PaymentOrderUnitOfWorkExecutor extends UnitOfWorkExecutor<PaymentOrderTask> {
 
-    private static final PaymentOrderPostFilterRequest FILTER = new PaymentOrderPostFilterRequest().statuses(List.of(READY, ACCEPTED, PROCESSED, CANCELLED, REJECTED, CANCELLATION_PENDING));
+    private static final List<Status> FILTER = List.of(READY, ACCEPTED, PROCESSED, CANCELLED, REJECTED, CANCELLATION_PENDING);
 
     private static final int PAGE_SIZE = 1000;
 
@@ -263,10 +264,11 @@ public class PaymentOrderUnitOfWorkExecutor extends UnitOfWorkExecutor<PaymentOr
             accessFilters.add(accessFilter);
         }
         paymentOrderPostFilterRequest.setAccessFilters(accessFilters);
+        paymentOrderPostFilterRequest.setStatuses(FILTER);
 
         return paymentOrdersApi.postFilterPaymentOrders(null, null, null, null, null, null, null, null,
                 null, null, null, null, null, null, currentCount / PAGE_SIZE, PAGE_SIZE, null,
-                null, FILTER)
+                null, paymentOrderPostFilterRequest)
             .retryWhen(fixedDelay(3, Duration.of(2000, MILLIS)).filter(
                 t -> t instanceof WebClientRequestException
                     || t instanceof WebClientResponseException.ServiceUnavailable))

--- a/stream-payment-order/payment-order-core/src/test/java/com/backbase/stream/config/PaymentOrderServiceConfigurationTest.java
+++ b/stream-payment-order/payment-order-core/src/test/java/com/backbase/stream/config/PaymentOrderServiceConfigurationTest.java
@@ -24,6 +24,10 @@ class PaymentOrderServiceConfigurationTest {
             .withBean(DbsApiClientsAutoConfiguration.class)
             .withBean(InterServiceWebClientConfiguration.class)
             .withUserConfiguration(PaymentOrderServiceConfiguration.class)
+            .withUserConfiguration(PaymentOrderTypeConfiguration.class)
+            .withPropertyValues(
+                    "backbase.stream.paymentorder.types=type1,type2,type3"
+            )
             .run(context -> {
                 assertThat(context).hasSingleBean(PaymentOrderTaskExecutor.class);
             });

--- a/stream-payment-order/payment-order-core/src/test/java/com/backbase/stream/task/PaymentOrderUnitOfWorkExecutorTest.java
+++ b/stream-payment-order/payment-order-core/src/test/java/com/backbase/stream/task/PaymentOrderUnitOfWorkExecutorTest.java
@@ -1,7 +1,10 @@
 package com.backbase.stream.task;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.lenient;
 
 import com.backbase.dbs.arrangement.api.service.v2.ArrangementsApi;
 import com.backbase.dbs.arrangement.api.service.v2.model.AccountArrangementItem;
@@ -22,7 +25,9 @@ import com.backbase.stream.paymentorder.PaymentOrderUnitOfWorkExecutor;
 import com.backbase.stream.worker.model.UnitOfWork;
 import com.backbase.stream.worker.repository.UnitOfWorkRepository;
 import java.math.BigDecimal;
+
 import java.util.ArrayList;
+import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -79,7 +84,7 @@ public class PaymentOrderUnitOfWorkExecutorTest extends PaymentOrderBaseTest {
                 .id("po_post_resp_id")
                 .putAdditionsItem("key", "val");
 
-        Mockito.lenient().when(paymentOrdersApi.postPaymentOrder(Mockito.any()))
+        lenient().when(paymentOrdersApi.postPaymentOrder(Mockito.any()))
                 .thenReturn(Mono.just(paymentOrderPostResponse));
 
         AccountArrangementItem accountArrangementItem = new AccountArrangementItem()
@@ -89,7 +94,7 @@ public class PaymentOrderUnitOfWorkExecutorTest extends PaymentOrderBaseTest {
         AccountArrangementItems accountArrangementItems = new AccountArrangementItems()
                 .addArrangementElementsItem(accountArrangementItem);
 
-        Mockito.lenient().when(arrangementsApi.postFilter(Mockito.any()))
+        lenient().when(arrangementsApi.postFilter(Mockito.any()))
                 .thenReturn(Mono.just(accountArrangementItems));
 
         StepVerifier.create(paymentOrderUnitOfWorkExecutor.prepareUnitOfWork(paymentOrderIngestRequestList))
@@ -110,11 +115,12 @@ public class PaymentOrderUnitOfWorkExecutorTest extends PaymentOrderBaseTest {
                 .id("po_post_resp_id")
                 .putAdditionsItem("key", "val");
 
-        Mockito.lenient().when(paymentOrdersApi.postPaymentOrder(any()))
+        lenient().when(paymentOrdersApi.postPaymentOrder(any()))
                 .thenReturn(Mono.just(paymentOrderPostResponse));
 
         GetPaymentOrderResponse getPaymentOrderResponse = new GetPaymentOrderResponse()
-                .id("arrangementId_1");
+                .id("arrangementId_1")
+                .bankReferenceId("bankReferenceId_1");
         PaymentOrderPostFilterResponse paymentOrderPostFilterResponse = new PaymentOrderPostFilterResponse()
                 .addPaymentOrdersItem(getPaymentOrderResponse)
                 .totalElements(new BigDecimal(1));
@@ -137,6 +143,42 @@ public class PaymentOrderUnitOfWorkExecutorTest extends PaymentOrderBaseTest {
                     Assertions.assertEquals(1, unitOfWork.getStreamTasks().size());
                     Assertions.assertEquals(paymentOrderPostRequest.size(), unitOfWork.getStreamTasks().get(0).getData().size());
                 })
+                .verifyComplete();
+    }
+
+    @Test
+    void test_prepareunitofwork_blankuserid() {
+
+        paymentOrderUnitOfWorkExecutor = new PaymentOrderUnitOfWorkExecutor(
+                repository, streamTaskExecutor, streamWorkerConfiguration,
+                paymentOrdersApi, arrangementsApi, null, paymentOrderTypeConfiguration);
+
+        paymentOrderPostRequest.get(0).setInternalUserId(StringUtils.EMPTY);
+        paymentOrderPostRequest.get(1).setInternalUserId(null);
+
+        Flux<PaymentOrderPostRequest> paymentOrderPostRequestFlux = Flux.fromIterable(paymentOrderPostRequest);
+
+        AccountArrangementItem accountArrangementItem = new AccountArrangementItem()
+                .id("arrangementId_1")
+                .externalArrangementId("externalArrangementId_1");
+        AccountArrangementItems accountArrangementItems = new AccountArrangementItems()
+                .addArrangementElementsItem(accountArrangementItem);
+
+        lenient().when(arrangementsApi.postFilter(Mockito.any()))
+                .thenReturn(Mono.just(accountArrangementItems));
+
+        GetPaymentOrderResponse getPaymentOrderResponseWithEmptyUserId = new GetPaymentOrderResponse()
+                .id("arrangementId_1");
+
+        PaymentOrderPostFilterResponse paymentOrderPostFilterResponse = new PaymentOrderPostFilterResponse()
+                .addPaymentOrdersItem(getPaymentOrderResponseWithEmptyUserId)
+                .totalElements(new BigDecimal(1));
+
+        lenient().doReturn(Mono.just(paymentOrderPostFilterResponse)).when(paymentOrdersApi).postFilterPaymentOrders(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any());
+
+        StepVerifier
+                .create(paymentOrderUnitOfWorkExecutor.prepareUnitOfWork(paymentOrderPostRequestFlux))
+                .expectNextCount(0)
                 .verifyComplete();
     }
 

--- a/stream-payment-order/payment-order-core/src/test/java/com/backbase/stream/task/PaymentOrderUnitOfWorkExecutorTest.java
+++ b/stream-payment-order/payment-order-core/src/test/java/com/backbase/stream/task/PaymentOrderUnitOfWorkExecutorTest.java
@@ -1,10 +1,7 @@
 package com.backbase.stream.task;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.lenient;
 
 import com.backbase.dbs.arrangement.api.service.v2.ArrangementsApi;
 import com.backbase.dbs.arrangement.api.service.v2.model.AccountArrangementItem;
@@ -15,6 +12,7 @@ import com.backbase.dbs.paymentorder.api.service.v2.model.PaymentOrderPostFilter
 import com.backbase.dbs.paymentorder.api.service.v2.model.PaymentOrderPostRequest;
 import com.backbase.dbs.paymentorder.api.service.v2.model.PaymentOrderPostResponse;
 import com.backbase.stream.common.PaymentOrderBaseTest;
+import com.backbase.stream.config.PaymentOrderTypeConfiguration;
 import com.backbase.stream.config.PaymentOrderWorkerConfigurationProperties;
 import com.backbase.stream.model.request.NewPaymentOrderIngestRequest;
 import com.backbase.stream.model.request.PaymentOrderIngestRequest;
@@ -24,13 +22,11 @@ import com.backbase.stream.paymentorder.PaymentOrderUnitOfWorkExecutor;
 import com.backbase.stream.worker.model.UnitOfWork;
 import com.backbase.stream.worker.repository.UnitOfWorkRepository;
 import java.math.BigDecimal;
-
-import org.apache.commons.lang3.StringUtils;
+import java.util.ArrayList;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -52,6 +48,8 @@ public class PaymentOrderUnitOfWorkExecutorTest extends PaymentOrderBaseTest {
     @Mock
     private UnitOfWorkRepository<PaymentOrderTask, String> repository;
 
+    private PaymentOrderTypeConfiguration paymentOrderTypeConfiguration = new PaymentOrderTypeConfiguration();
+
     private final PaymentOrderTaskExecutor streamTaskExecutor = new PaymentOrderTaskExecutor(paymentOrdersApi);
 
     private final PaymentOrderWorkerConfigurationProperties streamWorkerConfiguration = new PaymentOrderWorkerConfigurationProperties();
@@ -61,43 +59,47 @@ public class PaymentOrderUnitOfWorkExecutorTest extends PaymentOrderBaseTest {
 
     @BeforeEach
     void setup() {
+        List<String> pmtTypes = new ArrayList<>();
+        pmtTypes.add("INTRA_PMT");
+        paymentOrderTypeConfiguration.setTypes(pmtTypes);
         paymentOrderUnitOfWorkExecutor = new PaymentOrderUnitOfWorkExecutor(
-            repository, streamTaskExecutor, streamWorkerConfiguration,
-            paymentOrdersApi, arrangementsApi, paymentOrderTypeMapper);
+                repository, streamTaskExecutor, streamWorkerConfiguration,
+                paymentOrdersApi, arrangementsApi, paymentOrderTypeMapper,
+                paymentOrderTypeConfiguration);
     }
 
     @Test
     void test_prepareUnitOfWork_paymentOrderIngestRequestList() {
         List<PaymentOrderIngestRequest> paymentOrderIngestRequestList = List.of(
-            new NewPaymentOrderIngestRequest(paymentOrderPostRequest.get(0)),
-            new NewPaymentOrderIngestRequest(paymentOrderPostRequest.get(1))
+                new NewPaymentOrderIngestRequest(paymentOrderPostRequest.get(0)),
+                new NewPaymentOrderIngestRequest(paymentOrderPostRequest.get(1))
         );
 
         PaymentOrderPostResponse paymentOrderPostResponse = new PaymentOrderPostResponse()
-            .id("po_post_resp_id")
-            .putAdditionsItem("key", "val");
+                .id("po_post_resp_id")
+                .putAdditionsItem("key", "val");
 
-        lenient().when(paymentOrdersApi.postPaymentOrder(Mockito.any()))
-            .thenReturn(Mono.just(paymentOrderPostResponse));
+        Mockito.lenient().when(paymentOrdersApi.postPaymentOrder(Mockito.any()))
+                .thenReturn(Mono.just(paymentOrderPostResponse));
 
         AccountArrangementItem accountArrangementItem = new AccountArrangementItem()
-            .id("arrangementId_1")
-            .externalArrangementId("externalArrangementId_1");
+                .id("arrangementId_1")
+                .externalArrangementId("externalArrangementId_1");
 
         AccountArrangementItems accountArrangementItems = new AccountArrangementItems()
-            .addArrangementElementsItem(accountArrangementItem);
+                .addArrangementElementsItem(accountArrangementItem);
 
-        lenient().when(arrangementsApi.postFilter(Mockito.any()))
-            .thenReturn(Mono.just(accountArrangementItems));
+        Mockito.lenient().when(arrangementsApi.postFilter(Mockito.any()))
+                .thenReturn(Mono.just(accountArrangementItems));
 
         StepVerifier.create(paymentOrderUnitOfWorkExecutor.prepareUnitOfWork(paymentOrderIngestRequestList))
-            .assertNext(unitOfWork -> {
-                Assertions.assertTrue(unitOfWork.getUnitOfOWorkId().startsWith("payment-orders-mixed-"));
-                Assertions.assertEquals(UnitOfWork.State.NEW, unitOfWork.getState());
-                Assertions.assertEquals(1, unitOfWork.getStreamTasks().size());
-                Assertions.assertEquals(paymentOrderIngestRequestList.size(), unitOfWork.getStreamTasks().get(0).getData().size());
-            })
-            .verifyComplete();
+                .assertNext(unitOfWork -> {
+                    Assertions.assertTrue(unitOfWork.getUnitOfOWorkId().startsWith("payment-orders-mixed-"));
+                    Assertions.assertEquals(UnitOfWork.State.NEW, unitOfWork.getState());
+                    Assertions.assertEquals(1, unitOfWork.getStreamTasks().size());
+                    Assertions.assertEquals(paymentOrderIngestRequestList.size(), unitOfWork.getStreamTasks().get(0).getData().size());
+                })
+                .verifyComplete();
     }
 
     @Test
@@ -105,74 +107,37 @@ public class PaymentOrderUnitOfWorkExecutorTest extends PaymentOrderBaseTest {
         Flux<PaymentOrderPostRequest> paymentOrderPostRequestFlux = Flux.fromIterable(paymentOrderPostRequest);
 
         PaymentOrderPostResponse paymentOrderPostResponse = new PaymentOrderPostResponse()
-            .id("po_post_resp_id")
-            .putAdditionsItem("key", "val");
+                .id("po_post_resp_id")
+                .putAdditionsItem("key", "val");
 
-        lenient().when(paymentOrdersApi.postPaymentOrder(any()))
-            .thenReturn(Mono.just(paymentOrderPostResponse));
+        Mockito.lenient().when(paymentOrdersApi.postPaymentOrder(any()))
+                .thenReturn(Mono.just(paymentOrderPostResponse));
 
         GetPaymentOrderResponse getPaymentOrderResponse = new GetPaymentOrderResponse()
-            .id("arrangementId_1")
-            .bankReferenceId("bankReferenceId_1");
+                .id("arrangementId_1");
         PaymentOrderPostFilterResponse paymentOrderPostFilterResponse = new PaymentOrderPostFilterResponse()
-            .addPaymentOrdersItem(getPaymentOrderResponse)
-            .totalElements(new BigDecimal(1));
+                .addPaymentOrdersItem(getPaymentOrderResponse)
+                .totalElements(new BigDecimal(1));
 
         doReturn(Mono.just(paymentOrderPostFilterResponse)).when(paymentOrdersApi).postFilterPaymentOrders(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any());
 
         AccountArrangementItem accountArrangementItem = new AccountArrangementItem()
-            .id("arrangementId_1")
-            .externalArrangementId("externalArrangementId_1");
+                .id("arrangementId_1")
+                .externalArrangementId("externalArrangementId_1");
         AccountArrangementItems accountArrangementItems = new AccountArrangementItems()
-            .addArrangementElementsItem(accountArrangementItem);
+                .addArrangementElementsItem(accountArrangementItem);
 
         Mockito.when(arrangementsApi.postFilter(Mockito.any()))
-            .thenReturn(Mono.just(accountArrangementItems));
+                .thenReturn(Mono.just(accountArrangementItems));
 
         StepVerifier.create(paymentOrderUnitOfWorkExecutor.prepareUnitOfWork(paymentOrderPostRequestFlux))
-            .assertNext(unitOfWork -> {
-                Assertions.assertTrue(unitOfWork.getUnitOfOWorkId().startsWith("payment-orders-mixed-"));
-                Assertions.assertEquals(UnitOfWork.State.NEW, unitOfWork.getState());
-                Assertions.assertEquals(1, unitOfWork.getStreamTasks().size());
-                Assertions.assertEquals(paymentOrderPostRequest.size(), unitOfWork.getStreamTasks().get(0).getData().size());
-            })
-            .verifyComplete();
-    }
-
-    @Test
-    void test_prepareunitofwork_blankuserid() {
-
-        paymentOrderUnitOfWorkExecutor = new PaymentOrderUnitOfWorkExecutor(
-            repository, streamTaskExecutor, streamWorkerConfiguration,
-            paymentOrdersApi, arrangementsApi, null);
-
-        paymentOrderPostRequest.get(0).setInternalUserId(StringUtils.EMPTY);
-        paymentOrderPostRequest.get(1).setInternalUserId(null);
-
-        Flux<PaymentOrderPostRequest> paymentOrderPostRequestFlux = Flux.fromIterable(paymentOrderPostRequest);
-
-        AccountArrangementItem accountArrangementItem = new AccountArrangementItem()
-            .id("arrangementId_1")
-            .externalArrangementId("externalArrangementId_1");
-        AccountArrangementItems accountArrangementItems = new AccountArrangementItems()
-            .addArrangementElementsItem(accountArrangementItem);
-
-        lenient().when(arrangementsApi.postFilter(Mockito.any()))
-            .thenReturn(Mono.just(accountArrangementItems));
-
-        GetPaymentOrderResponse getPaymentOrderResponseWithEmptyUserId = new GetPaymentOrderResponse()
-            .id("arrangementId_1");
-
-        PaymentOrderPostFilterResponse paymentOrderPostFilterResponse = new PaymentOrderPostFilterResponse()
-            .addPaymentOrdersItem(getPaymentOrderResponseWithEmptyUserId)
-            .totalElements(new BigDecimal(1));
-
-        lenient().doReturn(Mono.just(paymentOrderPostFilterResponse)).when(paymentOrdersApi).postFilterPaymentOrders(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any());
-
-        StepVerifier
-            .create(paymentOrderUnitOfWorkExecutor.prepareUnitOfWork(paymentOrderPostRequestFlux))
-            .expectNextCount(0)
-            .verifyComplete();
+                .assertNext(unitOfWork -> {
+                    Assertions.assertTrue(unitOfWork.getUnitOfOWorkId().startsWith("payment-orders-mixed-"));
+                    Assertions.assertEquals(UnitOfWork.State.NEW, unitOfWork.getState());
+                    Assertions.assertEquals(1, unitOfWork.getStreamTasks().size());
+                    Assertions.assertEquals(paymentOrderPostRequest.size(), unitOfWork.getStreamTasks().get(0).getData().size());
+                })
+                .verifyComplete();
     }
 
 }

--- a/stream-sdk/stream-parent/pom.xml
+++ b/stream-sdk/stream-parent/pom.xml
@@ -78,4 +78,14 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.backbase.buildingblocks</groupId>
+                <artifactId>service-sdk-build-utils-maven-plugin</artifactId>
+                <version>16.1.7</version>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>

--- a/stream-sdk/stream-starter-parents/stream-http-starter-parent/pom.xml
+++ b/stream-sdk/stream-starter-parents/stream-http-starter-parent/pom.xml
@@ -71,6 +71,11 @@
         <pluginManagement>
             <plugins>
                 <plugin>
+                    <groupId>com.backbase.buildingblocks</groupId>
+                    <artifactId>service-sdk-build-utils-maven-plugin</artifactId>
+                    <version>16.1.7</version>
+                </plugin>
+                <plugin>
                     <groupId>com.backbase.oss</groupId>
                     <artifactId>boat-maven-plugin</artifactId>
                     <version>0.17.24</version>
@@ -96,6 +101,13 @@
                 </plugin>
             </plugins>
         </pluginManagement>
+        <plugins>
+            <plugin>
+                <groupId>com.backbase.buildingblocks</groupId>
+                <artifactId>service-sdk-build-utils-maven-plugin</artifactId>
+                <version>16.1.7</version>
+            </plugin>
+        </plugins>
     </build>
 
     <profiles>

--- a/stream-sdk/stream-starter-parents/stream-task-starter-parent/pom.xml
+++ b/stream-sdk/stream-starter-parents/stream-task-starter-parent/pom.xml
@@ -76,6 +76,25 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>com.backbase.buildingblocks</groupId>
+                    <artifactId>service-sdk-build-utils-maven-plugin</artifactId>
+                    <version>16.1.7</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+        <plugins>
+            <plugin>
+                <groupId>com.backbase.buildingblocks</groupId>
+                <artifactId>service-sdk-build-utils-maven-plugin</artifactId>
+                <version>16.1.7</version>
+            </plugin>
+        </plugins>
+    </build>
+
     <profiles>
         <profile>
             <id>docker-image</id>


### PR DESCRIPTION
Currently, during pmt ingestion, we query the payment-order-service to retrieve a list of existing pmts. That way we can see what needs to be updated and what is new. We query these pmts by using the user's id.
Unfortunately, as soon as we introduce joint users, then not all the payments will come up. This results in duplicates being created.

This update will query the payment-order-service by using the arrangement ids associated with the payment. This way should eliminate any duplicates.

 - [x] I made sure, I read [CONTRIBUTING.md](CONTRIBUTING.md) to put right branch prefix as per my need.
 - [x] I made sure to update [CHANGELOG.md](CHANGELOG.md).
 - [x] I made sure to update [Stream Wiki](https://github.com/Backbase/stream-services/wiki)(only valid in case of new stream module or architecture changes).
 - [x] My changes are adequately tested.
 - [x] I made sure all the SonarCloud Quality Gate are passed.
