### PR TITLE
Maint 31100 contacts conditional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
-## [5.9.0](https://github.com/Backbase/stream-services/compare/5.8.0...5.9.0)
+## [5.8.0](https://github.com/Backbase/stream-services/compare/5.7.0...5.8.0)
 ### Changed
 - make ContactsSaga use continueOnError flag
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [5.9.0](https://github.com/Backbase/stream-services/compare/5.8.0...5.9.0)
+### Changed
+- make ContactsSaga use continueOnError flag
+
 ## [5.7.0](https://github.com/Backbase/stream-services/compare/5.6.0...5.7.0)
 ### Changed
 - bug fixed - missing stream-starter module in stream-sdk

--- a/stream-contacts/contacts-core/src/main/java/com/backbase/stream/configuration/ContactsServiceConfiguration.java
+++ b/stream-contacts/contacts-core/src/main/java/com/backbase/stream/configuration/ContactsServiceConfiguration.java
@@ -20,8 +20,9 @@ import org.springframework.context.annotation.Configuration;
 public class ContactsServiceConfiguration {
 
     @Bean
-    public ContactsSaga contactsSaga(ContactsApi contactsApi) {
-        return new ContactsSaga(contactsApi);
+    public ContactsSaga contactsSaga(ContactsApi contactsApi,
+        ContactsWorkerConfigurationProperties contactsWorkerConfigurationProperties) {
+        return new ContactsSaga(contactsApi, contactsWorkerConfigurationProperties);
     }
 
     public static class InMemoryContactsUnitOfWorkRepository extends


### PR DESCRIPTION
## Description

Make use of continueOnError flag for Contacts ingestion. Currently subsequent runs of bootstrap with contacts fail on contacts re-ingestion and require cleanup of contact DB which is very annoying for development 

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
  
  Add N/A to the task if they are not relevant to the current PR(validation will be skipped). 
  e.g. [ ] My changes are adequately tested ~ N/A
-->

 - [x] I made sure, I read [CONTRIBUTING.md](CONTRIBUTING.md) to put right branch prefix as per my need.
 - [x] I made sure to update [CHANGELOG.md](CHANGELOG.md).
 - [x] I made sure to update [Stream Wiki](https://github.com/Backbase/stream-services/wiki)(only valid in case of new stream module or architecture changes).
 - [x] My changes are adequately tested.
 - [x] I made sure all the SonarCloud Quality Gate are passed.
