### PR TITLE
PRSUM-10218: arrangement-manager service V3 implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [5.8.0](https://github.com/Backbase/stream-services/compare/5.7.0...5.8.0)
+### Changed
+- **Arrangement Manager API** has been updated to `V3`, impacting its dependencies as follows:
+  - **User Preferences Update Operations:** These operations are no longer available. Since they were internal, the related `POST` and `PUT` endpoints have been removed. Consequently, any processes that involved creating or updating **User Preferences** have also been eliminated.
+  - **Arrangement Batch Upsert Operation:** This operation has been removed from the service-api layer and is now only available in the integration-api layer. It is primarily used for data ingestion by banks into Backbase’s platform. All data ingestion streams now use the integration-api for this purpose. The only change required is to use a different endpoint.
+  - **Retrieving Arrangements:** In `V3`, calls to retrieve a list of arrangements or an arrangement by `ID` can now be made using the new `POST /service-api/v3/arrangements/searches` endpoint. This endpoint provides multiple ways to retrieve arrangements through a single API call.
+  - **Product Kind Operations:** Only `GET` operations are now available for **Product Kinds**. The database management has been _deprecated_, as **Product Kind** data is now maintained statically through a `YAML` settings file in **Arrangement Manager**. As a result, `POST` and `PUT` endpoints are no longer available.
+
 ## [5.7.0](https://github.com/Backbase/stream-services/compare/5.6.0...5.7.0)
 ### Changed
 - bug fixed - missing stream-starter module in stream-sdk

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.backbase.buildingblocks</groupId>
         <artifactId>backbase-parent</artifactId>
-        <version>17.0.0</version>
+        <version>17.1.0</version>
         <relativePath/>
     </parent>
 
@@ -38,8 +38,8 @@
 
     <properties>
         <java.version>21</java.version>
-        <ssdk.version>17.0.0</ssdk.version>
-        <backbase-bom.version>2024.04</backbase-bom.version>
+        <ssdk.version>17.1.0</ssdk.version>
+        <backbase-bom.version>2024.08.1</backbase-bom.version>
         <boat-maven-plugin.version>0.17.26</boat-maven-plugin.version>
         <spring-boot.repackage.skip>true</spring-boot.repackage.skip>
         <openapi-generator-maven-plugin.language>spring</openapi-generator-maven-plugin.language>

--- a/stream-access-control/access-control-core/src/main/java/com/backbase/stream/service/EntitlementsService.java
+++ b/stream-access-control/access-control-core/src/main/java/com/backbase/stream/service/EntitlementsService.java
@@ -1,16 +1,15 @@
 package com.backbase.stream.service;
 
-import com.backbase.dbs.arrangement.api.service.v2.model.AccountArrangementItem;
+import com.backbase.dbs.arrangement.api.service.v3.model.ArrangementItem;
 import com.backbase.stream.exceptions.UserNotFoundException;
 import com.backbase.stream.legalentity.model.AssignedPermission;
+import com.backbase.stream.legalentity.model.BaseProductGroup.ProductGroupTypeEnum;
 import com.backbase.stream.legalentity.model.LegalEntity;
-import com.backbase.stream.legalentity.model.ProductGroup;
 import com.backbase.stream.legalentity.model.ServiceAgreement;
 import com.backbase.stream.legalentity.model.User;
 import com.backbase.stream.product.service.ArrangementService;
 import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import reactor.core.publisher.Flux;
@@ -71,42 +70,10 @@ public class EntitlementsService {
                     .map(products -> setAssignedPermissionForArrangements(permission, products)));
     }
 
-    /**
-     * Get All Products a legal entity has access to.
-     *
-     * @param legalEntityId Internal Legal Entity Id
-     * @return List of Products
-     */
-    public Flux<AccountArrangementItem> getProductsForInternalLegalEntityId(String legalEntityId) {
-        return legalEntityService.getMasterServiceAgreementForInternalLegalEntityId(legalEntityId)
-            .flatMapMany(sa -> accessGroupService.getDataGroupItemIdsByServiceAgreementId(sa.getInternalId())
-                .flatMap(arrangementService::getArrangement)
-            );
-    }
-
-    /**
-     * Get All Products a legal entity has access to.
-     *
-     * @param legalEntityId External Legal Entity Id
-     * @return List of Products
-     */
-    public Flux<AccountArrangementItem> getProductsForExternalLegalEntityId(String legalEntityId) {
-        return legalEntityService.getLegalEntityByExternalId(legalEntityId).flux()
-            .flatMap(legalEntity -> getProductsForInternalLegalEntityId(legalEntity.getInternalId()));
-    }
-
-    private AssignedPermission setAssignedPermissionForJourneys(AssignedPermission permission, List<String> externalIds,
-        ProductGroup.ProductGroupTypeEnum productGroupTypeEnum) {
-        permission.setPermittedObjectExternalIds(externalIds);
-        return permission;
-    }
-
     private AssignedPermission setAssignedPermissionForArrangements(AssignedPermission permission,
-        List<AccountArrangementItem> products) {
-        List<String> externalIds = products.stream().map(AccountArrangementItem::getExternalArrangementId)
-            .collect(Collectors.toList());
-        permission.setPermittedObjects(
-            Collections.singletonMap(ProductGroup.ProductGroupTypeEnum.ARRANGEMENTS.name(), products));
+        List<ArrangementItem> products) {
+        List<String> externalIds = products.stream().map(ArrangementItem::getExternalArrangementId).toList();
+        permission.setPermittedObjects(Collections.singletonMap(ProductGroupTypeEnum.ARRANGEMENTS.name(), products));
         permission.setPermittedObjectExternalIds(externalIds);
         return permission;
     }

--- a/stream-compositions/services/product-composition-service/src/main/java/com/backbase/stream/compositions/product/core/mapper/ArrangementMapper.java
+++ b/stream-compositions/services/product-composition-service/src/main/java/com/backbase/stream/compositions/product/core/mapper/ArrangementMapper.java
@@ -8,11 +8,11 @@ import org.springframework.stereotype.Component;
 @Mapper(componentModel = "spring", injectionStrategy = InjectionStrategy.CONSTRUCTOR)
 public interface ArrangementMapper {
     com.backbase.stream.compositions.product.api.model.AccountArrangementItemPut mapStreamToComposition(
-            com.backbase.dbs.arrangement.api.service.v2.model.AccountArrangementItemPut arrangement);
+            com.backbase.dbs.arrangement.api.service.v3.model.ArrangementPutItem arrangement);
 
-    com.backbase.dbs.arrangement.api.service.v2.model.AccountArrangementItemPut mapIntegrationToStream(
+    com.backbase.dbs.arrangement.api.service.v3.model.ArrangementPutItem mapIntegrationToStream(
         com.backbase.stream.compositions.product.integration.client.model.AccountArrangementItemPut arrangementItem);
 
-    com.backbase.dbs.arrangement.api.service.v2.model.AccountArrangementItemPut mapCompositionToStream(
+    com.backbase.dbs.arrangement.api.service.v3.model.ArrangementPutItem mapCompositionToStream(
             com.backbase.stream.compositions.product.api.model.AccountArrangementItemPut arrangementItem);
 }

--- a/stream-compositions/services/product-composition-service/src/main/java/com/backbase/stream/compositions/product/core/model/ArrangementIngestPushRequest.java
+++ b/stream-compositions/services/product-composition-service/src/main/java/com/backbase/stream/compositions/product/core/model/ArrangementIngestPushRequest.java
@@ -1,6 +1,6 @@
 package com.backbase.stream.compositions.product.core.model;
 
-import com.backbase.dbs.arrangement.api.service.v2.model.AccountArrangementItemPut;
+import com.backbase.dbs.arrangement.api.service.v3.model.ArrangementPutItem;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -11,7 +11,7 @@ import lombok.Setter;
 @Builder(toBuilder = true)
 @AllArgsConstructor
 public class ArrangementIngestPushRequest {
-    private AccountArrangementItemPut arrangement;
+    private ArrangementPutItem arrangement;
     private String arrangementInternalId;
     private String source;
     private RequestConfig config;

--- a/stream-compositions/services/product-composition-service/src/main/java/com/backbase/stream/compositions/product/core/model/ArrangementIngestResponse.java
+++ b/stream-compositions/services/product-composition-service/src/main/java/com/backbase/stream/compositions/product/core/model/ArrangementIngestResponse.java
@@ -1,6 +1,6 @@
 package com.backbase.stream.compositions.product.core.model;
 
-import com.backbase.dbs.arrangement.api.service.v2.model.AccountArrangementItemPut;
+import com.backbase.dbs.arrangement.api.service.v3.model.ArrangementPutItem;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -11,7 +11,7 @@ import lombok.Setter;
 @Builder(toBuilder = true)
 @AllArgsConstructor
 public class ArrangementIngestResponse {
-    private AccountArrangementItemPut arrangement;
+    private ArrangementPutItem arrangement;
     private String arrangementInternalId;
     private String source;
     private RequestConfig config;

--- a/stream-compositions/services/product-composition-service/src/main/java/com/backbase/stream/compositions/product/core/service/impl/ArrangementIngestionServiceImpl.java
+++ b/stream-compositions/services/product-composition-service/src/main/java/com/backbase/stream/compositions/product/core/service/impl/ArrangementIngestionServiceImpl.java
@@ -2,7 +2,7 @@ package com.backbase.stream.compositions.product.core.service.impl;
 
 import com.backbase.buildingblocks.presentation.errors.BadRequestException;
 import com.backbase.buildingblocks.presentation.errors.Error;
-import com.backbase.dbs.arrangement.api.service.v2.model.AccountArrangementItemPut;
+import com.backbase.dbs.arrangement.api.service.v3.model.ArrangementPutItem;
 import com.backbase.stream.compositions.product.core.model.ArrangementIngestPullRequest;
 import com.backbase.stream.compositions.product.core.model.ArrangementIngestPushRequest;
 import com.backbase.stream.compositions.product.core.model.ArrangementIngestResponse;
@@ -68,7 +68,7 @@ public class ArrangementIngestionServiceImpl implements ArrangementIngestionServ
     }
 
     private Mono<ArrangementIngestResponse> validate(ArrangementIngestResponse res) {
-        Set<ConstraintViolation<AccountArrangementItemPut>> violations = validator.validate(res.getArrangement());
+        Set<ConstraintViolation<ArrangementPutItem>> violations = validator.validate(res.getArrangement());
 
         if (!CollectionUtils.isEmpty(violations)) {
             List<Error> errors = violations.stream().map(c -> new Error()

--- a/stream-compositions/services/product-composition-service/src/test/java/com/backbase/stream/compositions/product/core/mapper/ArrangementRestMapperTest.java
+++ b/stream-compositions/services/product-composition-service/src/test/java/com/backbase/stream/compositions/product/core/mapper/ArrangementRestMapperTest.java
@@ -37,7 +37,7 @@ class ArrangementRestMapperTest {
         AccountArrangementItemPut arrangementItemPut = new AccountArrangementItemPut();
 
         when(arrangementMapper.mapCompositionToStream(arrangementItemPut))
-                .thenReturn(new com.backbase.dbs.arrangement.api.service.v2.model.AccountArrangementItemPut());
+                .thenReturn(new com.backbase.dbs.arrangement.api.service.v3.model.ArrangementPutItem());
 
         when(chainsMapper.map(any()))
                 .thenReturn(RequestConfig.builder().build());
@@ -79,8 +79,8 @@ class ArrangementRestMapperTest {
 
     @Test
     void mapResponse() {
-        com.backbase.dbs.arrangement.api.service.v2.model.AccountArrangementItemPut streamArrangement =
-                new com.backbase.dbs.arrangement.api.service.v2.model.AccountArrangementItemPut();
+        com.backbase.dbs.arrangement.api.service.v3.model.ArrangementPutItem streamArrangement =
+                new com.backbase.dbs.arrangement.api.service.v3.model.ArrangementPutItem();
 
         AccountArrangementItemPut compositionArrangement = new AccountArrangementItemPut();
 
@@ -89,7 +89,7 @@ class ArrangementRestMapperTest {
 
         ArrangementIngestResponse response = ArrangementIngestResponse
                 .builder()
-                .arrangement(new com.backbase.dbs.arrangement.api.service.v2.model.AccountArrangementItemPut())
+                .arrangement(new com.backbase.dbs.arrangement.api.service.v3.model.ArrangementPutItem())
                 .build();
 
         ResponseEntity<ArrangementIngestionResponse> responseEntity = arrangementRestMapper.mapResponse(response);

--- a/stream-compositions/services/product-composition-service/src/test/java/com/backbase/stream/compositions/product/core/service/impl/ArrangementIntegrationServiceImplTest.java
+++ b/stream-compositions/services/product-composition-service/src/test/java/com/backbase/stream/compositions/product/core/service/impl/ArrangementIntegrationServiceImplTest.java
@@ -44,7 +44,7 @@ class ArrangementIntegrationServiceImplTest {
                                         .name("name")
                         )));
         when(arrangementMapper.mapIntegrationToStream(any()))
-                .thenReturn(new com.backbase.dbs.arrangement.api.service.v2.model.AccountArrangementItemPut());
+                .thenReturn(new com.backbase.dbs.arrangement.api.service.v3.model.ArrangementPutItem());
 
         Mono<ArrangementIngestResponse> responseMono = arrangementIntegrationService.pullArrangement(request);
 

--- a/stream-compositions/services/product-composition-service/src/test/java/com/backbase/stream/compositions/product/http/ProductControllerIT.java
+++ b/stream-compositions/services/product-composition-service/src/test/java/com/backbase/stream/compositions/product/http/ProductControllerIT.java
@@ -1,6 +1,6 @@
 package com.backbase.stream.compositions.product.http;
 
-import com.backbase.dbs.arrangement.api.service.v2.model.AccountArrangementItemPut;
+import com.backbase.dbs.arrangement.api.service.v3.model.ArrangementPutItem;
 import com.backbase.stream.compositions.paymentorder.client.model.PaymentOrderIngestionResponse;
 import com.backbase.stream.compositions.paymentorder.client.model.PaymentOrderPostResponse;
 import com.backbase.stream.compositions.product.api.model.ArrangementPullIngestionRequest;
@@ -220,7 +220,7 @@ class ProductControllerIT extends IntegrationTest {
     @Test
     void pullIngestArrangement_Success() throws Exception {
         when(arrangementService.updateArrangement(any()))
-                .thenReturn(Mono.just(new AccountArrangementItemPut()));
+                .thenReturn(Mono.just(new ArrangementPutItem()));
 
         ArrangementPullIngestionRequest pullIngestionRequest =
                 new ArrangementPullIngestionRequest()
@@ -266,7 +266,7 @@ class ProductControllerIT extends IntegrationTest {
                 mapper.treeToValue(node, com.backbase.stream.compositions.product.api.model.AccountArrangementItemPut.class);
 
         when(arrangementService.updateArrangement(any()))
-                .thenReturn(Mono.just(new AccountArrangementItemPut()));
+                .thenReturn(Mono.just(new ArrangementPutItem()));
 
         ArrangementPushIngestionRequest pushIngestionRequest =
                 new ArrangementPushIngestionRequest()

--- a/stream-cursor/cursor-publishers/src/main/java/com/backbase/stream/cursor/events/AbstractLoginEventListener.java
+++ b/stream-cursor/cursor-publishers/src/main/java/com/backbase/stream/cursor/events/AbstractLoginEventListener.java
@@ -1,6 +1,6 @@
 package com.backbase.stream.cursor.events;
 
-import com.backbase.dbs.arrangement.api.service.v2.model.AccountArrangementItem;
+import com.backbase.dbs.arrangement.api.service.v3.model.ArrangementItem;
 import com.backbase.stream.TransactionService;
 import com.backbase.stream.cursor.configuration.CursorServiceConfigurationProperties;
 import com.backbase.stream.cursor.model.IngestionCursor;
@@ -85,10 +85,10 @@ public class AbstractLoginEventListener {
         List<IngestionCursor> ingestionCursors = new ArrayList<>();
         ProductGroup.ProductGroupTypeEnum arrangements1 = ProductGroup.ProductGroupTypeEnum.ARRANGEMENTS;
         Object arrangements = assignedPermission.getPermittedObjects().get(arrangements1.name());
-        if (arrangements instanceof List && (((List) arrangements).get(0) instanceof AccountArrangementItem)) {
-            List<AccountArrangementItem> products = (List<AccountArrangementItem>) arrangements;
+        if (arrangements instanceof List && (((List<?>) arrangements).getFirst() instanceof ArrangementItem)) {
+            @SuppressWarnings("unchecked") List<ArrangementItem> products = (List<ArrangementItem>) arrangements;
 
-            for (AccountArrangementItem product : products) {
+            for (ArrangementItem product : products) {
 
                 IngestionCursor ingestionCursor = createLoginIngestionCursor(loginEvent, user, legalEntity);
 

--- a/stream-dbs-clients/pom.xml
+++ b/stream-dbs-clients/pom.xml
@@ -257,9 +257,22 @@
                         <phase>generate-sources</phase>
                         <configuration>
                             <openapiNormalizer>REFACTOR_ALLOF_WITH_PROPERTIES_ONLY=true</openapiNormalizer>
-                            <inputSpec>${project.build.directory}/yaml/arrangement-manager/arrangement-service-api-v2*.yaml</inputSpec>
-                            <apiPackage>com.backbase.dbs.arrangement.api.service.v2</apiPackage>
-                            <modelPackage>com.backbase.dbs.arrangement.api.service.v2.model</modelPackage>
+                            <inputSpec>${project.build.directory}/yaml/arrangement-manager/arrangement-service-api-v3*.yaml</inputSpec>
+                            <apiPackage>com.backbase.dbs.arrangement.api.service.v3</apiPackage>
+                            <modelPackage>com.backbase.dbs.arrangement.api.service.v3.model</modelPackage>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>generate-arrangement-manager-integration-api-code</id>
+                        <goals>
+                            <goal>generate-webclient-embedded</goal>
+                        </goals>
+                        <phase>generate-sources</phase>
+                        <configuration>
+                            <openapiNormalizer>REFACTOR_ALLOF_WITH_PROPERTIES_ONLY=true</openapiNormalizer>
+                            <inputSpec>${project.build.directory}/yaml/arrangement-manager/arrangement-integration-inbound-api-v2*.yaml</inputSpec>
+                            <apiPackage>com.backbase.dbs.arrangement.api.integration.v2</apiPackage>
+                            <modelPackage>com.backbase.dbs.arrangement.api.integration.v2.model</modelPackage>
                         </configuration>
                     </execution>
                     <execution>

--- a/stream-dbs-clients/src/main/java/com/backbase/stream/clients/config/ArrangementManagerClientConfig.java
+++ b/stream-dbs-clients/src/main/java/com/backbase/stream/clients/config/ArrangementManagerClientConfig.java
@@ -1,9 +1,9 @@
 package com.backbase.stream.clients.config;
 
 import com.backbase.dbs.arrangement.api.service.ApiClient;
-import com.backbase.dbs.arrangement.api.service.v2.ArrangementsApi;
-import com.backbase.dbs.arrangement.api.service.v2.ProductKindsApi;
-import com.backbase.dbs.arrangement.api.service.v2.ProductsApi;
+import com.backbase.dbs.arrangement.api.service.v3.ArrangementsApi;
+import com.backbase.dbs.arrangement.api.service.v3.ProductKindsApi;
+import com.backbase.dbs.arrangement.api.service.v3.ProductsApi;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.text.DateFormat;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -30,8 +30,21 @@ public class ArrangementManagerClientConfig extends CompositeApiClientConfig {
 
     @Bean
     @ConditionalOnMissingBean
+    public com.backbase.dbs.arrangement.api.integration.ApiClient arrangementApiIntegrationClient(ObjectMapper objectMapper, DateFormat dateFormat) {
+        return new com.backbase.dbs.arrangement.api.integration.ApiClient(getWebClient(), objectMapper, dateFormat)
+            .setBasePath(createBasePath());
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
     public ArrangementsApi arrangementsApi(ApiClient arrangementManagerApiClient) {
         return new ArrangementsApi(arrangementManagerApiClient);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public com.backbase.dbs.arrangement.api.integration.v2.ArrangementsApi arrangementApiIntegration(com.backbase.dbs.arrangement.api.integration.ApiClient arrangementManagerIntegrationApiClient) {
+        return new com.backbase.dbs.arrangement.api.integration.v2.ArrangementsApi(arrangementManagerIntegrationApiClient);
     }
 
     @Bean

--- a/stream-legal-entity/legal-entity-bootstrap-task/src/test/resources/mappings/create-arrangements.json
+++ b/stream-legal-entity/legal-entity-bootstrap-task/src/test/resources/mappings/create-arrangements.json
@@ -1,7 +1,7 @@
 {
   "request": {
     "method": "POST",
-    "url": "/arrangement-manager/service-api/v2/arrangements/batch",
+    "url": "/arrangement-manager/integration-api/v2/arrangements/batch",
     "headers": {
       "X-B3-TraceId": {
         "matches": "[\\w-]+"
@@ -18,19 +18,22 @@
     "status": 207,
     "jsonBody": [
       {
-        "resourceId": "021000021",
-        "arrangementId": "arrangement-id",
-        "status": 200
+        "arrangementId" : "arrangement-id",
+        "action" : "add",
+        "resourceId" : "021000021",
+        "status" : "200"
       },
       {
-        "resourceId": "021000022",
-        "arrangementId": "arrangement-id",
-        "status": 200
+        "arrangementId" : "arrangement-id",
+        "action" : "add",
+        "resourceId" : "021000022",
+        "status" : "200"
       },
       {
-        "resourceId": "021000023",
-        "arrangementId": "arrangement-id",
-        "status": 200
+        "arrangementId" : "arrangement-id",
+        "action" : "add",
+        "resourceId" : "021000023",
+        "status" : "200"
       }
     ],
     "headers": {

--- a/stream-legal-entity/legal-entity-core/src/test/java/com/backbase/stream/UpdatedServiceAgreementSagaTest.java
+++ b/stream-legal-entity/legal-entity-core/src/test/java/com/backbase/stream/UpdatedServiceAgreementSagaTest.java
@@ -8,7 +8,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.backbase.dbs.accesscontrol.api.service.v3.model.FunctionGroupItem;
-import com.backbase.dbs.arrangement.api.service.v2.model.AccountArrangementItem;
+import com.backbase.dbs.arrangement.api.service.v3.model.ArrangementItem;
 import com.backbase.dbs.user.api.service.v2.model.GetUser;
 import com.backbase.stream.legalentity.model.BaseProductGroup;
 import com.backbase.stream.legalentity.model.BatchProductGroup;
@@ -108,7 +108,7 @@ class UpdatedServiceAgreementSagaTest {
 
         when(arrangementService.getArrangementByExternalId(ArgumentMatchers.<List<String>>any()))
             .thenReturn(Flux.fromIterable(
-                Collections.singletonList(new AccountArrangementItem().id(loanInId).externalArrangementId(loanExId))));
+                Collections.singletonList(new ArrangementItem().id(loanInId).externalArrangementId(loanExId))));
 
 
         UpdatedServiceAgreementTask actual = updatedServiceAgreementSaga.executeTask(task).block();

--- a/stream-legal-entity/legal-entity-http/src/test/java/com/backbase/stream/controller/ServiceAgreementControllerTest.java
+++ b/stream-legal-entity/legal-entity-http/src/test/java/com/backbase/stream/controller/ServiceAgreementControllerTest.java
@@ -9,7 +9,7 @@ import static org.mockito.Mockito.when;
 
 import com.backbase.dbs.accesscontrol.api.service.v3.LegalEntitiesApi;
 import com.backbase.dbs.accesscontrol.api.service.v3.model.FunctionGroupItem;
-import com.backbase.dbs.arrangement.api.service.v2.ArrangementsApi;
+import com.backbase.dbs.arrangement.api.service.v3.ArrangementsApi;
 import com.backbase.dbs.contact.api.service.v2.ContactsApi;
 import com.backbase.dbs.limit.api.service.v2.LimitsServiceApi;
 import com.backbase.dbs.user.api.service.v2.IdentityManagementApi;
@@ -109,7 +109,10 @@ class ServiceAgreementControllerTest {
     private com.backbase.dbs.user.profile.api.service.v2.UserProfileManagementApi userProfileManagement;
 
     @MockBean
-    private ArrangementsApi arrangementsApi;
+    private ArrangementsApi arrangementsApiV3;
+
+    @MockBean
+    private com.backbase.dbs.arrangement.api.integration.v2.ArrangementsApi arrangementsApi;
 
     @MockBean
     private UserKindSegmentationSaga userKindSegmentationSaga;

--- a/stream-legal-entity/legal-entity-http/src/test/java/com/backbase/stream/it/LegalEntitySagaIT.java
+++ b/stream-legal-entity/legal-entity-http/src/test/java/com/backbase/stream/it/LegalEntitySagaIT.java
@@ -263,7 +263,7 @@ class LegalEntitySagaIT {
         );
 
         stubFor(
-            WireMock.post("/arrangement-manager/service-api/v2/arrangements/batch")
+            WireMock.post("/arrangement-manager/integration-api/v2/arrangements/batch")
                 .willReturn(WireMock.aResponse().withStatus(HttpStatus.ACCEPTED.value()))
         );
 

--- a/stream-payment-order/payment-order-core/src/main/java/com/backbase/stream/config/PaymentOrderServiceConfiguration.java
+++ b/stream-payment-order/payment-order-core/src/main/java/com/backbase/stream/config/PaymentOrderServiceConfiguration.java
@@ -1,6 +1,6 @@
 package com.backbase.stream.config;
 
-import com.backbase.dbs.arrangement.api.service.v2.ArrangementsApi;
+import com.backbase.dbs.arrangement.api.service.v3.ArrangementsApi;
 import com.backbase.dbs.paymentorder.api.service.v3.PaymentOrdersApi;
 import com.backbase.stream.PaymentOrderService;
 import com.backbase.stream.PaymentOrderServiceImpl;

--- a/stream-payment-order/payment-order-core/src/main/java/com/backbase/stream/model/PaymentOrderIngestContext.java
+++ b/stream-payment-order/payment-order-core/src/main/java/com/backbase/stream/model/PaymentOrderIngestContext.java
@@ -1,12 +1,10 @@
 package com.backbase.stream.model;
 
-import com.backbase.dbs.arrangement.api.service.v2.model.AccountArrangementItems;
-import java.util.ArrayList;
-import java.util.List;
-
+import com.backbase.dbs.arrangement.api.service.v3.model.ArrangementSearchesListResponse;
 import com.backbase.dbs.paymentorder.api.service.v3.model.GetPaymentOrderResponse;
 import com.backbase.dbs.paymentorder.api.service.v3.model.PaymentOrderPostRequest;
-
+import java.util.ArrayList;
+import java.util.List;
 import lombok.Data;
 import lombok.experimental.Accessors;
 
@@ -17,5 +15,5 @@ public class PaymentOrderIngestContext {
     private String internalUserId;
     private List<PaymentOrderPostRequest> corePaymentOrder = new ArrayList<>();
     private List<GetPaymentOrderResponse> existingPaymentOrder = new ArrayList<>();
-    private List<AccountArrangementItems> arrangementIds = new ArrayList<>();
+    private List<ArrangementSearchesListResponse> arrangementIds = new ArrayList<>();
 }

--- a/stream-payment-order/payment-order-core/src/test/java/com/backbase/stream/task/PaymentOrderUnitOfWorkExecutorTest.java
+++ b/stream-payment-order/payment-order-core/src/test/java/com/backbase/stream/task/PaymentOrderUnitOfWorkExecutorTest.java
@@ -5,10 +5,12 @@ import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.when;
+import static reactor.core.publisher.Mono.just;
 
-import com.backbase.dbs.arrangement.api.service.v2.ArrangementsApi;
-import com.backbase.dbs.arrangement.api.service.v2.model.AccountArrangementItem;
-import com.backbase.dbs.arrangement.api.service.v2.model.AccountArrangementItems;
+import com.backbase.dbs.arrangement.api.service.v3.ArrangementsApi;
+import com.backbase.dbs.arrangement.api.service.v3.model.ArrangementItem;
+import com.backbase.dbs.arrangement.api.service.v3.model.ArrangementSearchesListResponse;
 import com.backbase.dbs.paymentorder.api.service.v3.PaymentOrdersApi;
 import com.backbase.dbs.paymentorder.api.service.v3.model.GetPaymentOrderResponse;
 import com.backbase.dbs.paymentorder.api.service.v3.model.PaymentOrderPostFilterResponse;
@@ -79,15 +81,14 @@ public class PaymentOrderUnitOfWorkExecutorTest extends PaymentOrderBaseTest {
         lenient().when(paymentOrdersApi.postPaymentOrder(Mockito.any()))
                 .thenReturn(Mono.just(paymentOrderPostResponse));
 
-        AccountArrangementItem accountArrangementItem = new AccountArrangementItem()
+        ArrangementItem arrangementItem = new ArrangementItem()
                 .id("arrangementId_1")
                 .externalArrangementId("externalArrangementId_1");
 
-        AccountArrangementItems accountArrangementItems = new AccountArrangementItems()
-                .addArrangementElementsItem(accountArrangementItem);
+        ArrangementSearchesListResponse arrangementSearchesListResponse = new ArrangementSearchesListResponse()
+            .addArrangementElementsItem(arrangementItem);
 
-        lenient().when(arrangementsApi.postFilter(Mockito.any()))
-                .thenReturn(Mono.just(accountArrangementItems));
+        lenient().when(arrangementsApi.postSearchArrangements(any())).thenReturn(just(arrangementSearchesListResponse));
 
         StepVerifier.create(paymentOrderUnitOfWorkExecutor.prepareUnitOfWork(paymentOrderIngestRequestList))
                 .assertNext(unitOfWork -> {
@@ -107,7 +108,7 @@ public class PaymentOrderUnitOfWorkExecutorTest extends PaymentOrderBaseTest {
                 .id("po_post_resp_id");
 
         lenient().when(paymentOrdersApi.postPaymentOrder(any()))
-                .thenReturn(Mono.just(paymentOrderPostResponse));
+                .thenReturn(just(paymentOrderPostResponse));
 
         GetPaymentOrderResponse getPaymentOrderResponse = new GetPaymentOrderResponse()
                 .id("arrangementId_1")
@@ -116,16 +117,15 @@ public class PaymentOrderUnitOfWorkExecutorTest extends PaymentOrderBaseTest {
                 .addPaymentOrdersItem(getPaymentOrderResponse)
                 .totalElements(new BigDecimal(1));
 
-        doReturn(Mono.just(paymentOrderPostFilterResponse)).when(paymentOrdersApi).postFilterPaymentOrders(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any());
+        doReturn(just(paymentOrderPostFilterResponse)).when(paymentOrdersApi).postFilterPaymentOrders(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any());
 
-        AccountArrangementItem accountArrangementItem = new AccountArrangementItem()
+        ArrangementItem accountArrangementItem = new ArrangementItem()
                 .id("arrangementId_1")
                 .externalArrangementId("externalArrangementId_1");
-        AccountArrangementItems accountArrangementItems = new AccountArrangementItems()
-                .addArrangementElementsItem(accountArrangementItem);
 
-        Mockito.when(arrangementsApi.postFilter(Mockito.any()))
-                .thenReturn(Mono.just(accountArrangementItems));
+        ArrangementSearchesListResponse arrangementSearchesListResponse = new ArrangementSearchesListResponse();
+        arrangementSearchesListResponse.addArrangementElementsItem(accountArrangementItem);
+        when(arrangementsApi.postSearchArrangements(any())).thenReturn(just(arrangementSearchesListResponse));
 
         StepVerifier.create(paymentOrderUnitOfWorkExecutor.prepareUnitOfWork(paymentOrderPostRequestFlux))
             .assertNext(unitOfWork -> {
@@ -149,14 +149,14 @@ public class PaymentOrderUnitOfWorkExecutorTest extends PaymentOrderBaseTest {
 
         Flux<PaymentOrderPostRequest> paymentOrderPostRequestFlux = Flux.fromIterable(paymentOrderPostRequest);
 
-        AccountArrangementItem accountArrangementItem = new AccountArrangementItem()
+        ArrangementItem arrangementItem = new ArrangementItem()
                 .id("arrangementId_1")
                 .externalArrangementId("externalArrangementId_1");
-        AccountArrangementItems accountArrangementItems = new AccountArrangementItems()
-                .addArrangementElementsItem(accountArrangementItem);
 
-        lenient().when(arrangementsApi.postFilter(Mockito.any()))
-                .thenReturn(Mono.just(accountArrangementItems));
+        ArrangementSearchesListResponse arrangementSearchesListResponse = new ArrangementSearchesListResponse();
+        arrangementSearchesListResponse.addArrangementElementsItem(arrangementItem);
+
+        lenient().when(arrangementsApi.postSearchArrangements(any())).thenReturn(just(arrangementSearchesListResponse));
 
         GetPaymentOrderResponse getPaymentOrderResponseWithEmptyUserId = new GetPaymentOrderResponse()
                 .id("arrangementId_1");
@@ -165,7 +165,7 @@ public class PaymentOrderUnitOfWorkExecutorTest extends PaymentOrderBaseTest {
                 .addPaymentOrdersItem(getPaymentOrderResponseWithEmptyUserId)
                 .totalElements(new BigDecimal(1));
 
-        lenient().doReturn(Mono.just(paymentOrderPostFilterResponse)).when(paymentOrdersApi).postFilterPaymentOrders(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any());
+        lenient().doReturn(just(paymentOrderPostFilterResponse)).when(paymentOrdersApi).postFilterPaymentOrders(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any());
 
         StepVerifier
                 .create(paymentOrderUnitOfWorkExecutor.prepareUnitOfWork(paymentOrderPostRequestFlux))

--- a/stream-product-catalog/product-catalog-core/src/main/java/com/backbase/stream/productcatalog/configuration/ProductCatalogServiceConfiguration.java
+++ b/stream-product-catalog/product-catalog-core/src/main/java/com/backbase/stream/productcatalog/configuration/ProductCatalogServiceConfiguration.java
@@ -1,7 +1,7 @@
 package com.backbase.stream.productcatalog.configuration;
 
-import com.backbase.dbs.arrangement.api.service.v2.ProductKindsApi;
-import com.backbase.dbs.arrangement.api.service.v2.ProductsApi;
+import com.backbase.dbs.arrangement.api.service.v3.ProductKindsApi;
+import com.backbase.dbs.arrangement.api.service.v3.ProductsApi;
 import com.backbase.stream.productcatalog.ProductCatalogService;
 import com.backbase.stream.productcatalog.ReactiveProductCatalogService;
 import org.springframework.context.annotation.Bean;

--- a/stream-product-catalog/product-catalog-core/src/main/java/com/backbase/stream/productcatalog/mapper/ProductCatalogMapper.java
+++ b/stream-product-catalog/product-catalog-core/src/main/java/com/backbase/stream/productcatalog/mapper/ProductCatalogMapper.java
@@ -1,11 +1,10 @@
 package com.backbase.stream.productcatalog.mapper;
 
 
-import com.backbase.dbs.arrangement.api.service.v2.model.AccountProductItem;
-import com.backbase.dbs.arrangement.api.service.v2.model.AccountSchemasProductItem;
-import com.backbase.dbs.arrangement.api.service.v2.model.ExternalProductKindItemExtended;
-import com.backbase.dbs.arrangement.api.service.v2.model.ExternalProductKindItemPut;
-import com.backbase.dbs.arrangement.api.service.v2.model.ProductKindItem;
+import com.backbase.dbs.arrangement.api.service.v3.model.ArrangementProductItemBase;
+import com.backbase.dbs.arrangement.api.service.v3.model.ArrangementProductsListElement;
+import com.backbase.dbs.arrangement.api.service.v3.model.ExternalProductKindItemExtended;
+import com.backbase.dbs.arrangement.api.service.v3.model.ProductKindItem;
 import com.backbase.stream.productcatalog.model.ProductKind;
 import com.backbase.stream.productcatalog.model.ProductType;
 import org.mapstruct.Mapper;
@@ -13,21 +12,14 @@ import org.mapstruct.Mapper;
 @Mapper
 public interface ProductCatalogMapper {
 
-    AccountProductItem toPresentation(ProductType productType);
+    ArrangementProductItemBase toPresentation(ProductType productType);
 
     ExternalProductKindItemExtended toPresentation(ProductKind productKind);
 
     ProductKind toStream(ProductKindItem productKindItem);
 
-    ExternalProductKindItemPut toPutPresentation(ExternalProductKindItemExtended productKindItem);
-
-    ExternalProductKindItemExtended toStream(ExternalProductKindItemPut productKindItem);
-
     ProductKind toStream(ExternalProductKindItemExtended presentationProductKindItemGet);
 
-    /*ProductKind toStream(ProductKindItem productKindItem);*/
-
-    ProductType toStream(AccountSchemasProductItem productItem);
-
+    ProductType toStream(ArrangementProductsListElement arrangementProductsListElement);
 
 }

--- a/stream-product-catalog/product-catalog-task/src/test/resources/mappings/arrangement-manager-stubs.json
+++ b/stream-product-catalog/product-catalog-task/src/test/resources/mappings/arrangement-manager-stubs.json
@@ -2,13 +2,13 @@
   "mappings": [
     {
       "id": "ec55d9b3-ff28-4aec-9310-a57b8120d615",
-      "name": "service-api_v2_products",
+      "name": "service-api_v3_products",
       "request": {
-        "url": "/service-api/v2/products",
+        "url": "/service-api/v3/products",
         "method": "POST",
         "bodyPatterns": [
           {
-            "equalToJson": "{\"externalId\":null,\"externalTypeId\":null,\"typeName\":\"Savings Accounts\",\"externalProductId\":\"savings-account\",\"externalProductKindId\":\"kind2\",\"productKindName\":\"Savings Account\",\"externalProductTypeId\":null,\"productTypeName\":\"Savings Accounts\",\"productKind\":null}",
+            "equalToJson": "{\"externalId\":null,\"externalTypeId\":null,\"typeName\":\"Savings Accounts\",\"externalProductId\":\"savings-account\",\"externalProductKindId\":\"kind2\",\"productKindName\":\"Savings Account\",\"externalProductTypeId\":null,\"productTypeName\":\"savings-account\",\"productKind\":null,\"translations\":[],\"additions\":{}}",
             "ignoreArrayOrder": true,
             "ignoreExtraElements": true
           }
@@ -37,13 +37,13 @@
     },
     {
       "id": "cf183288-e389-4287-bbb3-309889d699c2",
-      "name": "service-api_v2_products",
+      "name": "service-api_v3_products",
       "request": {
-        "url": "/service-api/v2/products",
+        "url": "/service-api/v3/products",
         "method": "POST",
         "bodyPatterns": [
           {
-            "equalToJson": "{\"externalId\":null,\"externalTypeId\":null,\"typeName\":\"Current Account\",\"externalProductId\":\"current-account\",\"externalProductKindId\":\"kind1\",\"productKindName\":\"Current Account\",\"externalProductTypeId\":null,\"productTypeName\":\"Current Account\",\"productKind\":null}",
+            "equalToJson": "{\"externalId\":null,\"externalTypeId\":null,\"typeName\":\"Current Account\",\"externalProductId\":\"current-account\",\"externalProductKindId\":\"kind1\",\"productKindName\":\"Current Account\",\"externalProductTypeId\":null,\"productTypeName\":\"current-account\",\"productKind\":null,\"translations\":[],\"additions\":{}}",
             "ignoreArrayOrder": true,
             "ignoreExtraElements": true
           }
@@ -72,14 +72,14 @@
     },
     {
       "id": "48f1fc4a-545f-4812-9a3e-0358a89cc490",
-      "name": "service-api_v2_product-kinds",
+      "name": "service-api_v3_product-kinds",
       "request": {
-        "url": "/service-api/v2/product-kinds",
+        "url": "/service-api/v3/product-kinds",
         "method": "GET"
       },
       "response": {
         "status": 200,
-        "body": "{\"productKinds\":[{\"id\":1,\"externalKindId\":\"kind1\",\"kindName\":\"Current Account\",\"kindUri\":\"current-account\",\"translations\":[]},{\"id\":2,\"externalKindId\":\"kind2\",\"kindName\":\"Savings Account\",\"kindUri\":\"savings-account\",\"translations\":[]},{\"id\":3,\"externalKindId\":\"kind3\",\"kindName\":\"Debit Card\",\"kindUri\":\"debit-card\",\"translations\":[]},{\"id\":4,\"externalKindId\":\"kind4\",\"kindName\":\"Credit Card\",\"kindUri\":\"credit-card\",\"translations\":[]},{\"id\":5,\"externalKindId\":\"kind5\",\"kindName\":\"Loan\",\"kindUri\":\"loan\",\"translations\":[]},{\"id\":6,\"externalKindId\":\"kind6\",\"kindName\":\"Term Deposit\",\"kindUri\":\"term-deposit\",\"translations\":[]},{\"id\":7,\"externalKindId\":\"kind7\",\"kindName\":\"Investment Account\",\"kindUri\":\"investment-account\",\"translations\":[]},{\"id\":8,\"externalKindId\":\"kind8\",\"kindName\":\"Pocket Parent\",\"kindUri\":\"pocket-parent\",\"translations\":[]},{\"id\":9,\"externalKindId\":\"kind9\",\"kindName\":\"Pocket\",\"kindUri\":\"pocket\",\"translations\":[]}]}",
+        "body": "{\"productKindElements\":[{\"id\":1,\"externalKindId\":\"kind1\",\"kindName\":\"Current Account\",\"kindUri\":\"current-account\",\"translations\":[]},{\"id\":2,\"externalKindId\":\"kind2\",\"kindName\":\"Savings Account\",\"kindUri\":\"savings-account\",\"translations\":[]},{\"id\":3,\"externalKindId\":\"kind3\",\"kindName\":\"Debit Card\",\"kindUri\":\"debit-card\",\"translations\":[]},{\"id\":4,\"externalKindId\":\"kind4\",\"kindName\":\"Credit Card\",\"kindUri\":\"credit-card\",\"translations\":[]},{\"id\":5,\"externalKindId\":\"kind5\",\"kindName\":\"Loan\",\"kindUri\":\"loan\",\"translations\":[]},{\"id\":6,\"externalKindId\":\"kind6\",\"kindName\":\"Term Deposit\",\"kindUri\":\"term-deposit\",\"translations\":[]},{\"id\":7,\"externalKindId\":\"kind7\",\"kindName\":\"Investment Account\",\"kindUri\":\"investment-account\",\"translations\":[]},{\"id\":8,\"externalKindId\":\"kind8\",\"kindName\":\"Pocket Parent\",\"kindUri\":\"pocket-parent\",\"translations\":[]},{\"id\":9,\"externalKindId\":\"kind9\",\"kindName\":\"Pocket\",\"kindUri\":\"pocket\",\"translations\":[]}]}",
         "headers": {
           "x-content-type-options": "nosniff",
           "x-xss-protection": "1; mode=block",
@@ -100,14 +100,14 @@
     },
     {
       "id": "bb6a3fa4-2612-479b-8e76-a02d2fbb1b47",
-      "name": "service-api_v2_products",
+      "name": "service-api_v3_products",
       "request": {
-        "url": "/service-api/v2/products",
+        "url": "/service-api/v3/products",
         "method": "GET"
       },
       "response": {
         "status": 200,
-        "body": "[{\"externalId\":\"default-pocket-external-id\",\"typeName\":\"Pocket\",\"externalProductId\":\"default-pocket-external-id\",\"externalProductKindId\":\"kind9\",\"productKindName\":\"Pocket\",\"productTypeName\":\"Pocket\",\"productKind\":{\"externalKindId\":\"kind9\",\"kindName\":\"Pocket\",\"kindUri\":\"pocket\",\"translations\":[]},\"translations\":[],\"id\":\"5e493bca-4f58-4593-90b8-c2dfde2d1620\"},{\"externalId\":\"default-pocket-parent-external-id\",\"typeName\":\"Pocket Parent\",\"externalProductId\":\"default-pocket-parent-external-id\",\"externalProductKindId\":\"kind8\",\"productKindName\":\"Pocket Parent\",\"productTypeName\":\"Pocket Parent\",\"productKind\":{\"externalKindId\":\"kind8\",\"kindName\":\"Pocket Parent\",\"kindUri\":\"pocket-parent\",\"translations\":[]},\"translations\":[],\"id\":\"c55edc8b-ceef-439b-b637-ee9bc74f91e4\"}]",
+        "body": "{\"arrangementProductElements\":[{\"externalId\":\"default-pocket-external-id\",\"typeName\":\"Pocket\",\"externalProductId\":\"default-pocket-external-id\",\"externalProductKindId\":\"kind9\",\"productKindName\":\"Pocket\",\"productTypeName\":\"Pocket\",\"productKind\":{\"externalKindId\":\"kind9\",\"kindName\":\"Pocket\",\"kindUri\":\"pocket\",\"translations\":[]},\"translations\":[],\"id\":\"5e493bca-4f58-4593-90b8-c2dfde2d1620\"},{\"externalId\":\"default-pocket-parent-external-id\",\"typeName\":\"Pocket Parent\",\"externalProductId\":\"default-pocket-parent-external-id\",\"externalProductKindId\":\"kind8\",\"productKindName\":\"Pocket Parent\",\"productTypeName\":\"Pocket Parent\",\"productKind\":{\"externalKindId\":\"kind8\",\"kindName\":\"Pocket Parent\",\"kindUri\":\"pocket-parent\",\"translations\":[]},\"translations\":[],\"id\":\"c55edc8b-ceef-439b-b637-ee9bc74f91e4\"}]}",
         "headers": {
           "x-content-type-options": "nosniff",
           "x-xss-protection": "1; mode=block",
@@ -128,14 +128,14 @@
     },
     {
       "id": "13f4e38d-071d-4670-9308-e7a7760434d6",
-      "name": "service-api_v2_product-kinds",
+      "name": "service-api_v3_product-kinds",
       "request": {
-        "url": "/service-api/v2/product-kinds",
+        "url": "/service-api/v3/product-kinds",
         "method": "GET"
       },
       "response": {
         "status": 200,
-        "body": "{\"productKinds\":[{\"id\":1,\"externalKindId\":\"kind1\",\"kindName\":\"Current Account\",\"kindUri\":\"current-account\",\"translations\":[]},{\"id\":2,\"externalKindId\":\"kind2\",\"kindName\":\"Savings Account\",\"kindUri\":\"savings-account\",\"translations\":[]},{\"id\":3,\"externalKindId\":\"kind3\",\"kindName\":\"Debit Card\",\"kindUri\":\"debit-card\",\"translations\":[]},{\"id\":4,\"externalKindId\":\"kind4\",\"kindName\":\"Credit Card\",\"kindUri\":\"credit-card\",\"translations\":[]},{\"id\":5,\"externalKindId\":\"kind5\",\"kindName\":\"Loan\",\"kindUri\":\"loan\",\"translations\":[]},{\"id\":6,\"externalKindId\":\"kind6\",\"kindName\":\"Term Deposit\",\"kindUri\":\"term-deposit\",\"translations\":[]},{\"id\":7,\"externalKindId\":\"kind7\",\"kindName\":\"Investment Account\",\"kindUri\":\"investment-account\",\"translations\":[]},{\"id\":8,\"externalKindId\":\"kind8\",\"kindName\":\"Pocket Parent\",\"kindUri\":\"pocket-parent\",\"translations\":[]},{\"id\":9,\"externalKindId\":\"kind9\",\"kindName\":\"Pocket\",\"kindUri\":\"pocket\",\"translations\":[]}]}",
+        "body": "{\"productKindElements\":[{\"id\":1,\"externalKindId\":\"kind1\",\"kindName\":\"Current Account\",\"kindUri\":\"current-account\",\"translations\":[]},{\"id\":2,\"externalKindId\":\"kind2\",\"kindName\":\"Savings Account\",\"kindUri\":\"savings-account\",\"translations\":[]},{\"id\":3,\"externalKindId\":\"kind3\",\"kindName\":\"Debit Card\",\"kindUri\":\"debit-card\",\"translations\":[]},{\"id\":4,\"externalKindId\":\"kind4\",\"kindName\":\"Credit Card\",\"kindUri\":\"credit-card\",\"translations\":[]},{\"id\":5,\"externalKindId\":\"kind5\",\"kindName\":\"Loan\",\"kindUri\":\"loan\",\"translations\":[]},{\"id\":6,\"externalKindId\":\"kind6\",\"kindName\":\"Term Deposit\",\"kindUri\":\"term-deposit\",\"translations\":[]},{\"id\":7,\"externalKindId\":\"kind7\",\"kindName\":\"Investment Account\",\"kindUri\":\"investment-account\",\"translations\":[]},{\"id\":8,\"externalKindId\":\"kind8\",\"kindName\":\"Pocket Parent\",\"kindUri\":\"pocket-parent\",\"translations\":[]},{\"id\":9,\"externalKindId\":\"kind9\",\"kindName\":\"Pocket\",\"kindUri\":\"pocket\",\"translations\":[]}]}",
         "headers": {
           "x-content-type-options": "nosniff",
           "x-xss-protection": "1; mode=block",

--- a/stream-product/product-core/src/main/java/com/backbase/stream/product/configuration/ProductConfiguration.java
+++ b/stream-product/product-core/src/main/java/com/backbase/stream/product/configuration/ProductConfiguration.java
@@ -1,7 +1,7 @@
 package com.backbase.stream.product.configuration;
 
 
-import com.backbase.dbs.arrangement.api.service.v2.ArrangementsApi;
+import com.backbase.dbs.arrangement.api.service.v3.ArrangementsApi;
 import com.backbase.stream.product.service.ArrangementService;
 import lombok.AllArgsConstructor;
 import org.springframework.context.annotation.Bean;
@@ -15,8 +15,9 @@ import org.springframework.context.annotation.Configuration;
 public class ProductConfiguration {
 
     @Bean
-    public ArrangementService arrangementService(ArrangementsApi arrangementsApi) {
-        return new ArrangementService(arrangementsApi);
+    public ArrangementService arrangementService(ArrangementsApi arrangementsApi,
+        com.backbase.dbs.arrangement.api.integration.v2.ArrangementsApi arrangementsIntegrationApi) {
+        return new ArrangementService(arrangementsApi, arrangementsIntegrationApi);
     }
 
 }

--- a/stream-product/product-core/src/main/java/com/backbase/stream/product/mapping/ProductMapper.java
+++ b/stream-product/product-core/src/main/java/com/backbase/stream/product/mapping/ProductMapper.java
@@ -1,11 +1,11 @@
 package com.backbase.stream.product.mapping;
 
-import com.backbase.dbs.arrangement.api.service.v2.model.AccountArrangementItem;
-import com.backbase.dbs.arrangement.api.service.v2.model.AccountArrangementItemBase;
-import com.backbase.dbs.arrangement.api.service.v2.model.AccountArrangementItemPost;
-import com.backbase.dbs.arrangement.api.service.v2.model.AccountArrangementItemPut;
-import com.backbase.dbs.arrangement.api.service.v2.model.AccountUserPreferencesItemPut;
-import com.backbase.dbs.arrangement.api.service.v2.model.TimeUnit;
+import com.backbase.dbs.arrangement.api.integration.v2.model.PostArrangement;
+import com.backbase.dbs.arrangement.api.integration.v2.model.TimeUnit;
+import com.backbase.dbs.arrangement.api.service.v3.model.ArrangementItem;
+import com.backbase.dbs.arrangement.api.service.v3.model.ArrangementItemBase;
+import com.backbase.dbs.arrangement.api.service.v3.model.ArrangementItemPostRequest;
+import com.backbase.dbs.arrangement.api.service.v3.model.ArrangementPutItem;
 import com.backbase.stream.legalentity.model.AvailableBalance;
 import com.backbase.stream.legalentity.model.BaseProduct;
 import com.backbase.stream.legalentity.model.BookedBalance;
@@ -24,7 +24,6 @@ import com.backbase.stream.legalentity.model.Product;
 import com.backbase.stream.legalentity.model.SavingsAccount;
 import com.backbase.stream.legalentity.model.TermDeposit;
 import com.backbase.stream.legalentity.model.TermUnit;
-import com.backbase.stream.legalentity.model.UserPreferences;
 import java.math.BigDecimal;
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
@@ -46,151 +45,147 @@ import org.springframework.util.StringUtils;
 public interface ProductMapper {
 
 
-    @Mapping(source = ProductMapperConstants.EXTERNAL_ID, target = ProductMapperConstants.EXTERNAL_ARRANGEMENT_ID)
-    @Mapping(source = ProductMapperConstants.PRODUCT_TYPE_EXTERNAL_ID, target = ProductMapperConstants.EXTERNAL_PRODUCT_ID)
-    @Mapping(source = ProductMapperConstants.LEGAL_ENTITIES, target = ProductMapperConstants.EXTERNAL_LEGAL_ENTITY_IDS)
-    @Mapping(source = "state.externalStateId", target = ProductMapperConstants.EXTERNAL_STATE_ID)
+    @Mapping(source = ProductMapperConstants.EXTERNAL_ID, target = ProductMapperConstants.ID)
+    @Mapping(source = ProductMapperConstants.PRODUCT_TYPE_EXTERNAL_ID, target = ProductMapperConstants.PRODUCT_ID)
+    @Mapping(source = ProductMapperConstants.LEGAL_ENTITIES, target = ProductMapperConstants.LEGAL_ENTITY_IDS)
+    @Mapping(source = "state.externalStateId", target = ProductMapperConstants.STATE_ID)
     @Mapping(source = ProductMapperConstants.ACCOUNT_HOLDER_NAME, target = ProductMapperConstants.ACCOUNT_HOLDER_NAMES)
-    AccountArrangementItemPost toPresentation(Product product);
+    PostArrangement toPresentation(Product product);
 
 
     @Mapping(source = ProductMapperConstants.EXTERNAL_ID, target = ProductMapperConstants.EXTERNAL_ARRANGEMENT_ID)
     @Mapping(source = ProductMapperConstants.PRODUCT_TYPE_EXTERNAL_ID, target = ProductMapperConstants.EXTERNAL_PRODUCT_ID)
     @Mapping(source = ProductMapperConstants.LEGAL_ENTITIES, target = ProductMapperConstants.EXTERNAL_LEGAL_ENTITY_IDS)
     @Mapping(source = "state.externalStateId", target = ProductMapperConstants.EXTERNAL_STATE_ID)
-    AccountArrangementItemPost toPresentation(BaseProduct product);
+    ArrangementItemPostRequest toPresentation(BaseProduct product);
 
 
-    @Mapping(source = ProductMapperConstants.EXTERNAL_ID, target = ProductMapperConstants.EXTERNAL_ARRANGEMENT_ID)
-    @Mapping(source = ProductMapperConstants.PRODUCT_TYPE_EXTERNAL_ID, target = ProductMapperConstants.EXTERNAL_PRODUCT_ID)
-    @Mapping(source = ProductMapperConstants.LEGAL_ENTITIES, target = ProductMapperConstants.EXTERNAL_LEGAL_ENTITY_IDS)
+    @Mapping(source = ProductMapperConstants.EXTERNAL_ID, target = ProductMapperConstants.ID)
+    @Mapping(source = ProductMapperConstants.PRODUCT_TYPE_EXTERNAL_ID, target = ProductMapperConstants.PRODUCT_ID)
+    @Mapping(source = ProductMapperConstants.LEGAL_ENTITIES, target = ProductMapperConstants.LEGAL_ENTITY_IDS)
     @InheritConfiguration
     @Mapping(source = "debitCardsItems", target = "debitCards")
     @Mapping(source = ProductMapperConstants.ACCOUNT_HOLDER_NAME, target = ProductMapperConstants.ACCOUNT_HOLDER_NAMES)
     @Mapping(source = ProductMapperConstants.PAN_SUFFIX, target = ProductMapperConstants.NUMBER)
-    AccountArrangementItemPost toPresentation(CurrentAccount currentAccount);
+    PostArrangement toPresentation(CurrentAccount currentAccount);
 
 
-    @Mapping(source = ProductMapperConstants.EXTERNAL_ID, target = ProductMapperConstants.EXTERNAL_ARRANGEMENT_ID)
-    @Mapping(source = ProductMapperConstants.PRODUCT_TYPE_EXTERNAL_ID, target = ProductMapperConstants.EXTERNAL_PRODUCT_ID)
-    @Mapping(source = ProductMapperConstants.LEGAL_ENTITIES, target = ProductMapperConstants.EXTERNAL_LEGAL_ENTITY_IDS)
+    @Mapping(source = ProductMapperConstants.EXTERNAL_ID, target = ProductMapperConstants.ID)
+    @Mapping(source = ProductMapperConstants.PRODUCT_TYPE_EXTERNAL_ID, target = ProductMapperConstants.PRODUCT_ID)
+    @Mapping(source = ProductMapperConstants.LEGAL_ENTITIES, target = ProductMapperConstants.LEGAL_ENTITY_IDS)
     @Mapping(source = ProductMapperConstants.DEBIT_CARDS_ITEMS, target = ProductMapperConstants.DEBIT_CARDS)
     @Mapping(source = ProductMapperConstants.ACCOUNT_HOLDER_NAME, target = ProductMapperConstants.ACCOUNT_HOLDER_NAMES)
     @Mapping(source = ProductMapperConstants.PAN_SUFFIX, target = ProductMapperConstants.NUMBER)
     @InheritConfiguration
-    AccountArrangementItemPost toPresentation(SavingsAccount savingsAccount);
+    PostArrangement toPresentation(SavingsAccount savingsAccount);
 
 
-    @Mapping(source = ProductMapperConstants.EXTERNAL_ID, target = ProductMapperConstants.EXTERNAL_ARRANGEMENT_ID)
-    @Mapping(source = ProductMapperConstants.PRODUCT_TYPE_EXTERNAL_ID, target = ProductMapperConstants.EXTERNAL_PRODUCT_ID)
-    @Mapping(source = ProductMapperConstants.LEGAL_ENTITIES, target = ProductMapperConstants.EXTERNAL_LEGAL_ENTITY_IDS)
+    @Mapping(source = ProductMapperConstants.EXTERNAL_ID, target = ProductMapperConstants.ID)
+    @Mapping(source = ProductMapperConstants.PRODUCT_TYPE_EXTERNAL_ID, target = ProductMapperConstants.PRODUCT_ID)
+    @Mapping(source = ProductMapperConstants.LEGAL_ENTITIES, target = ProductMapperConstants.LEGAL_ENTITY_IDS)
     @Mapping(source = ProductMapperConstants.ACCOUNT_HOLDER_NAME, target = ProductMapperConstants.ACCOUNT_HOLDER_NAMES)
     @Mapping(source = "debitCard", qualifiedByName = "mapDebitCardNumber", target = ProductMapperConstants.NUMBER)
     @InheritConfiguration
-    AccountArrangementItemPost toPresentation(DebitCard debitCard);
+    PostArrangement toPresentation(DebitCard debitCard);
 
 
-    @Mapping(source = ProductMapperConstants.EXTERNAL_ID, target = ProductMapperConstants.EXTERNAL_ARRANGEMENT_ID)
-    @Mapping(source = ProductMapperConstants.PRODUCT_TYPE_EXTERNAL_ID, target = ProductMapperConstants.EXTERNAL_PRODUCT_ID)
-    @Mapping(source = ProductMapperConstants.LEGAL_ENTITIES, target = ProductMapperConstants.EXTERNAL_LEGAL_ENTITY_IDS)
+    @Mapping(source = ProductMapperConstants.EXTERNAL_ID, target = ProductMapperConstants.ID)
+    @Mapping(source = ProductMapperConstants.PRODUCT_TYPE_EXTERNAL_ID, target = ProductMapperConstants.PRODUCT_ID)
+    @Mapping(source = ProductMapperConstants.LEGAL_ENTITIES, target = ProductMapperConstants.LEGAL_ENTITY_IDS)
     @Mapping(source = ProductMapperConstants.ACCOUNT_HOLDER_NAME, target = ProductMapperConstants.ACCOUNT_HOLDER_NAMES)
     @Mapping(source = "creditCard", qualifiedByName = "mapCreditCardNumber", target = ProductMapperConstants.NUMBER)
     @InheritConfiguration
-    AccountArrangementItemPost toPresentation(CreditCard creditCard);
+    PostArrangement toPresentation(CreditCard creditCard);
 
-    @Mapping(source = ProductMapperConstants.EXTERNAL_ID, target = ProductMapperConstants.EXTERNAL_ARRANGEMENT_ID)
-    @Mapping(source = ProductMapperConstants.PRODUCT_TYPE_EXTERNAL_ID, target = ProductMapperConstants.EXTERNAL_PRODUCT_ID)
-    @Mapping(source = ProductMapperConstants.LEGAL_ENTITIES, target = ProductMapperConstants.EXTERNAL_LEGAL_ENTITY_IDS)
+    @Mapping(source = ProductMapperConstants.EXTERNAL_ID, target = ProductMapperConstants.ID)
+    @Mapping(source = ProductMapperConstants.PRODUCT_TYPE_EXTERNAL_ID, target = ProductMapperConstants.PRODUCT_ID)
+    @Mapping(source = ProductMapperConstants.LEGAL_ENTITIES, target = ProductMapperConstants.LEGAL_ENTITY_IDS)
     @Mapping(source = ProductMapperConstants.ACCOUNT_HOLDER_NAME, target = ProductMapperConstants.ACCOUNT_HOLDER_NAMES)
     @Mapping(source = ProductMapperConstants.PAN_SUFFIX, target = ProductMapperConstants.NUMBER)
     @InheritConfiguration
-    AccountArrangementItemPost toPresentation(TermDeposit termDeposit);
+    PostArrangement toPresentation(TermDeposit termDeposit);
 
-    @Mapping(source = ProductMapperConstants.EXTERNAL_ID, target = ProductMapperConstants.EXTERNAL_ARRANGEMENT_ID)
-    @Mapping(source = ProductMapperConstants.PRODUCT_TYPE_EXTERNAL_ID, target = ProductMapperConstants.EXTERNAL_PRODUCT_ID)
-    @Mapping(source = ProductMapperConstants.LEGAL_ENTITIES, target = ProductMapperConstants.EXTERNAL_LEGAL_ENTITY_IDS)
+    @Mapping(source = ProductMapperConstants.EXTERNAL_ID, target = ProductMapperConstants.ID)
+    @Mapping(source = ProductMapperConstants.PRODUCT_TYPE_EXTERNAL_ID, target = ProductMapperConstants.PRODUCT_ID)
+    @Mapping(source = ProductMapperConstants.LEGAL_ENTITIES, target = ProductMapperConstants.LEGAL_ENTITY_IDS)
     @Mapping(source = "currentInvestment.amount", target = "currentInvestmentValue")
     @Mapping(source = ProductMapperConstants.PAN_SUFFIX, target = ProductMapperConstants.NUMBER)
     @InheritConfiguration
-    AccountArrangementItemPost toPresentation(InvestmentAccount investmentAccount);
+    PostArrangement toPresentation(InvestmentAccount investmentAccount);
 
-
-    @Mapping(source = ProductMapperConstants.EXTERNAL_ID, target = ProductMapperConstants.EXTERNAL_ARRANGEMENT_ID)
-    @Mapping(source = ProductMapperConstants.PRODUCT_TYPE_EXTERNAL_ID, target = ProductMapperConstants.EXTERNAL_PRODUCT_ID)
-    @Mapping(source = ProductMapperConstants.LEGAL_ENTITIES, target = ProductMapperConstants.EXTERNAL_LEGAL_ENTITY_IDS)
+    @Mapping(source = ProductMapperConstants.EXTERNAL_ID, target = ProductMapperConstants.ID)
+    @Mapping(source = ProductMapperConstants.PRODUCT_TYPE_EXTERNAL_ID, target = ProductMapperConstants.PRODUCT_ID)
+    @Mapping(source = ProductMapperConstants.LEGAL_ENTITIES, target = ProductMapperConstants.LEGAL_ENTITY_IDS)
     @Mapping(source = ProductMapperConstants.ACCOUNT_HOLDER_NAME, target = ProductMapperConstants.ACCOUNT_HOLDER_NAMES)
     @Mapping(source = ProductMapperConstants.PAN_SUFFIX, target = ProductMapperConstants.NUMBER)
     @InheritConfiguration
-    AccountArrangementItemPost toPresentation(Loan loan);
+    PostArrangement toPresentation(Loan loan);
 
-    AccountArrangementItem toArrangementItem(AccountArrangementItemPost arrangementItemPost);
+    @Mapping(source = ProductMapperConstants.STATE_ID, target = "state.state")
+    @Mapping(source = ProductMapperConstants.ID, target = ProductMapperConstants.EXTERNAL_ARRANGEMENT_ID)
+    ArrangementItem toArrangementItem(PostArrangement arrangementItemPost);
 
-    AccountArrangementItemPut toArrangementItemPut(AccountArrangementItemPost arrangementItemPost);
+    @Mapping(source = ProductMapperConstants.ID, target = ProductMapperConstants.EXTERNAL_ARRANGEMENT_ID)
+    ArrangementPutItem toArrangementItemPut(PostArrangement arrangementItemPost);
 
-    AccountArrangementItemBase toArrangementItemBase(AccountArrangementItemPost arrangementItemPost);
+    ArrangementItemBase toArrangementItemBase(ArrangementItemPostRequest arrangementItemPost);
 
-    AccountArrangementItem toArrangementItem(AccountArrangementItemBase arrangementItemBase);
+    ArrangementItem toArrangementItem(ArrangementItemBase arrangementItemBase);
 
-    AccountArrangementItem toArrangementItem(AccountArrangementItemPut arrangementItemPut);
+    ArrangementItem toArrangementItem(ArrangementPutItem arrangementItemPut);
 
     @Mapping(source = ProductMapperConstants.EXTERNAL_ID, target = ProductMapperConstants.EXTERNAL_ARRANGEMENT_ID)
-    AccountArrangementItem toPresentationWithWeirdSpellingError(Product product);
-
-//    @Mapping(source = ProductMapperConstants.EXTERNAL_ARRANGEMENT_ID, target = ProductMapperConstants.EXTERNAL_ID)
-//    @Mapping(source = ProductMapperConstants.EXTERNAL_PRODUCT_ID, target = ProductMapperConstants.PRODUCT_TYPE_EXTERNAL_ID)
-//    @Mapping(source = ProductMapperConstants.LEGAL_ENTITY_IDS, target = ProductMapperConstants.LEGAL_ENTITIES)
-//    @Mapping(source = ProductMapperConstants.ID, target = ProductMapperConstants.INTERNAL_ID)
-//    BaseProduct toBaseProduct(ArrangementItem arrangementItem);
+    ArrangementItem toPresentationWithWeirdSpellingError(Product product);
 
     @Mapping(source = ProductMapperConstants.EXTERNAL_ARRANGEMENT_ID, target = ProductMapperConstants.EXTERNAL_ID)
     @Mapping(source = ProductMapperConstants.EXTERNAL_PRODUCT_ID, target = ProductMapperConstants.PRODUCT_TYPE_EXTERNAL_ID)
     @Mapping(source = ProductMapperConstants.LEGAL_ENTITY_IDS, target = ProductMapperConstants.LEGAL_ENTITIES)
     @Mapping(source = ProductMapperConstants.ID, target = ProductMapperConstants.INTERNAL_ID)
     @InheritConfiguration
-    Product mapCustomProduct(AccountArrangementItem arrangementItem);
+    Product mapCustomProduct(ArrangementItem arrangementItem);
 
     @Mapping(source = ProductMapperConstants.EXTERNAL_ARRANGEMENT_ID, target = ProductMapperConstants.EXTERNAL_ID)
     @Mapping(source = ProductMapperConstants.EXTERNAL_PRODUCT_ID, target = ProductMapperConstants.PRODUCT_TYPE_EXTERNAL_ID)
     @Mapping(source = ProductMapperConstants.LEGAL_ENTITY_IDS, target = ProductMapperConstants.LEGAL_ENTITIES)
     @Mapping(source = ProductMapperConstants.ID, target = ProductMapperConstants.INTERNAL_ID)
-    CurrentAccount mapCurrentAccount(AccountArrangementItem product);
+    CurrentAccount mapCurrentAccount(ArrangementItem product);
 
     @Mapping(source = ProductMapperConstants.EXTERNAL_ARRANGEMENT_ID, target = ProductMapperConstants.EXTERNAL_ID)
     @Mapping(source = ProductMapperConstants.EXTERNAL_PRODUCT_ID, target = ProductMapperConstants.PRODUCT_TYPE_EXTERNAL_ID)
     @Mapping(source = ProductMapperConstants.LEGAL_ENTITY_IDS, target = ProductMapperConstants.LEGAL_ENTITIES)
     @Mapping(source = ProductMapperConstants.ID, target = ProductMapperConstants.INTERNAL_ID)
-    SavingsAccount mapSavingAccount(AccountArrangementItem product);
+    SavingsAccount mapSavingAccount(ArrangementItem product);
 
     @Mapping(source = ProductMapperConstants.EXTERNAL_ARRANGEMENT_ID, target = ProductMapperConstants.EXTERNAL_ID)
     @Mapping(source = ProductMapperConstants.EXTERNAL_PRODUCT_ID, target = ProductMapperConstants.PRODUCT_TYPE_EXTERNAL_ID)
     @Mapping(source = ProductMapperConstants.LEGAL_ENTITY_IDS, target = ProductMapperConstants.LEGAL_ENTITIES)
     @Mapping(source = ProductMapperConstants.ID, target = ProductMapperConstants.INTERNAL_ID)
-    DebitCard mapDebitCard(AccountArrangementItem product);
+    DebitCard mapDebitCard(ArrangementItem product);
 
     @Mapping(source = ProductMapperConstants.EXTERNAL_ARRANGEMENT_ID, target = ProductMapperConstants.EXTERNAL_ID)
     @Mapping(source = ProductMapperConstants.EXTERNAL_PRODUCT_ID, target = ProductMapperConstants.PRODUCT_TYPE_EXTERNAL_ID)
     @Mapping(source = ProductMapperConstants.LEGAL_ENTITY_IDS, target = ProductMapperConstants.LEGAL_ENTITIES)
     @Mapping(source = ProductMapperConstants.ID, target = ProductMapperConstants.INTERNAL_ID)
-    CreditCard mapCreditCard(AccountArrangementItem product);
+    CreditCard mapCreditCard(ArrangementItem product);
 
     @Mapping(source = ProductMapperConstants.EXTERNAL_ARRANGEMENT_ID, target = ProductMapperConstants.EXTERNAL_ID)
     @Mapping(source = ProductMapperConstants.EXTERNAL_PRODUCT_ID, target = ProductMapperConstants.PRODUCT_TYPE_EXTERNAL_ID)
     @Mapping(source = ProductMapperConstants.LEGAL_ENTITY_IDS, target = ProductMapperConstants.LEGAL_ENTITIES)
     @Mapping(source = ProductMapperConstants.ID, target = ProductMapperConstants.INTERNAL_ID)
-    Loan mapLoan(AccountArrangementItem product);
+    Loan mapLoan(ArrangementItem product);
 
     @Mapping(source = ProductMapperConstants.EXTERNAL_ARRANGEMENT_ID, target = ProductMapperConstants.EXTERNAL_ID)
     @Mapping(source = ProductMapperConstants.EXTERNAL_PRODUCT_ID, target = ProductMapperConstants.PRODUCT_TYPE_EXTERNAL_ID)
     @Mapping(source = ProductMapperConstants.LEGAL_ENTITY_IDS, target = ProductMapperConstants.LEGAL_ENTITIES)
     @Mapping(source = ProductMapperConstants.ID, target = ProductMapperConstants.INTERNAL_ID)
-    TermDeposit mapTermDeposit(AccountArrangementItem product);
+    TermDeposit mapTermDeposit(ArrangementItem product);
 
     @Mapping(source = ProductMapperConstants.EXTERNAL_ARRANGEMENT_ID, target = ProductMapperConstants.EXTERNAL_ID)
     @Mapping(source = ProductMapperConstants.EXTERNAL_PRODUCT_ID, target = ProductMapperConstants.PRODUCT_TYPE_EXTERNAL_ID)
     @Mapping(source = ProductMapperConstants.LEGAL_ENTITY_IDS, target = ProductMapperConstants.LEGAL_ENTITIES)
     @Mapping(source = ProductMapperConstants.ID, target = ProductMapperConstants.INTERNAL_ID)
     @Mapping(source = "currentInvestmentValue", target = "currentInvestment")
-    InvestmentAccount mapInvestmentAccount(AccountArrangementItem product);
+    InvestmentAccount mapInvestmentAccount(ArrangementItem product);
 
 
     default List<LegalEntityReference> mapLegalEntities(Set<String> externalIds) {
@@ -323,28 +318,28 @@ public interface ProductMapper {
     }
 
     @ValueMappings({
-            @ValueMapping(source = "QUARTERLY", target = MappingConstants.NULL),
-            @ValueMapping(source = ProductMapperConstants.DAILY, target = ProductMapperConstants.D),
-            @ValueMapping(source = ProductMapperConstants.WEEKLY, target = ProductMapperConstants.W),
-            @ValueMapping(source = ProductMapperConstants.MONTHLY, target = ProductMapperConstants.M),
-            @ValueMapping(source = ProductMapperConstants.YEARLY, target = ProductMapperConstants.Y)
+        @ValueMapping(source = ProductMapperConstants.DAILY, target = ProductMapperConstants.D),
+        @ValueMapping(source = ProductMapperConstants.WEEKLY, target = ProductMapperConstants.W),
+        @ValueMapping(source = ProductMapperConstants.MONTHLY, target = ProductMapperConstants.M),
+        @ValueMapping(source = ProductMapperConstants.QUARTERLY, target = MappingConstants.NULL),
+        @ValueMapping(source = ProductMapperConstants.YEARLY, target = ProductMapperConstants.Y)
     })
     TimeUnit map(TermUnit termUnit);
 
     @ValueMappings({
-            @ValueMapping(source = "QUARTERLY", target = MappingConstants.NULL),
-            @ValueMapping(source = ProductMapperConstants.DAILY, target = ProductMapperConstants.D),
-            @ValueMapping(source = ProductMapperConstants.WEEKLY, target = ProductMapperConstants.W),
-            @ValueMapping(source = ProductMapperConstants.MONTHLY, target = ProductMapperConstants.M),
-            @ValueMapping(source = ProductMapperConstants.YEARLY, target = ProductMapperConstants.Y)
+        @ValueMapping(source = ProductMapperConstants.DAILY, target = ProductMapperConstants.D),
+        @ValueMapping(source = ProductMapperConstants.WEEKLY, target = ProductMapperConstants.W),
+        @ValueMapping(source = ProductMapperConstants.MONTHLY, target = ProductMapperConstants.M),
+        @ValueMapping(source = ProductMapperConstants.QUARTERLY, target = MappingConstants.NULL),
+        @ValueMapping(source = ProductMapperConstants.YEARLY, target = ProductMapperConstants.Y)
     })
     TimeUnit map(InterestPaymentFrequencyUnit interestPaymentFrequencyUnit);
 
     @ValueMappings({
-            @ValueMapping(source = ProductMapperConstants.D, target = ProductMapperConstants.DAILY),
-            @ValueMapping(source = ProductMapperConstants.W, target = ProductMapperConstants.WEEKLY),
-            @ValueMapping(source = ProductMapperConstants.M, target = ProductMapperConstants.MONTHLY),
-            @ValueMapping(source = ProductMapperConstants.Y, target = ProductMapperConstants.YEARLY)
+        @ValueMapping(source = ProductMapperConstants.D, target = ProductMapperConstants.DAILY),
+        @ValueMapping(source = ProductMapperConstants.W, target = ProductMapperConstants.WEEKLY),
+        @ValueMapping(source = ProductMapperConstants.M, target = ProductMapperConstants.MONTHLY),
+        @ValueMapping(source = ProductMapperConstants.Y, target = ProductMapperConstants.YEARLY)
     })
     TermUnit map(TimeUnit unit);
 
@@ -356,7 +351,6 @@ public interface ProductMapper {
         }
     }
 
-
     default List<LegalEntityReference> mapLegalEntityReference(List<String> value) {
         if (value != null) {
             return value.stream().map(id -> new LegalEntityReference().externalId(id)).collect(Collectors.toList());
@@ -365,17 +359,13 @@ public interface ProductMapper {
         }
     }
 
-
     @ValueMappings({
-            @ValueMapping(source = ProductMapperConstants.D, target = ProductMapperConstants.DAILY),
-            @ValueMapping(source = ProductMapperConstants.W, target = ProductMapperConstants.WEEKLY),
-            @ValueMapping(source = ProductMapperConstants.M, target = ProductMapperConstants.MONTHLY),
-            @ValueMapping(source = ProductMapperConstants.Y, target = ProductMapperConstants.YEARLY)
+        @ValueMapping(source = ProductMapperConstants.D, target = ProductMapperConstants.DAILY),
+        @ValueMapping(source = ProductMapperConstants.W, target = ProductMapperConstants.WEEKLY),
+        @ValueMapping(source = ProductMapperConstants.M, target = ProductMapperConstants.MONTHLY),
+        @ValueMapping(source = ProductMapperConstants.Y, target = ProductMapperConstants.YEARLY)
     })
     InterestPaymentFrequencyUnit mapInterestPayment(TimeUnit unit);
-
-    @Mapping(source = "userExternalId", target = "userId")
-    AccountUserPreferencesItemPut mapUserPreference(UserPreferences userPreferences);
 
     @Named("mapDebitCardNumber")
     default String mapDebitCardNumber(DebitCard debitCard) {
@@ -392,4 +382,40 @@ public interface ProductMapper {
         }
         return creditCard.getPanSuffix();
     }
+
+    @ValueMappings({
+        @ValueMapping(source = ProductMapperConstants.DAILY, target = ProductMapperConstants.D),
+        @ValueMapping(source = ProductMapperConstants.WEEKLY, target = ProductMapperConstants.W),
+        @ValueMapping(source = ProductMapperConstants.MONTHLY, target = ProductMapperConstants.M),
+        @ValueMapping(source = ProductMapperConstants.QUARTERLY, target = MappingConstants.NULL),
+        @ValueMapping(source = ProductMapperConstants.YEARLY, target = ProductMapperConstants.Y)
+    })
+    com.backbase.dbs.arrangement.api.service.v3.model.TimeUnit mapTimeUnitV3(TermUnit termUnit);
+
+    @ValueMappings({
+        @ValueMapping(source = ProductMapperConstants.DAILY, target = ProductMapperConstants.D),
+        @ValueMapping(source = ProductMapperConstants.WEEKLY, target = ProductMapperConstants.W),
+        @ValueMapping(source = ProductMapperConstants.MONTHLY, target = ProductMapperConstants.M),
+        @ValueMapping(source = ProductMapperConstants.QUARTERLY, target = MappingConstants.NULL),
+        @ValueMapping(source = ProductMapperConstants.YEARLY, target = ProductMapperConstants.Y)
+    })
+    com.backbase.dbs.arrangement.api.service.v3.model.TimeUnit mapInterestPaymentFrequencyUnitToTimeUnitV3(InterestPaymentFrequencyUnit interestPaymentFrequencyUnit);
+
+    @ValueMappings({
+        @ValueMapping(source = ProductMapperConstants.D, target = ProductMapperConstants.DAILY),
+        @ValueMapping(source = ProductMapperConstants.W, target = ProductMapperConstants.WEEKLY),
+        @ValueMapping(source = ProductMapperConstants.M, target = ProductMapperConstants.MONTHLY),
+        @ValueMapping(source = ProductMapperConstants.Y, target = ProductMapperConstants.YEARLY)
+    })
+    TermUnit mapTimeUnitV3ToTermUnit(com.backbase.dbs.arrangement.api.service.v3.model.TimeUnit timeUnit);
+
+    @ValueMappings({
+        @ValueMapping(source = ProductMapperConstants.D, target = ProductMapperConstants.DAILY),
+        @ValueMapping(source = ProductMapperConstants.W, target = ProductMapperConstants.WEEKLY),
+        @ValueMapping(source = ProductMapperConstants.M, target = ProductMapperConstants.MONTHLY),
+        @ValueMapping(source = ProductMapperConstants.Y, target = ProductMapperConstants.YEARLY)
+    })
+    InterestPaymentFrequencyUnit mapTimeUnitV3ToInterestPaymentFrequencyUnit(com.backbase.dbs.arrangement.api.service.v3.model.TimeUnit timeUnit);
+
+    com.backbase.dbs.arrangement.api.service.v3.model.TimeUnit mapTimeUnitV2ToTimeUnitV3(TimeUnit timeUnit);
 }

--- a/stream-product/product-core/src/main/java/com/backbase/stream/product/mapping/ProductMapperConstants.java
+++ b/stream-product/product-core/src/main/java/com/backbase/stream/product/mapping/ProductMapperConstants.java
@@ -12,6 +12,7 @@ class ProductMapperConstants {
     static final String DAILY = "DAILY";
     static final String WEEKLY = "WEEKLY";
     static final String MONTHLY = "MONTHLY";
+    static final String QUARTERLY = "QUARTERLY";
     static final String YEARLY = "YEARLY";
     static final String D = "D";
     static final String W = "W";
@@ -33,5 +34,9 @@ class ProductMapperConstants {
     static final String DEBIT_CARDS = "debitCards";
     static final String NUMBER = "number";
     static final String PAN_SUFFIX = "panSuffix";
+    static final String PRODUCT_ID = "productId";
+    static final String STATE_ID = "stateId";
+    static final String INTEREST_PAYMENT_FREQUENCY_UNIT = "interestPaymentFrequencyUnit";
+    static final String TERM_UNIT = "termUnit";
 
 }

--- a/stream-product/product-core/src/test/java/com/backbase/stream/product/mapping/ProductMapperTest.java
+++ b/stream-product/product-core/src/test/java/com/backbase/stream/product/mapping/ProductMapperTest.java
@@ -1,10 +1,11 @@
 package com.backbase.stream.product.mapping;
 
-import com.backbase.dbs.arrangement.api.service.v2.model.*;
+import com.backbase.dbs.arrangement.api.integration.v2.model.PostArrangement;
 import com.backbase.stream.legalentity.model.*;
-import com.backbase.stream.legalentity.model.DebitCardItem;
-import com.backbase.stream.legalentity.model.InterestDetails;
-import com.backbase.stream.legalentity.model.UserPreferences;
+import com.backbase.dbs.arrangement.api.service.v3.model.ArrangementItem;
+import com.backbase.dbs.arrangement.api.service.v3.model.ArrangementPutItem;
+import com.backbase.stream.legalentity.model.Product;
+import com.backbase.stream.legalentity.model.SavingsAccount;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mapstruct.factory.Mappers;
@@ -20,7 +21,7 @@ public class ProductMapperTest {
     private final ProductMapper productMapper = Mappers.getMapper(ProductMapper.class);
 
     LegalEntityReference buildLegalEntityReference(String legalEntityExternalId) {
-        return new LegalEntityReference().externalId(legalEntityExternalId);
+        return new LegalEntityReference(null, legalEntityExternalId);
     }
 
     private void buildBaseProduct(BaseProduct baseProduct) {
@@ -116,211 +117,215 @@ public class ProductMapperTest {
     }
 
     @Test
-    public void map_Product_To_AccountArrangementItemPost() {
+    void map_Product_To_AccountArrangementItemPost() {
         Product source = buildProduct();
-        AccountArrangementItemPost target = productMapper.toPresentation(source);
-        Assertions.assertEquals(source.getExternalId(), target.getExternalArrangementId());
-        Assertions.assertEquals(source.getProductTypeExternalId(), target.getExternalProductId());
-        Assertions.assertNotNull(target.getExternalLegalEntityIds());
-        Assertions.assertEquals(source.getLegalEntities().size(), target.getExternalLegalEntityIds().size());
-        Assertions.assertEquals(source.getState().getExternalStateId(), target.getExternalStateId());
+        PostArrangement target = productMapper.toPresentation(source);
+        Assertions.assertEquals(source.getExternalId(), target.getId());
+        Assertions.assertEquals(source.getProductTypeExternalId(), target.getProductId());
+        Assertions.assertNotNull(target.getLegalEntityIds());
+        Assertions.assertEquals(source.getLegalEntities().size(), target.getLegalEntityIds().size());
+        Assertions.assertEquals(source.getState().getExternalStateId(), target.getStateId());
         Assertions.assertEquals(source.getAccountHolderName(), target.getAccountHolderNames());
     }
 
     @Test
-    public void map_BaseProduct_To_AccountArrangementItemPost() {
+    void map_BaseProduct_To_AccountArrangementItemPost() {
         Product source = buildProduct();
-        AccountArrangementItemPost target = productMapper.toPresentation(source);
-        Assertions.assertEquals(source.getExternalId(), target.getExternalArrangementId());
-        Assertions.assertEquals(source.getProductTypeExternalId(), target.getExternalProductId());
-        Assertions.assertNotNull(target.getExternalLegalEntityIds());
-        Assertions.assertEquals(source.getLegalEntities().size(), target.getExternalLegalEntityIds().size());
-        Assertions.assertEquals(source.getState().getExternalStateId(), target.getExternalStateId());
+        PostArrangement target = productMapper.toPresentation(source);
+        Assertions.assertEquals(source.getExternalId(), target.getId());
+        Assertions.assertEquals(source.getProductTypeExternalId(), target.getProductId());
+        Assertions.assertNotNull(target.getLegalEntityIds());
+        Assertions.assertEquals(source.getLegalEntities().size(), target.getLegalEntityIds().size());
+        Assertions.assertEquals(source.getState().getExternalStateId(), target.getStateId());
         Assertions.assertEquals(source.getAccountHolderName(), target.getAccountHolderNames());
     }
 
     @Test
-    public void map_SavingsAccount_To_AccountArrangementItemPost() {
+    void map_SavingsAccount_To_AccountArrangementItemPost() {
         SavingsAccount source = buildSavingsAccount();
-        AccountArrangementItemPost target = productMapper.toPresentation(source);
-        Assertions.assertEquals(source.getExternalId(), target.getExternalArrangementId());
-        Assertions.assertEquals(source.getProductTypeExternalId(), target.getExternalProductId());
-        Assertions.assertNotNull(target.getExternalLegalEntityIds());
-        Assertions.assertEquals(source.getLegalEntities().size(), target.getExternalLegalEntityIds().size());
+        PostArrangement target = productMapper.toPresentation(source);
+        Assertions.assertEquals(source.getExternalId(), target.getId());
+        Assertions.assertEquals(source.getProductTypeExternalId(), target.getProductId());
+        Assertions.assertNotNull(target.getLegalEntityIds());
+        Assertions.assertEquals(source.getLegalEntities().size(), target.getLegalEntityIds().size());
         Assertions.assertNotNull(target.getDebitCards());
         Assertions.assertEquals(source.getDebitCardsItems().size(), target.getDebitCards().size());
-        Assertions.assertEquals(source.getState().getExternalStateId(), target.getExternalStateId());
+        Assertions.assertEquals(source.getState().getExternalStateId(), target.getStateId());
         Assertions.assertEquals(source.getAccountHolderName(), target.getAccountHolderNames());
     }
 
     @Test
-    public void map_DebitCard_To_AccountArrangementItemPost() {
+    void map_DebitCard_To_AccountArrangementItemPost() {
         DebitCard source = buildDebitCard();
-        AccountArrangementItemPost target = productMapper.toPresentation(source);
-        Assertions.assertEquals(source.getExternalId(), target.getExternalArrangementId());
-        Assertions.assertEquals(source.getProductTypeExternalId(), target.getExternalProductId());
-        Assertions.assertNotNull(target.getExternalLegalEntityIds());
-        Assertions.assertEquals(source.getLegalEntities().size(), target.getExternalLegalEntityIds().size());
-        Assertions.assertEquals(source.getState().getExternalStateId(), target.getExternalStateId());
+        PostArrangement target = productMapper.toPresentation(source);
+        Assertions.assertEquals(source.getExternalId(), target.getId());
+        Assertions.assertEquals(source.getProductTypeExternalId(), target.getProductId());
+        Assertions.assertNotNull(target.getLegalEntityIds());
+        Assertions.assertEquals(source.getLegalEntities().size(), target.getLegalEntityIds().size());
+        Assertions.assertEquals(source.getState().getExternalStateId(), target.getStateId());
         Assertions.assertEquals(source.getAccountHolderName(), target.getAccountHolderNames());
     }
 
     @Test
-    public void map_CreditCard_To_AccountArrangementItemPost() {
+    void map_CreditCard_To_AccountArrangementItemPost() {
         CreditCard source = buildCreditCard();
-        AccountArrangementItemPost target = productMapper.toPresentation(source);
-        Assertions.assertEquals(source.getExternalId(), target.getExternalArrangementId());
-        Assertions.assertEquals(source.getProductTypeExternalId(), target.getExternalProductId());
-        Assertions.assertNotNull(target.getExternalLegalEntityIds());
-        Assertions.assertEquals(source.getLegalEntities().size(), target.getExternalLegalEntityIds().size());
-        Assertions.assertEquals(source.getState().getExternalStateId(), target.getExternalStateId());
+        PostArrangement target = productMapper.toPresentation(source);
+        Assertions.assertEquals(source.getExternalId(), target.getId());
+        Assertions.assertEquals(source.getProductTypeExternalId(), target.getProductId());
+        Assertions.assertNotNull(target.getLegalEntityIds());
+        Assertions.assertEquals(source.getLegalEntities().size(), target.getLegalEntityIds().size());
+        Assertions.assertEquals(source.getState().getExternalStateId(), target.getStateId());
         Assertions.assertEquals(source.getAccountHolderName(), target.getAccountHolderNames());
     }
 
     @Test
-    public void map_TermDeposit_To_AccountArrangementItemPost() {
+    void map_TermDeposit_To_AccountArrangementItemPost() {
         TermDeposit source = buildTermDeposit();
-        AccountArrangementItemPost target = productMapper.toPresentation(source);
-        Assertions.assertEquals(source.getExternalId(), target.getExternalArrangementId());
-        Assertions.assertEquals(source.getProductTypeExternalId(), target.getExternalProductId());
-        Assertions.assertNotNull(target.getExternalLegalEntityIds());
-        Assertions.assertEquals(source.getLegalEntities().size(), target.getExternalLegalEntityIds().size());
-        Assertions.assertEquals(source.getState().getExternalStateId(), target.getExternalStateId());
+        PostArrangement target = productMapper.toPresentation(source);
+        Assertions.assertEquals(source.getExternalId(), target.getId());
+        Assertions.assertEquals(source.getProductTypeExternalId(), target.getProductId());
+        Assertions.assertNotNull(target.getLegalEntityIds());
+        Assertions.assertEquals(source.getLegalEntities().size(), target.getLegalEntityIds().size());
+        Assertions.assertEquals(source.getState().getExternalStateId(), target.getStateId());
         Assertions.assertEquals(source.getAccountHolderName(), target.getAccountHolderNames());
     }
 
     @Test
-    public void map_InvestmentAccount_To_AccountArrangementItemPost() {
+    void map_InvestmentAccount_To_AccountArrangementItemPost() {
         InvestmentAccount source = buildInvestmentAccount();
-        AccountArrangementItemPost target = productMapper.toPresentation(source);
-        Assertions.assertEquals(source.getExternalId(), target.getExternalArrangementId());
-        Assertions.assertEquals(source.getProductTypeExternalId(), target.getExternalProductId());
-        Assertions.assertNotNull(target.getExternalLegalEntityIds());
-        Assertions.assertEquals(source.getLegalEntities().size(), target.getExternalLegalEntityIds().size());
-        Assertions.assertEquals(source.getState().getExternalStateId(), target.getExternalStateId());
+        PostArrangement target = productMapper.toPresentation(source);
+        Assertions.assertEquals(source.getExternalId(), target.getId());
+        Assertions.assertEquals(source.getProductTypeExternalId(), target.getProductId());
+        Assertions.assertNotNull(target.getLegalEntityIds());
+        Assertions.assertEquals(source.getLegalEntities().size(), target.getLegalEntityIds().size());
+        Assertions.assertEquals(source.getState().getExternalStateId(), target.getStateId());
     }
 
     @Test
-    public void map_Loan_To_AccountArrangementItemPost() {
+    void map_Loan_To_AccountArrangementItemPost() {
         Loan source = buildLoan();
-        AccountArrangementItemPost target = productMapper.toPresentation(source);
-        Assertions.assertEquals(source.getExternalId(), target.getExternalArrangementId());
-        Assertions.assertEquals(source.getProductTypeExternalId(), target.getExternalProductId());
-        Assertions.assertNotNull(target.getExternalLegalEntityIds());
-        Assertions.assertEquals(source.getLegalEntities().size(), target.getExternalLegalEntityIds().size());
-        Assertions.assertEquals(source.getState().getExternalStateId(), target.getExternalStateId());
+        PostArrangement target = productMapper.toPresentation(source);
+        Assertions.assertEquals(source.getExternalId(), target.getId());
+        Assertions.assertEquals(source.getProductTypeExternalId(), target.getProductId());
+        Assertions.assertNotNull(target.getLegalEntityIds());
+        Assertions.assertEquals(source.getLegalEntities().size(), target.getLegalEntityIds().size());
+        Assertions.assertEquals(source.getState().getExternalStateId(), target.getStateId());
         Assertions.assertEquals(source.getAccountHolderName(), target.getAccountHolderNames());
     }
 
     @Test
-    public void map_AccountArrangementItemPost_To_AccountArrangementItem() {
-        AccountArrangementItemPost source = productMapper.toPresentation(buildProduct());
-        AccountArrangementItem target = productMapper.toArrangementItem(source);
-        Assertions.assertEquals(target.getExternalArrangementId(), source.getExternalArrangementId());
-        Assertions.assertEquals(target.getExternalProductId(), source.getExternalProductId());
-        Assertions.assertEquals(target.getExternalStateId(), source.getExternalStateId());
+    void map_AccountArrangementItemPost_To_AccountArrangementItem() {
+        PostArrangement source = productMapper.toPresentation(buildProduct());
+        ArrangementItem target = productMapper.toArrangementItem(source);
+        Assertions.assertEquals(target.getId(), source.getId());
+        Assertions.assertEquals(target.getProductId(), source.getProductId());
+        Assertions.assertNotNull(target.getState());
+        Assertions.assertEquals(target.getState().getState(), source.getStateId());
         Assertions.assertEquals(target.getAccountHolderNames(), source.getAccountHolderNames());
     }
 
     @Test
-    public void map_AccountArrangementItemPost_To_AccountArrangementItemPut() {
-        AccountArrangementItemPost source = productMapper.toPresentation(buildProduct());
-        AccountArrangementItemPut target = productMapper.toArrangementItemPut(source);
-        Assertions.assertEquals(target.getExternalArrangementId(), source.getExternalArrangementId());
-        Assertions.assertEquals(target.getExternalStateId(), source.getExternalStateId());
+    void map_AccountArrangementItemPost_To_AccountArrangementItemPut() {
+        PostArrangement source = productMapper.toPresentation(buildProduct());
+        source.setStateId("123");
+        ArrangementPutItem target = productMapper.toArrangementItemPut(source);
+
+        Assertions.assertEquals(target.getExternalArrangementId(), source.getId());
+        Assertions.assertEquals(String.valueOf(target.getStateId()), source.getStateId());
         Assertions.assertEquals(target.getAccountHolderNames(), source.getAccountHolderNames());
     }
 
     @Test
-    public void map_AccountArrangementItemBase_To_AccountArrangementItem() {
-        AccountArrangementItemPost source = productMapper.toPresentation(buildProduct());
-        AccountArrangementItem target = productMapper.toArrangementItem(source);
-        Assertions.assertEquals(target.getExternalArrangementId(), source.getExternalArrangementId());
-        Assertions.assertEquals(target.getExternalStateId(), source.getExternalStateId());
+    void map_AccountArrangementItemBase_To_AccountArrangementItem() {
+        PostArrangement source = productMapper.toPresentation(buildProduct());
+        ArrangementItem target = productMapper.toArrangementItem(source);
+        Assertions.assertEquals(target.getId(), source.getId());
+        Assertions.assertNotNull(target.getState());
+        Assertions.assertEquals(target.getState().getState(), source.getStateId());
         Assertions.assertEquals(target.getAccountHolderNames(), source.getAccountHolderNames());
     }
 
     @Test
-    public void map_Product_To_AccountArrangementItem() {
+    void map_Product_To_AccountArrangementItem() {
         Product source = buildProduct();
-        AccountArrangementItem target = productMapper.toPresentationWithWeirdSpellingError(source);
+        ArrangementItem target = productMapper.toPresentationWithWeirdSpellingError(source);
         Assertions.assertEquals(target.getExternalArrangementId(), source.getExternalId());
         Assertions.assertEquals(target.getExternalStateId(), source.getState().getExternalStateId());
     }
 
     @Test
-    public void map_AccountArrangementItem_To_Product() {
-        AccountArrangementItem source = productMapper.toArrangementItem(productMapper.toPresentation(buildProduct()));
+    void map_AccountArrangementItem_To_Product() {
+        ArrangementItem source = productMapper.toArrangementItem(productMapper.toPresentation(buildProduct()));
         Product target = productMapper.mapCustomProduct(source);
         Assertions.assertEquals(target.getExternalId(), source.getExternalArrangementId());
         Assertions.assertEquals(target.getProductTypeExternalId(), source.getExternalProductId());
     }
 
     @Test
-    public void map_AccountArrangementItem_To_CurrentAccount() {
-        AccountArrangementItem source = productMapper.toArrangementItem(productMapper.toPresentation(buildProduct()));
+    void map_AccountArrangementItem_To_CurrentAccount() {
+        ArrangementItem source = productMapper.toArrangementItem(productMapper.toPresentation(buildProduct()));
         CurrentAccount target = productMapper.mapCurrentAccount(source);
         Assertions.assertEquals(target.getExternalId(), source.getExternalArrangementId());
         Assertions.assertEquals(target.getProductTypeExternalId(), source.getExternalProductId());
     }
 
     @Test
-    public void map_AccountArrangementItem_To_SavingsAccount() {
-        AccountArrangementItem source = productMapper.toArrangementItem(productMapper.toPresentation(buildProduct()));
+    void map_AccountArrangementItem_To_SavingsAccount() {
+        ArrangementItem source = productMapper.toArrangementItem(productMapper.toPresentation(buildProduct()));
         SavingsAccount target = productMapper.mapSavingAccount(source);
         Assertions.assertEquals(target.getExternalId(), source.getExternalArrangementId());
         Assertions.assertEquals(target.getProductTypeExternalId(), source.getExternalProductId());
     }
 
     @Test
-    public void map_AccountArrangementItem_To_DebitCard() {
-        AccountArrangementItem source = productMapper.toArrangementItem(productMapper.toPresentation(buildProduct()));
+    void map_AccountArrangementItem_To_DebitCard() {
+        ArrangementItem source = productMapper.toArrangementItem(productMapper.toPresentation(buildProduct()));
         DebitCard target = productMapper.mapDebitCard(source);
         Assertions.assertEquals(target.getExternalId(), source.getExternalArrangementId());
         Assertions.assertEquals(target.getProductTypeExternalId(), source.getExternalProductId());
     }
 
     @Test
-    public void map_AccountArrangementItem_To_CreditCard() {
-        AccountArrangementItem source = productMapper.toArrangementItem(productMapper.toPresentation(buildProduct()));
+    void map_AccountArrangementItem_To_CreditCard() {
+        ArrangementItem source = productMapper.toArrangementItem(productMapper.toPresentation(buildProduct()));
         CreditCard target = productMapper.mapCreditCard(source);
         Assertions.assertEquals(target.getExternalId(), source.getExternalArrangementId());
         Assertions.assertEquals(target.getProductTypeExternalId(), source.getExternalProductId());
     }
 
     @Test
-    public void map_AccountArrangementItem_To_Loan() {
-        AccountArrangementItem source = productMapper.toArrangementItem(productMapper.toPresentation(buildProduct()));
+    void map_AccountArrangementItem_To_Loan() {
+        ArrangementItem source = productMapper.toArrangementItem(productMapper.toPresentation(buildProduct()));
         Loan target = productMapper.mapLoan(source);
         Assertions.assertEquals(target.getExternalId(), source.getExternalArrangementId());
         Assertions.assertEquals(target.getProductTypeExternalId(), source.getExternalProductId());
     }
 
     @Test
-    public void map_AccountArrangementItem_To_TermDeposit() {
-        AccountArrangementItem source = productMapper.toArrangementItem(productMapper.toPresentation(buildProduct()));
+    void map_AccountArrangementItem_To_TermDeposit() {
+        ArrangementItem source = productMapper.toArrangementItem(productMapper.toPresentation(buildProduct()));
         TermDeposit target = productMapper.mapTermDeposit(source);
         Assertions.assertEquals(target.getExternalId(), source.getExternalArrangementId());
         Assertions.assertEquals(target.getProductTypeExternalId(), source.getExternalProductId());
     }
 
     @Test
-    public void map_AccountArrangementItem_To_InvestmentAccount() {
-        AccountArrangementItem source = productMapper.toArrangementItem(productMapper.toPresentation(buildProduct()));
+    void map_AccountArrangementItem_To_InvestmentAccount() {
+        ArrangementItem source = productMapper.toArrangementItem(productMapper.toPresentation(buildProduct()));
         InvestmentAccount target = productMapper.mapInvestmentAccount(source);
         Assertions.assertEquals(target.getExternalId(), source.getExternalArrangementId());
         Assertions.assertEquals(target.getProductTypeExternalId(), source.getExternalProductId());
     }
 
     @Test
-    public void mapBookedBalance() {
+    void mapBookedBalance() {
         BigDecimal source = new BigDecimal("130.79");
         BookedBalance target = productMapper.mapBookedBalance(source);
         Assertions.assertEquals(source, target.getAmount());
     }
 
     @Test
-    public void mapAvailable() {
+    void mapAvailable() {
         BigDecimal source = new BigDecimal("130.79");
         AvailableBalance target = productMapper.mapAvailable(source);
         Assertions.assertEquals(source, target.getAmount());
@@ -334,62 +339,62 @@ public class ProductMapperTest {
     }
 
     @Test
-    public void mapPrincipal() {
+    void mapPrincipal() {
         BigDecimal source = new BigDecimal("130.79");
         PrincipalAmount target = productMapper.mapPrincipal(source);
         Assertions.assertEquals(source, target.getAmount());
     }
 
     @Test
-    public void mapCreditLimit() {
+    void mapCreditLimit() {
         BigDecimal source = new BigDecimal("130.79");
         CreditLimit target = productMapper.mapCreditLimit(source);
         Assertions.assertEquals(source, target.getAmount());
     }
 
     @Test
-    public void mapLegalEntity() {
+    void mapLegalEntity() {
         LegalEntity target = productMapper.mapLegalEntity("leid");
         Assertions.assertEquals("leid", target.getExternalId());
     }
 
     @Test
-    public void map_TermUnit_To_TimeUnit() {
+    void map_TermUnit_To_TimeUnit() {
         Assertions.assertNull(productMapper.map(TermUnit.QUARTERLY));
-        Assertions.assertEquals(TimeUnit.D, productMapper.map(TermUnit.DAILY));
-        Assertions.assertEquals(TimeUnit.W, productMapper.map(TermUnit.WEEKLY));
-        Assertions.assertEquals(TimeUnit.M, productMapper.map(TermUnit.MONTHLY));
-        Assertions.assertEquals(TimeUnit.Y, productMapper.map(TermUnit.YEARLY));
+        Assertions.assertEquals(com.backbase.dbs.arrangement.api.integration.v2.model.TimeUnit.D, productMapper.map(TermUnit.DAILY));
+        Assertions.assertEquals(com.backbase.dbs.arrangement.api.integration.v2.model.TimeUnit.W, productMapper.map(TermUnit.WEEKLY));
+        Assertions.assertEquals(com.backbase.dbs.arrangement.api.integration.v2.model.TimeUnit.M, productMapper.map(TermUnit.MONTHLY));
+        Assertions.assertEquals(com.backbase.dbs.arrangement.api.integration.v2.model.TimeUnit.Y, productMapper.map(TermUnit.YEARLY));
     }
 
     @Test
-    public void map_InterestPaymentFrequencyUnit_To_TimeUnit() {
+    void map_InterestPaymentFrequencyUnit_To_TimeUnit() {
         Assertions.assertNull(productMapper.map(InterestPaymentFrequencyUnit.QUARTERLY));
-        Assertions.assertEquals(TimeUnit.D, productMapper.map(InterestPaymentFrequencyUnit.DAILY));
-        Assertions.assertEquals(TimeUnit.W, productMapper.map(InterestPaymentFrequencyUnit.WEEKLY));
-        Assertions.assertEquals(TimeUnit.M, productMapper.map(InterestPaymentFrequencyUnit.MONTHLY));
-        Assertions.assertEquals(TimeUnit.Y, productMapper.map(InterestPaymentFrequencyUnit.YEARLY));
+        Assertions.assertEquals(com.backbase.dbs.arrangement.api.integration.v2.model.TimeUnit.D, productMapper.map(InterestPaymentFrequencyUnit.DAILY));
+        Assertions.assertEquals(com.backbase.dbs.arrangement.api.integration.v2.model.TimeUnit.W, productMapper.map(InterestPaymentFrequencyUnit.WEEKLY));
+        Assertions.assertEquals(com.backbase.dbs.arrangement.api.integration.v2.model.TimeUnit.M, productMapper.map(InterestPaymentFrequencyUnit.MONTHLY));
+        Assertions.assertEquals(com.backbase.dbs.arrangement.api.integration.v2.model.TimeUnit.Y, productMapper.map(InterestPaymentFrequencyUnit.YEARLY));
     }
 
     @Test
-    public void map_TimeUnit_TermUnit() {
-        Assertions.assertEquals(TermUnit.DAILY, productMapper.map(TimeUnit.D));
-        Assertions.assertEquals(TermUnit.WEEKLY, productMapper.map(TimeUnit.W));
-        Assertions.assertEquals(TermUnit.MONTHLY, productMapper.map(TimeUnit.M));
-        Assertions.assertEquals(TermUnit.YEARLY, productMapper.map(TimeUnit.Y));
+    void map_TimeUnit_TermUnit() {
+        Assertions.assertEquals(TermUnit.DAILY, productMapper.map(com.backbase.dbs.arrangement.api.integration.v2.model.TimeUnit.D));
+        Assertions.assertEquals(TermUnit.WEEKLY, productMapper.map(com.backbase.dbs.arrangement.api.integration.v2.model.TimeUnit.W));
+        Assertions.assertEquals(TermUnit.MONTHLY, productMapper.map(com.backbase.dbs.arrangement.api.integration.v2.model.TimeUnit.M));
+        Assertions.assertEquals(TermUnit.YEARLY, productMapper.map(com.backbase.dbs.arrangement.api.integration.v2.model.TimeUnit.Y));
     }
 
     @Test
-    public void map_TimeUnit_To_InterestPaymentFrequencyUnit() {
+    void map_TimeUnit_To_InterestPaymentFrequencyUnit() {
         Assertions.assertNull(productMapper.mapInterestPayment(null));
-        Assertions.assertEquals(InterestPaymentFrequencyUnit.DAILY, productMapper.mapInterestPayment(TimeUnit.D));
-        Assertions.assertEquals(InterestPaymentFrequencyUnit.WEEKLY, productMapper.mapInterestPayment(TimeUnit.W));
-        Assertions.assertEquals(InterestPaymentFrequencyUnit.MONTHLY, productMapper.mapInterestPayment(TimeUnit.M));
-        Assertions.assertEquals(InterestPaymentFrequencyUnit.YEARLY, productMapper.mapInterestPayment(TimeUnit.Y));
+        Assertions.assertEquals(InterestPaymentFrequencyUnit.DAILY, productMapper.mapInterestPayment(com.backbase.dbs.arrangement.api.integration.v2.model.TimeUnit.D));
+        Assertions.assertEquals(InterestPaymentFrequencyUnit.WEEKLY, productMapper.mapInterestPayment(com.backbase.dbs.arrangement.api.integration.v2.model.TimeUnit.W));
+        Assertions.assertEquals(InterestPaymentFrequencyUnit.MONTHLY, productMapper.mapInterestPayment(com.backbase.dbs.arrangement.api.integration.v2.model.TimeUnit.M));
+        Assertions.assertEquals(InterestPaymentFrequencyUnit.YEARLY, productMapper.mapInterestPayment(com.backbase.dbs.arrangement.api.integration.v2.model.TimeUnit.Y));
     }
 
     @Test
-    public void mapLegalEntityId() {
+    void mapLegalEntityId() {
         Assertions.assertNull(productMapper.mapLegalEntityId(null));
 
         List<LegalEntityReference> legalEntityReferenceList = List.of(buildLegalEntityReference("leid_1"), buildLegalEntityReference("leid_2"));
@@ -399,26 +404,4 @@ public class ProductMapperTest {
         Assertions.assertNull(productMapper.mapLegalEntityReference(null));
         Assertions.assertEquals(legalEntityIdList.size(), productMapper.mapLegalEntityReference(legalEntityIdList).size());
     }
-
-    @Test
-    public void mapUserPreference() {
-        Assertions.assertNull(productMapper.mapUserPreference(null));
-
-        UserPreferences source = new UserPreferences()
-                .userExternalId("user_ext_id")
-                .visible(true)
-                .alias("user_alias")
-                .favorite(false)
-                .putAdditionsItem("k1", "v1")
-                .putAdditionsItem("k2", "v2");
-
-        AccountUserPreferencesItemPut target = productMapper.mapUserPreference(source);
-        Assertions.assertEquals(source.getUserExternalId(), target.getUserId());
-        Assertions.assertEquals(source.getVisible(), target.getVisible());
-        Assertions.assertEquals(source.getAlias(), target.getAlias());
-        Assertions.assertEquals(source.getFavorite(), target.getFavorite());
-        Assertions.assertNotNull(target.getAdditions());
-        Assertions.assertEquals(source.getAdditions().size(), target.getAdditions().size());
-    }
-
 }

--- a/stream-product/product-core/src/test/java/com/backbase/stream/product/service/ArrangementServiceTest.java
+++ b/stream-product/product-core/src/test/java/com/backbase/stream/product/service/ArrangementServiceTest.java
@@ -1,27 +1,27 @@
 package com.backbase.stream.product.service;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.argThat;
-import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.anySet;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.backbase.dbs.arrangement.api.integration.v2.model.ArrangementAddedResponse;
+import com.backbase.dbs.arrangement.api.integration.v2.model.BatchResponseItemExtended;
+import com.backbase.dbs.arrangement.api.integration.v2.model.BatchResponseStatusCode;
+import com.backbase.dbs.arrangement.api.integration.v2.model.ErrorItem;
+import com.backbase.dbs.arrangement.api.integration.v2.model.ExternalLegalEntityIds;
+import com.backbase.dbs.arrangement.api.integration.v2.model.PostArrangement;
 import com.backbase.dbs.arrangement.api.service.ApiClient;
-import com.backbase.dbs.arrangement.api.service.v2.ArrangementsApi;
-import com.backbase.dbs.arrangement.api.service.v2.model.AccountArrangementAddedResponse;
-import com.backbase.dbs.arrangement.api.service.v2.model.AccountArrangementItem;
-import com.backbase.dbs.arrangement.api.service.v2.model.AccountArrangementItemPost;
-import com.backbase.dbs.arrangement.api.service.v2.model.AccountArrangementItemPut;
-import com.backbase.dbs.arrangement.api.service.v2.model.AccountArrangementItems;
-import com.backbase.dbs.arrangement.api.service.v2.model.AccountBatchResponseItemExtended;
-import com.backbase.dbs.arrangement.api.service.v2.model.AccountExternalLegalEntityIds;
-import com.backbase.dbs.arrangement.api.service.v2.model.AccountInternalIdGetResponseBody;
-import com.backbase.dbs.arrangement.api.service.v2.model.AccountUserPreferencesItemPut;
-import com.backbase.dbs.arrangement.api.service.v2.model.BatchResponseStatusCode;
-import com.backbase.dbs.arrangement.api.service.v2.model.ErrorItem;
+import com.backbase.dbs.arrangement.api.service.v3.ArrangementsApi;
+import com.backbase.dbs.arrangement.api.service.v3.model.ArrangementItem;
+import com.backbase.dbs.arrangement.api.service.v3.model.ArrangementPutItem;
+import com.backbase.dbs.arrangement.api.service.v3.model.ArrangementSearchesListResponse;
+import com.backbase.dbs.arrangement.api.service.v3.model.ArrangementsDeleteItem;
+import com.backbase.dbs.arrangement.api.service.v3.model.ArrangementsDeleteItem.SelectorEnum;
+import com.backbase.dbs.arrangement.api.service.v3.model.ArrangementsDeleteResponseElement;
+import com.backbase.dbs.arrangement.api.service.v3.model.ArrangementsSearchesPostRequest;
 import com.backbase.stream.product.exception.ArrangementCreationException;
 import com.backbase.stream.product.exception.ArrangementUpdateException;
 import java.util.ArrayList;
@@ -41,7 +41,7 @@ import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
 @ExtendWith(MockitoExtension.class)
-public class ArrangementServiceTest {
+class ArrangementServiceTest {
 
     @InjectMocks
     private ArrangementService arrangementService;
@@ -49,153 +49,143 @@ public class ArrangementServiceTest {
     @Mock
     private ArrangementsApi arrangementsApi;
 
-    private static WebClientResponseException buildWebClientResponseException(HttpStatus httpStatus,
-        String statusText) {
+    @Mock
+    private com.backbase.dbs.arrangement.api.integration.v2.ArrangementsApi arrangementsIntegrationApi;
+
+    private static WebClientResponseException buildWebClientResponseException(HttpStatus httpStatus, String statusText) {
         return WebClientResponseException.create(httpStatus.value(), statusText, null, null, null);
     }
 
-    private static AccountArrangementItemPost buildAccountArrangementItemPost() {
-        return new AccountArrangementItemPost()
+    private static PostArrangement buildPostArrangement() {
+        PostArrangement postArrangement = new PostArrangement();
+        postArrangement.setId("ext_arr_id");
+        postArrangement.setLegalEntityIds(Set.of("ext_leid_1", "ext_leid_2"));
+        postArrangement.setProductId("ext_prod_id");
+        postArrangement.setStateId("ext_state_id");
+        return postArrangement;
+    }
+
+    private static ArrangementPutItem buildArrangementPutItem() {
+        return new ArrangementPutItem()
             .externalArrangementId("ext_arr_id")
-            .externalLegalEntityIds(Set.of("ext_leid_1", "ext_leid_2"))
-            .legalEntityIds(Set.of("leid_1", "leid_2"))
-            .externalProductId("ext_prod_id")
-            .externalStateId("ext_state_id")
             .productId("prod_id");
     }
 
-    private static AccountArrangementItemPut buildAccountArrangementItemPut() {
-        return new AccountArrangementItemPut()
-            .externalArrangementId("ext_arr_id")
-            .productId("prod_id");
-    }
-
-    private static AccountUserPreferencesItemPut buildAccountUserPreferencesItemPut() {
-        return new AccountUserPreferencesItemPut()
-            .arrangementId("arr_id")
-            .userId("user_id");
-    }
+    // USER PREFERENCES UPDATE HAS BEEN REMOVED FROM V3 ENDPOINT ONWARDS BECAUSE USER PREFERENCES
+    // UPDATE IS AN INTERNAL OPERATION
+//    private static AccountUserPreferencesItemPut buildAccountUserPreferencesItemPut() {
+//        return new AccountUserPreferencesItemPut()
+//            .arrangementId("arr_id")
+//            .userId("user_id");
+//    }
 
     @Test
     void createArrangement() {
-        AccountArrangementItemPost request = buildAccountArrangementItemPost();
+        PostArrangement request = buildPostArrangement();
 
-        AccountArrangementAddedResponse accountArrangementAddedResponse = new AccountArrangementAddedResponse().id(
-            "arr_response_id");
-        when(arrangementsApi.postArrangements(any()))
-            .thenReturn(Mono.just(accountArrangementAddedResponse));
+        ArrangementItem accountArrangementAddedResponse = new ArrangementItem().id("arr_response_id");
+
+        ArrangementAddedResponse arrangementAddedResponse = new ArrangementAddedResponse().id(accountArrangementAddedResponse.getId());
+        when(arrangementsIntegrationApi.postArrangements(request)).thenReturn(Mono.just(arrangementAddedResponse));
 
         StepVerifier.create(arrangementService.createArrangement(request))
             .assertNext(response -> {
                 Assertions.assertNotNull(response);
                 Assertions.assertEquals(accountArrangementAddedResponse.getId(), response.getId());
-                Assertions.assertEquals(request.getExternalArrangementId(), response.getExternalArrangementId());
-                Assertions.assertEquals(request.getExternalProductId(), response.getExternalProductId());
-                Assertions.assertEquals(request.getExternalStateId(), response.getExternalStateId());
-                Assertions.assertEquals(request.getExternalProductId(), response.getExternalProductId());
+                Assertions.assertEquals(request.getProductId(), response.getProductId());
+                Assertions.assertNotNull(response.getState());
+                Assertions.assertEquals(request.getStateId(), response.getState().getState());
+                Assertions.assertEquals(request.getProductId(), response.getProductId());
                 Assertions.assertEquals(request.getLegalEntityIds(), response.getLegalEntityIds());
-            })
-            .verifyComplete();
+            }).verifyComplete();
 
-        verify(arrangementsApi).postArrangements(any());
+        verify(arrangementsIntegrationApi).postArrangements(request);
     }
 
     @Test
     void createArrangement_Failure() {
-        AccountArrangementItemPost request = buildAccountArrangementItemPost();
+        PostArrangement request = buildPostArrangement();
 
-        WebClientResponseException webClientResponseException = buildWebClientResponseException(HttpStatus.BAD_REQUEST,
-            "Bad Request for create arrangement");
+        WebClientResponseException webClientResponseException = buildWebClientResponseException(HttpStatus.BAD_REQUEST, "Bad Request for create arrangement");
 
-        when(arrangementsApi.postArrangements(any()))
-            .thenReturn(Mono.error(webClientResponseException));
+        when(arrangementsIntegrationApi.postArrangements(any())).thenReturn(Mono.error(webClientResponseException));
 
         StepVerifier.create(arrangementService.createArrangement(request))
             .consumeErrorWith(e -> {
-                Assertions.assertTrue(e instanceof ArrangementCreationException);
+                Assertions.assertInstanceOf(ArrangementCreationException.class, e);
                 Assertions.assertEquals("Failed to post arrangements", e.getMessage());
                 Assertions.assertEquals(webClientResponseException.getMessage(), e.getCause().getMessage());
-            })
-            .verify();
+            }).verify();
 
-        verify(arrangementsApi).postArrangements(any());
+        verify(arrangementsIntegrationApi).postArrangements(any());
     }
 
     @Test
     void updateArrangement() {
-        AccountArrangementItemPut request = buildAccountArrangementItemPut();
+        ArrangementPutItem request = buildArrangementPutItem();
 
-        when(arrangementsApi.putArrangements(any()))
-            .thenReturn(Mono.empty());
+        when(arrangementsApi.putArrangementById(request.getExternalArrangementId(), request)).thenReturn(Mono.empty());
 
         StepVerifier.create(arrangementService.updateArrangement(request))
             .assertNext(response -> {
                 Assertions.assertNotNull(response);
                 Assertions.assertEquals(request.getExternalArrangementId(), response.getExternalArrangementId());
                 Assertions.assertEquals(request.getProductId(), response.getProductId());
-            })
-            .verifyComplete();
+            }).verifyComplete();
 
-        verify(arrangementsApi).putArrangements(any());
+        verify(arrangementsApi).putArrangementById(request.getExternalArrangementId(), request);
     }
 
     @Test
     void updateArrangement_Failure() {
-        AccountArrangementItemPut request = buildAccountArrangementItemPut();
+        ArrangementPutItem request = buildArrangementPutItem();
 
-        WebClientResponseException webClientResponseException = buildWebClientResponseException(HttpStatus.BAD_REQUEST,
-            "Bad Request for update arrangement");
-        when(arrangementsApi.putArrangements(any()))
-            .thenReturn(Mono.error(webClientResponseException));
+        WebClientResponseException webClientResponseException = buildWebClientResponseException(HttpStatus.BAD_REQUEST, "Bad Request for update arrangement");
+        when(arrangementsApi.putArrangementById(request.getExternalArrangementId(), request)).thenReturn(Mono.error(webClientResponseException));
 
         StepVerifier.create(arrangementService.updateArrangement(request))
             .consumeErrorWith(e -> {
-                Assertions.assertTrue(e instanceof ArrangementUpdateException);
-                Assertions.assertEquals("Failed to update Arrangement: " + request.getExternalArrangementId(),
-                    e.getMessage());
+                Assertions.assertInstanceOf(ArrangementUpdateException.class, e);
+                Assertions.assertEquals("Failed to update Arrangement: %s".formatted(request.getExternalArrangementId()), e.getMessage());
                 Assertions.assertEquals(webClientResponseException.getMessage(), e.getCause().getMessage());
-            })
-            .verify();
+            }).verify();
 
-        verify(arrangementsApi).putArrangements(any());
+        verify(arrangementsApi).putArrangementById(request.getExternalArrangementId(), request);
     }
 
     @Test
     void upsertBatchArrangements() {
-        AccountArrangementItemPost request = buildAccountArrangementItemPost();
+        PostArrangement request = buildPostArrangement();
 
-        AccountBatchResponseItemExtended accountBatchResponseItemExtended = new AccountBatchResponseItemExtended()
+        BatchResponseItemExtended accountBatchResponseItemExtended = (BatchResponseItemExtended) new BatchResponseItemExtended()
             .arrangementId("arr_id")
             .resourceId("resource_id")
             .status(BatchResponseStatusCode.HTTP_STATUS_OK);
 
-        when(arrangementsApi.postBatchUpsertArrangements(any()))
-            .thenReturn(Flux.just(accountBatchResponseItemExtended));
+        when(arrangementsIntegrationApi.postBatchUpsertArrangements(any())).thenReturn(Flux.just(accountBatchResponseItemExtended));
 
         StepVerifier.create(arrangementService.upsertBatchArrangements(List.of(request)))
             .assertNext(response -> {
                 Assertions.assertNotNull(response);
                 Assertions.assertEquals(accountBatchResponseItemExtended.getArrangementId(),
                     response.getArrangementId());
-            })
-            .verifyComplete();
+            }).verifyComplete();
 
-        verify(arrangementsApi).postBatchUpsertArrangements(any());
+        verify(arrangementsIntegrationApi).postBatchUpsertArrangements(any());
     }
 
     @Test
     void upsertBatchArrangements_Batch_Error() {
-        AccountArrangementItemPost request = buildAccountArrangementItemPost();
+        PostArrangement request = buildPostArrangement();
 
-        AccountBatchResponseItemExtended accountBatchResponseItemExtended = new AccountBatchResponseItemExtended()
-            .arrangementId("arr_id")
-            .resourceId("resource_id")
-            .status(BatchResponseStatusCode.HTTP_STATUS_BAD_REQUEST)
-            .addErrorsItem(new ErrorItem().message("Some error"))
-            .addErrorsItem(new ErrorItem().message("Some other error"));
+        BatchResponseItemExtended accountBatchResponseItemExtended = new BatchResponseItemExtended();
+        accountBatchResponseItemExtended.setArrangementId("arr_id");
+        accountBatchResponseItemExtended.setResourceId("resource_id");
+        accountBatchResponseItemExtended.setStatus(BatchResponseStatusCode.HTTP_STATUS_BAD_REQUEST);
+        accountBatchResponseItemExtended.addErrorsItem(new ErrorItem().message("Some error"));
+        accountBatchResponseItemExtended.addErrorsItem(new ErrorItem().message("Some other error"));
 
-        when(arrangementsApi.postBatchUpsertArrangements(any()))
-            .thenReturn(Flux.just(accountBatchResponseItemExtended));
+        when(arrangementsIntegrationApi.postBatchUpsertArrangements(any())).thenReturn(Flux.just(accountBatchResponseItemExtended));
 
         StepVerifier.create(arrangementService.upsertBatchArrangements(List.of(request)))
             .consumeErrorWith(e -> {
@@ -203,76 +193,40 @@ public class ArrangementServiceTest {
                 Assertions.assertTrue(errorMessage.startsWith("Batch arrangement update failed: 'resource_id'"));
                 Assertions.assertTrue(errorMessage.contains("message: Some error"));
                 Assertions.assertTrue(errorMessage.contains("message: Some other error"));
-            })
-            .verify();
+            }).verify();
 
-        verify(arrangementsApi).postBatchUpsertArrangements(any());
+        verify(arrangementsIntegrationApi).postBatchUpsertArrangements(any());
     }
 
     @Test
     void upsertBatchArrangements_Failure() {
-        AccountArrangementItemPost request = buildAccountArrangementItemPost();
+        PostArrangement request = buildPostArrangement();
 
-        WebClientResponseException webClientResponseException = buildWebClientResponseException(HttpStatus.BAD_REQUEST,
-            "Bad Request for upsert arrangement");
-        when(arrangementsApi.postBatchUpsertArrangements(any()))
-            .thenReturn(Flux.error(webClientResponseException));
+        WebClientResponseException webClientResponseException = buildWebClientResponseException(HttpStatus.BAD_REQUEST, "Bad Request for upsert arrangement");
+        when(arrangementsIntegrationApi.postBatchUpsertArrangements(any())).thenReturn(Flux.error(webClientResponseException));
 
         StepVerifier.create(arrangementService.upsertBatchArrangements(List.of(request)))
             .consumeErrorWith(e -> {
-                Assertions.assertTrue(e instanceof ArrangementUpdateException);
+                Assertions.assertInstanceOf(ArrangementUpdateException.class, e);
                 Assertions.assertEquals("Batch arrangement update failed: " + List.of(request), e.getMessage());
                 Assertions.assertEquals(webClientResponseException.getMessage(), e.getCause().getMessage());
-            })
-            .verify();
+            }).verify();
 
-        verify(arrangementsApi).postBatchUpsertArrangements(any());
-    }
-
-    @Test
-    void updateUserPreferences() {
-        AccountUserPreferencesItemPut request = buildAccountUserPreferencesItemPut();
-
-        when(arrangementsApi.putUserPreferences(any()))
-            .thenReturn(Mono.empty());
-
-        // arrangementService.updateUserPreferences(request).block();
-
-        StepVerifier.create(arrangementService.updateUserPreferences(request))
-            .verifyComplete();
-
-        verify(arrangementsApi).putUserPreferences(any());
-    }
-
-    @Test
-    void updateUserPreferences_NotFound() {
-        AccountUserPreferencesItemPut request = buildAccountUserPreferencesItemPut();
-
-        WebClientResponseException webClientResponseException = buildWebClientResponseException(HttpStatus.NOT_FOUND,
-            "User Not Found");
-        when(arrangementsApi.putUserPreferences(any()))
-            .thenReturn(Mono.error(webClientResponseException));
-
-        StepVerifier.create(arrangementService.updateUserPreferences(request))
-            .verifyComplete();
-
-        verify(arrangementsApi).putUserPreferences(any());
+        verify(arrangementsIntegrationApi).postBatchUpsertArrangements(any());
     }
 
     @Test
     void getArrangement() {
         String internalId = "internal_id";
-        AccountArrangementItem accountArrangementItem = new AccountArrangementItem().id("acct_arr_item_id");
 
-        when(arrangementsApi.getArrangementById(internalId, false))
-            .thenReturn(Mono.just(accountArrangementItem));
+        ArrangementItem arrangementItem = new ArrangementItem().id("acct_arr_item_id");
+        when(arrangementsApi.getArrangementById(internalId, false)).thenReturn(Mono.just(arrangementItem));
 
         StepVerifier.create(arrangementService.getArrangement(internalId))
             .assertNext(response -> {
                 Assertions.assertNotNull(response);
-                Assertions.assertEquals(response.getId(), accountArrangementItem.getId());
-            })
-            .verifyComplete();
+                Assertions.assertEquals(response.getId(), arrangementItem.getId());
+            }).verifyComplete();
 
         verify(arrangementsApi).getArrangementById(internalId, false);
     }
@@ -281,13 +235,10 @@ public class ArrangementServiceTest {
     void getArrangement_NotFound() {
         String internalId = "internal_id";
 
-        WebClientResponseException webClientResponseException = buildWebClientResponseException(HttpStatus.NOT_FOUND,
-            "Arrangement Not Found");
-        when(arrangementsApi.getArrangementById(internalId, false))
-            .thenReturn(Mono.error(webClientResponseException));
+        WebClientResponseException webClientResponseException = buildWebClientResponseException(HttpStatus.NOT_FOUND, "Arrangement Not Found");
+        when(arrangementsApi.getArrangementById(internalId, false)).thenReturn(Mono.error(webClientResponseException));
 
-        StepVerifier.create(arrangementService.getArrangement(internalId))
-            .verifyComplete();
+        StepVerifier.create(arrangementService.getArrangement(internalId)).verifyComplete();
 
         verify(arrangementsApi).getArrangementById(internalId, false);
     }
@@ -296,203 +247,216 @@ public class ArrangementServiceTest {
     void getArrangementByExternalId() {
         String externalId = "external_id";
 
-        AccountArrangementItem accountArrangementItem = new AccountArrangementItem().id("acct_arr_item_id");
-        AccountArrangementItems accountArrangementItems = new AccountArrangementItems()
-            .addArrangementElementsItem(accountArrangementItem);
-        when(arrangementsApi.getArrangements(null, null, List.of(externalId)))
-            .thenReturn(Mono.just(accountArrangementItems));
+        ArrangementsSearchesPostRequest arrangementsSearchesPostRequest = new ArrangementsSearchesPostRequest();
+        arrangementsSearchesPostRequest.setExternalArrangementIds(Set.of(externalId));
+
+        ArrangementSearchesListResponse arrangementSearchesListResponse = new ArrangementSearchesListResponse();
+
+        ArrangementItem arrangementItem = new ArrangementItem().id("acct_arr_item_id");
+        arrangementSearchesListResponse.setArrangementElements(List.of(arrangementItem));
+
+        when(arrangementsApi.postSearchArrangements(arrangementsSearchesPostRequest)).thenReturn(Mono.just(arrangementSearchesListResponse));
 
         StepVerifier.create(arrangementService.getArrangementByExternalId(externalId))
             .assertNext(response -> {
                 Assertions.assertNotNull(response);
-                Assertions.assertEquals(response.getId(), accountArrangementItem.getId());
-            })
-            .verifyComplete();
+                Assertions.assertEquals(response.getId(), arrangementItem.getId());
+            }).verifyComplete();
 
-        verify(arrangementsApi).getArrangements(null, null, List.of(externalId));
+        verify(arrangementsApi).postSearchArrangements(arrangementsSearchesPostRequest);
     }
 
     @Test
     void getArrangementByExternalId_NotFound() {
         String externalId = "external_id";
 
-        when(arrangementsApi.getArrangements(null, null, List.of(externalId)))
-            .thenReturn(Mono.empty());
+        ArrangementsSearchesPostRequest arrangementsSearchesPostRequest = new ArrangementsSearchesPostRequest();
+        arrangementsSearchesPostRequest.setExternalArrangementIds(Set.of(externalId));
+        when(arrangementsApi.postSearchArrangements(arrangementsSearchesPostRequest)).thenReturn(Mono.empty());
 
-        StepVerifier.create(arrangementService.getArrangementByExternalId(externalId))
-            .verifyComplete();
+        StepVerifier.create(arrangementService.getArrangementByExternalId(externalId)).verifyComplete();
 
-        verify(arrangementsApi).getArrangements(null, null, List.of(externalId));
+        verify(arrangementsApi).postSearchArrangements(arrangementsSearchesPostRequest);
     }
 
     @Test
     void getArrangementInternalId() {
         String externalId = "external_id";
-        AccountInternalIdGetResponseBody accountInternalIdGetResponseBody =
-            new AccountInternalIdGetResponseBody().internalId("internal_id");
 
-        when(arrangementsApi.getInternalId(externalId))
-            .thenReturn(Mono.just(accountInternalIdGetResponseBody));
+        ArrangementsSearchesPostRequest arrangementsSearchesPostRequest = new ArrangementsSearchesPostRequest();
+        arrangementsSearchesPostRequest.setExternalArrangementIds(Set.of(externalId));
+
+        ArrangementItem arrangementItem = new ArrangementItem();
+        arrangementItem.setId("internal_id");
+
+        ArrangementSearchesListResponse arrangementSearchesListResponse = new ArrangementSearchesListResponse();
+        arrangementSearchesListResponse.setArrangementElements(List.of(arrangementItem));
+
+        when(arrangementsApi.postSearchArrangements(arrangementsSearchesPostRequest)).thenReturn(Mono.just(arrangementSearchesListResponse));
 
         StepVerifier.create(arrangementService.getArrangementInternalId(externalId))
-            .assertNext(response -> Assertions.assertEquals(response, accountInternalIdGetResponseBody.getInternalId()))
+            .assertNext(response -> Assertions.assertEquals(response, arrangementItem.getId()))
             .verifyComplete();
 
-        verify(arrangementsApi).getInternalId(externalId);
+        verify(arrangementsApi).postSearchArrangements(arrangementsSearchesPostRequest);
     }
 
     @Test
     void getArrangementInternalId_NotFound() {
         String externalId = "external_id";
 
-        WebClientResponseException webClientResponseException = buildWebClientResponseException(HttpStatus.NOT_FOUND,
-            "Arrangement Not Found");
-        when(arrangementsApi.getInternalId(externalId))
-            .thenReturn(Mono.error(webClientResponseException));
+        WebClientResponseException webClientResponseException = buildWebClientResponseException(HttpStatus.NOT_FOUND, "Arrangement Not Found");
 
-        StepVerifier.create(arrangementService.getArrangementInternalId(externalId))
-            .verifyComplete();
+        ArrangementsSearchesPostRequest arrangementsSearchesPostRequest = new ArrangementsSearchesPostRequest();
+        arrangementsSearchesPostRequest.setExternalArrangementIds(Set.of(externalId));
 
-        verify(arrangementsApi).getInternalId(externalId);
+        when(arrangementsApi.postSearchArrangements(arrangementsSearchesPostRequest)).thenReturn(Mono.error(webClientResponseException));
+
+        StepVerifier.create(arrangementService.getArrangementInternalId(externalId)).verifyComplete();
+
+        verify(arrangementsApi).postSearchArrangements(arrangementsSearchesPostRequest);
     }
 
     @Test
     void getArrangementInternalId_Failure() {
         String externalId = "external_id";
 
-        WebClientResponseException webClientResponseException = buildWebClientResponseException(HttpStatus.BAD_REQUEST,
-            "Bad Request to get Internal Id");
-        when(arrangementsApi.getInternalId(externalId))
-            .thenReturn(Mono.error(webClientResponseException));
+        WebClientResponseException webClientResponseException = buildWebClientResponseException(HttpStatus.BAD_REQUEST, "Bad Request to get Internal Id");
 
-        StepVerifier.create(arrangementService.getArrangementInternalId(externalId))
-            .verifyComplete();
+        ArrangementsSearchesPostRequest arrangementsSearchesPostRequest = new ArrangementsSearchesPostRequest();
+        arrangementsSearchesPostRequest.setExternalArrangementIds(Set.of(externalId));
 
-        verify(arrangementsApi).getInternalId(externalId);
+        when(arrangementsApi.postSearchArrangements(arrangementsSearchesPostRequest)).thenReturn(Mono.error(webClientResponseException));
+
+        StepVerifier.create(arrangementService.getArrangementInternalId(externalId)).verifyComplete();
+
+        verify(arrangementsApi).postSearchArrangements(arrangementsSearchesPostRequest);
     }
 
     @Test
     void deleteArrangementByInternalId() {
         String arrangementInternalId = "arr_internal_id";
-        AccountArrangementItem accountArrangementItem = new AccountArrangementItem()
-            .externalArrangementId("ext_arr_id");
 
-        when(arrangementsApi.getArrangementById(arrangementInternalId, false))
-            .thenReturn(Mono.just(accountArrangementItem));
+        ArrangementItem arrangementItem = new ArrangementItem();
+        arrangementItem.setExternalArrangementId("ext_arr_id");
 
-        when(arrangementsApi.deleteExternalArrangementId(accountArrangementItem.getExternalArrangementId()))
-            .thenReturn(Mono.empty());
+        ArrangementsDeleteItem arrangementsDeleteItem = new ArrangementsDeleteItem();
+        arrangementsDeleteItem.setSelector(SelectorEnum.EXTERNAL_ID);
+        arrangementsDeleteItem.setValue("ext_arr_id");
+
+        Set<ArrangementsDeleteItem> arrangementsDeleteItemSet = Set.of(arrangementsDeleteItem);
+        ArrangementsDeleteResponseElement arrangementsDeleteResponseElement = new ArrangementsDeleteResponseElement();
+        arrangementsDeleteResponseElement.setValue(arrangementItem.getExternalArrangementId());
+        arrangementsDeleteResponseElement.setSelector(ArrangementsDeleteResponseElement.SelectorEnum.EXTERNAL_ID);
+
+        when(arrangementsApi.getArrangementById(arrangementInternalId, false)).thenReturn(Mono.just(arrangementItem));
+        when(arrangementsApi.postDelete(arrangementsDeleteItemSet)).thenReturn(Flux.just(arrangementsDeleteResponseElement));
 
         StepVerifier.create(arrangementService.deleteArrangementByInternalId(arrangementInternalId))
-            .expectNext(arrangementInternalId)
-            .verifyComplete();
+            .expectNext(arrangementInternalId).verifyComplete();
 
         verify(arrangementsApi).getArrangementById(arrangementInternalId, false);
-        verify(arrangementsApi).deleteExternalArrangementId(accountArrangementItem.getExternalArrangementId());
+        verify(arrangementsApi).postDelete(arrangementsDeleteItemSet);
     }
 
     @Test
     void deleteArrangementByInternalId_GetArrangement_Failure() {
         String arrangementInternalId = "arr_internal_id";
 
-        WebClientResponseException webClientResponseException = buildWebClientResponseException(
-            HttpStatus.INTERNAL_SERVER_ERROR, "Some error");
+        WebClientResponseException webClientResponseException = buildWebClientResponseException(HttpStatus.INTERNAL_SERVER_ERROR, "Some error");
 
-        when(arrangementsApi.getArrangementById(arrangementInternalId, false))
-            .thenReturn(Mono.error(webClientResponseException));
+        when(arrangementsApi.getArrangementById(arrangementInternalId, false)).thenReturn(Mono.error(webClientResponseException));
 
         StepVerifier.create(arrangementService.deleteArrangementByInternalId(arrangementInternalId))
-            .expectNext(arrangementInternalId)
-            .verifyComplete();
+                    .expectNext(arrangementInternalId).verifyComplete();
 
-        verify(arrangementsApi, times(1)).getArrangementById(arrangementInternalId, false);
-        verify(arrangementsApi, times(0)).deleteExternalArrangementId(anyString());
+        verify(arrangementsApi).getArrangementById(arrangementInternalId, false);
+        verify(arrangementsApi, times(0)).postDelete(anySet());
     }
 
     @Test
     void deleteArrangementByInternalId_DeleteArrangement_Failure() {
         String arrangementInternalId = "arr_internal_id";
 
-        AccountArrangementItem accountArrangementItem = new AccountArrangementItem()
-            .externalArrangementId("ext_arr_id");
-        when(arrangementsApi.getArrangementById(arrangementInternalId, false))
-            .thenReturn(Mono.just(accountArrangementItem));
+        ArrangementItem accountArrangementItem = new ArrangementItem().externalArrangementId("ext_arr_id");
 
-        WebClientResponseException webClientResponseException = buildWebClientResponseException(
-            HttpStatus.INTERNAL_SERVER_ERROR, "Some error");
-        when(arrangementsApi.deleteExternalArrangementId(accountArrangementItem.getExternalArrangementId()))
-            .thenReturn(Mono.error(webClientResponseException));
+        when(arrangementsApi.getArrangementById(arrangementInternalId, false)).thenReturn(Mono.just(accountArrangementItem));
+        WebClientResponseException webClientResponseException = buildWebClientResponseException(HttpStatus.INTERNAL_SERVER_ERROR, "Some error");
+
+        ArrangementsDeleteItem arrangementsDeleteItem = new ArrangementsDeleteItem();
+        arrangementsDeleteItem.setSelector(SelectorEnum.EXTERNAL_ID);
+        arrangementsDeleteItem.setValue(accountArrangementItem.getExternalArrangementId());
+
+        Set<ArrangementsDeleteItem> arrangementsDeleteItemSet = Set.of(arrangementsDeleteItem);
+        when(arrangementsApi.postDelete(arrangementsDeleteItemSet)).thenReturn(Flux.error(webClientResponseException));
 
         StepVerifier.create(arrangementService.deleteArrangementByInternalId(arrangementInternalId))
             .consumeErrorWith(e -> {
-                Assertions.assertTrue(e instanceof WebClientResponseException);
+                Assertions.assertInstanceOf(WebClientResponseException.class, e);
                 Assertions.assertEquals("500 Some error", e.getMessage());
-            })
-            .verify();
+            }).verify();
 
-        verify(arrangementsApi, times(1)).getArrangementById(arrangementInternalId, false);
-        verify(arrangementsApi, times(1)).deleteExternalArrangementId(anyString());
+        verify(arrangementsApi).getArrangementById(arrangementInternalId, false);
+        verify(arrangementsApi).postDelete(arrangementsDeleteItemSet);
     }
 
     @Test
     void addLegalEntitiesForArrangement() {
         String arrangementExternalId = "arr_ext_id";
         Set<String> legalEntitiesExternalIds = Set.of("leid_1", "leid_2");
-        AccountExternalLegalEntityIds accountExternalLegalEntityIds =
-            new AccountExternalLegalEntityIds().ids(legalEntitiesExternalIds);
 
-        when(arrangementsApi.postArrangementLegalEntities(arrangementExternalId, accountExternalLegalEntityIds))
+        ExternalLegalEntityIds externalLegalEntityIds = new ExternalLegalEntityIds();
+        externalLegalEntityIds.ids(legalEntitiesExternalIds);
+
+        when(arrangementsIntegrationApi.postArrangementLegalEntities(arrangementExternalId, externalLegalEntityIds))
             .thenReturn(Mono.empty());
 
-        StepVerifier.create(arrangementService.addLegalEntitiesForArrangement(arrangementExternalId,
-                new ArrayList<>(legalEntitiesExternalIds)))
+        StepVerifier.create(arrangementService.addLegalEntitiesForArrangement(arrangementExternalId, new ArrayList<>(legalEntitiesExternalIds)))
             .verifyComplete();
 
-        verify(arrangementsApi).postArrangementLegalEntities(arrangementExternalId, accountExternalLegalEntityIds);
+        verify(arrangementsIntegrationApi).postArrangementLegalEntities(arrangementExternalId, externalLegalEntityIds);
     }
 
     @Test
     void addLegalEntitiesForArrangement_Failure() {
         String arrangementExternalId = "arr_ext_id";
         Set<String> legalEntitiesExternalIds = Set.of("leid_1", "leid_2");
-        AccountExternalLegalEntityIds accountExternalLegalEntityIds =
-            new AccountExternalLegalEntityIds().ids(legalEntitiesExternalIds);
 
-        WebClientResponseException webClientResponseException = buildWebClientResponseException(
-            HttpStatus.INTERNAL_SERVER_ERROR, "Some error");
-        when(arrangementsApi.postArrangementLegalEntities(arrangementExternalId, accountExternalLegalEntityIds))
+        WebClientResponseException webClientResponseException = buildWebClientResponseException(HttpStatus.INTERNAL_SERVER_ERROR, "Some error");
+
+        ExternalLegalEntityIds externalLegalEntityIds = new ExternalLegalEntityIds();
+        externalLegalEntityIds.ids(legalEntitiesExternalIds);
+
+        when(arrangementsIntegrationApi.postArrangementLegalEntities(arrangementExternalId, externalLegalEntityIds))
             .thenReturn(Mono.error(webClientResponseException));
 
         StepVerifier.create(arrangementService.addLegalEntitiesForArrangement(arrangementExternalId,
-                new ArrayList<>(legalEntitiesExternalIds)))
-            .consumeErrorWith(e -> {
-                Assertions.assertTrue(e instanceof WebClientResponseException);
-                Assertions.assertEquals("500 Some error", e.getMessage());
-            })
-            .verify();
+            new ArrayList<>(legalEntitiesExternalIds))).consumeErrorWith(e -> {
+            Assertions.assertInstanceOf(WebClientResponseException.class, e);
+            Assertions.assertEquals("500 Some error", e.getMessage());
+        }).verify();
 
-        verify(arrangementsApi).postArrangementLegalEntities(arrangementExternalId, accountExternalLegalEntityIds);
+        verify(arrangementsIntegrationApi).postArrangementLegalEntities(arrangementExternalId, externalLegalEntityIds);
     }
 
     @Test
     @Disabled
     void removeLegalEntityFromArrangement() {
         String arrangementExternalId = "arr_ext_id";
-        List<String> legalEntityExternalIds = List.of("leid_1", "leid_2");
+        Set<String> legalEntityExternalIds = Set.of("leid_1", "leid_2");
 
         ApiClient apiClient = mock(ApiClient.class);
-        when(arrangementsApi.getApiClient())
-            .thenReturn(apiClient);
+        when(arrangementsApi.getApiClient()).thenReturn(apiClient);
 
-        verify(arrangementsApi).deleteArrangementLegalEntities(eq(arrangementExternalId),
-            argThat(accountExternalLegalEntityIds -> accountExternalLegalEntityIds.getIds()
-                    .containsAll(legalEntityExternalIds)));
+        ExternalLegalEntityIds externalLegalEntityIds = new ExternalLegalEntityIds();
+        externalLegalEntityIds.setIds(legalEntityExternalIds);
+
+        verify(arrangementsIntegrationApi).deleteArrangementLegalEntities(arrangementExternalId, externalLegalEntityIds);
 
         StepVerifier.create(arrangementService.removeLegalEntityFromArrangement(arrangementExternalId,
-                legalEntityExternalIds))
-            .verifyComplete();
+                legalEntityExternalIds.stream().toList())).verifyComplete();
 
-        verify(arrangementsApi).getApiClient();
+        verify(arrangementsIntegrationApi).getApiClient();
     }
 
     @Test
@@ -503,25 +467,21 @@ public class ArrangementServiceTest {
 
         ApiClient apiClient = mock(ApiClient.class);
 
-        when(arrangementsApi.getApiClient())
-            .thenReturn(apiClient);
+        when(arrangementsApi.getApiClient()).thenReturn(apiClient);
 
-        WebClientResponseException webClientResponseException = buildWebClientResponseException(
-            HttpStatus.INTERNAL_SERVER_ERROR, "Some error");
+        WebClientResponseException webClientResponseException = buildWebClientResponseException(HttpStatus.INTERNAL_SERVER_ERROR, "Some error");
 
-        verify(arrangementsApi).deleteArrangementLegalEntities(eq(arrangementExternalId),
-            argThat(accountExternalLegalEntityIds -> accountExternalLegalEntityIds.getIds()
-                .containsAll(legalEntityExternalIds)))
+        ExternalLegalEntityIds externalLegalEntityIds = new ExternalLegalEntityIds();
+        externalLegalEntityIds.setIds(legalEntityExternalIds);
+
+        verify(arrangementsIntegrationApi).deleteArrangementLegalEntities(arrangementExternalId, externalLegalEntityIds)
             .thenReturn(Mono.error(webClientResponseException));
 
-        StepVerifier.create(
-                arrangementService.removeLegalEntityFromArrangement(arrangementExternalId,
-                    new ArrayList<>(legalEntityExternalIds)))
+        StepVerifier.create(arrangementService.removeLegalEntityFromArrangement(arrangementExternalId, new ArrayList<>(legalEntityExternalIds)))
             .consumeErrorWith(e -> {
-                Assertions.assertTrue(e instanceof WebClientResponseException);
+                Assertions.assertInstanceOf(WebClientResponseException.class, e);
                 Assertions.assertEquals("500 Some error", e.getMessage());
-            })
-            .verify();
+            }).verify();
 
         verify(arrangementsApi).getApiClient();
     }


### PR DESCRIPTION
## Description

**Arrangement Manager API** has been updated to `V3`, impacting its dependencies as follows:
  - **User Preferences Update Operations:** These operations are no longer available. Since they were internal, the related `POST` and `PUT` endpoints have been removed. Consequently, any processes that involved creating or updating **User Preferences** have also been eliminated.
  - **Arrangement Batch Upsert Operation:** This operation has been removed from the service-api layer and is now only available in the integration-api layer. It is primarily used for data ingestion by banks into Backbase’s platform. All data ingestion streams now use the integration-api for this purpose. The only change required is to use a different endpoint.
  - **Retrieving Arrangements:** In `V3`, calls to retrieve a list of arrangements or an arrangement by `ID` can now be made using the new `POST /service-api/v3/arrangements/searches` endpoint. This endpoint provides multiple ways to retrieve arrangements through a single API call.
  - **Product Kind Operations:** Only `GET` operations are now available for **Product Kinds**. The database management has been _deprecated_, as **Product Kind** data is now maintained statically through a `YAML` settings file in **Arrangement Manager**. As a result, `POST` and `PUT` endpoints are no longer available.

## Checklist

 - [X] I made sure, I read [CONTRIBUTING.md](CONTRIBUTING.md) to put right branch prefix as per my need.
 - [X] I made sure to update [CHANGELOG.md](CHANGELOG.md).
 - [ ] I made sure to update [Stream Wiki](https://github.com/Backbase/stream-services/wiki)(only valid in case of new stream module or architecture changes). ~ N/A
 - [X] My changes are adequately tested.
 - [X] I made sure all the SonarCloud Quality Gate are passed.
