### PR TITLE
Hotfix/po arr duplicate retrieval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [4.1.6](https://github.com/Backbase/stream-services/compare/4.1.4...4.1.6)
+### Fix
+- Fix arrangements being retrieved per payment order instead of once per payment order ingestion request.
+- 
 ## [4.1.4](https://github.com/Backbase/stream-services/compare/4.1.3...4.1.4)
 ### Fix
 - Fixed deletion of non-repository custom data-group items on data-group update

--- a/stream-payment-order/payment-order-core/src/main/java/com/backbase/stream/model/PaymentOrderIngestContext.java
+++ b/stream-payment-order/payment-order-core/src/main/java/com/backbase/stream/model/PaymentOrderIngestContext.java
@@ -1,5 +1,6 @@
 package com.backbase.stream.model;
 
+import com.backbase.dbs.arrangement.api.service.v2.model.AccountArrangementItem;
 import com.backbase.dbs.arrangement.api.service.v2.model.AccountArrangementItems;
 import java.util.ArrayList;
 import java.util.List;
@@ -17,5 +18,5 @@ public class PaymentOrderIngestContext {
     private String internalUserId;
     private List<PaymentOrderPostRequest> corePaymentOrder = new ArrayList<>();
     private List<GetPaymentOrderResponse> existingPaymentOrder = new ArrayList<>();
-    private List<AccountArrangementItems> arrangementIds = new ArrayList<>();
+    private List<AccountArrangementItem> arrangementIds = new ArrayList<>();
 }

--- a/stream-payment-order/payment-order-core/src/main/java/com/backbase/stream/paymentorder/PaymentOrderUnitOfWorkExecutor.java
+++ b/stream-payment-order/payment-order-core/src/main/java/com/backbase/stream/paymentorder/PaymentOrderUnitOfWorkExecutor.java
@@ -133,7 +133,8 @@ public class PaymentOrderUnitOfWorkExecutor extends UnitOfWorkExecutor<PaymentOr
 
     private Mono<List<AccountArrangementItem>> getArrangements(@NotNull List<PaymentOrderPostRequest> coreRequests) {
         final Set<String> externalIds = coreRequests.stream().map(PaymentOrderPostRequest::getOriginatorAccount)
-                .filter(Objects::nonNull).map(SimpleOriginatorAccount::getExternalArrangementId).collect(toSet());
+                .filter(Objects::nonNull).map(SimpleOriginatorAccount::getExternalArrangementId).filter(Objects::nonNull)
+                .collect(toSet());
         final var externalArrangementIdFilter =  new AccountArrangementsFilter().externalArrangementIds(externalIds);
         return arrangementsApi.postFilter(externalArrangementIdFilter)
                 .map(AccountArrangementItems::getArrangementElements).defaultIfEmpty(emptyList());

--- a/stream-payment-order/payment-order-core/src/main/java/com/backbase/stream/paymentorder/PaymentOrderUnitOfWorkExecutor.java
+++ b/stream-payment-order/payment-order-core/src/main/java/com/backbase/stream/paymentorder/PaymentOrderUnitOfWorkExecutor.java
@@ -1,5 +1,8 @@
 package com.backbase.stream.paymentorder;
 
+import static java.util.stream.Collectors.toList;
+import static org.apache.commons.lang3.ObjectUtils.defaultIfNull;
+import static java.util.stream.Collectors.toSet;
 import static com.backbase.dbs.paymentorder.api.service.v2.model.Status.ACCEPTED;
 import static com.backbase.dbs.paymentorder.api.service.v2.model.Status.CANCELLATION_PENDING;
 import static com.backbase.dbs.paymentorder.api.service.v2.model.Status.CANCELLED;
@@ -22,19 +25,14 @@ import java.math.BigDecimal;
 import java.time.Duration;
 import com.backbase.dbs.paymentorder.api.service.v2.model.AccessFilter;
 import com.backbase.stream.config.PaymentOrderTypeConfiguration;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.stream.Collectors;
+import java.util.*;
 import java.util.stream.Stream;
 
+import com.backbase.dbs.paymentorder.api.service.v2.model.*;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 
 import com.backbase.dbs.paymentorder.api.service.v2.PaymentOrdersApi;
-import com.backbase.dbs.paymentorder.api.service.v2.model.GetPaymentOrderResponse;
-import com.backbase.dbs.paymentorder.api.service.v2.model.PaymentOrderPostFilterRequest;
-import com.backbase.dbs.paymentorder.api.service.v2.model.PaymentOrderPostFilterResponse;
-import com.backbase.dbs.paymentorder.api.service.v2.model.PaymentOrderPostRequest;
 import com.backbase.stream.config.PaymentOrderWorkerConfigurationProperties;
 import com.backbase.stream.mappers.PaymentOrderTypeMapper;
 import com.backbase.stream.model.PaymentOrderIngestContext;
@@ -49,6 +47,7 @@ import com.backbase.stream.worker.model.UnitOfWork;
 import com.backbase.stream.worker.repository.UnitOfWorkRepository;
 
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.ObjectUtils;
 import org.springframework.web.reactive.function.client.WebClientRequestException;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
 import reactor.core.publisher.Flux;
@@ -127,19 +126,17 @@ public class PaymentOrderUnitOfWorkExecutor extends UnitOfWorkExecutor<PaymentOr
                         log.debug("Successfully fetched dbs scheduled payment orders"));
     }
 
-    private @NotNull @Valid Mono<PaymentOrderIngestContext> addArrangementIdMap(PaymentOrderIngestContext paymentOrderIngestContext) {
-
-        return Flux.fromIterable(paymentOrderIngestContext.corePaymentOrder())
-            .flatMap(this::getArrangement)
-            .distinct()
-            .collectList()
-            .map(accountInternalIdGetResponseBody -> paymentOrderIngestContext.arrangementIds(accountInternalIdGetResponseBody));
+    private Mono<PaymentOrderIngestContext> addArrangementIdMap(@NotNull PaymentOrderIngestContext paymentOrderIngestContext) {
+        final var arrangements = getArrangements(defaultIfNull(paymentOrderIngestContext.corePaymentOrder(),emptyList()));
+        return arrangements.map(paymentOrderIngestContext::arrangementIds);
     }
 
-    private Mono<AccountArrangementItems> getArrangement(PaymentOrderPostRequest paymentOrderPostRequest) {
-        AccountArrangementsFilter accountArrangementsFilter = new AccountArrangementsFilter()
-            .addExternalArrangementIdsItem(paymentOrderPostRequest.getOriginatorAccount().getExternalArrangementId());
-        return arrangementsApi.postFilter(accountArrangementsFilter);
+    private Mono<List<AccountArrangementItem>> getArrangements(@NotNull List<PaymentOrderPostRequest> coreRequests) {
+        final Set<String> externalIds = coreRequests.stream().map(PaymentOrderPostRequest::getOriginatorAccount)
+                .filter(Objects::nonNull).map(SimpleOriginatorAccount::getExternalArrangementId).collect(toSet());
+        final var externalArrangementIdFilter =  new AccountArrangementsFilter().externalArrangementIds(externalIds);
+        return arrangementsApi.postFilter(externalArrangementIdFilter)
+                .map(AccountArrangementItems::getArrangementElements).defaultIfEmpty(emptyList());
     }
 
     /**
@@ -148,16 +145,15 @@ public class PaymentOrderUnitOfWorkExecutor extends UnitOfWorkExecutor<PaymentOr
      * @param arrangementIds   Check for all the arrangements that belong to this PMT.
      * @return A Mono with the response from the service api.
      */
-    private Mono<PaymentOrderPostFilterResponse> getPayments(List<AccountArrangementItems> arrangementIds) {
+    private Mono<PaymentOrderPostFilterResponse> getPayments(List<AccountArrangementItem> arrangementIds) {
 
         if (isEmptyArrangmetIds(arrangementIds)) {
             return Mono.just(new PaymentOrderPostFilterResponse().paymentOrders(emptyList()).totalElements(new BigDecimal(0)));
         }
         List<String> allArrangementIds = arrangementIds
-                .stream().flatMap(accountArrangementItems ->
-                        accountArrangementItems.getArrangementElements().stream())
+                .stream()
                 .map(AccountArrangementItem::getId)
-                .collect(Collectors.toList());
+                .toList();
 
         return pullFromDBS(allArrangementIds).map(result -> {
             final var response = new PaymentOrderPostFilterResponse();
@@ -226,10 +222,9 @@ public class PaymentOrderUnitOfWorkExecutor extends UnitOfWorkExecutor<PaymentOr
         }
     }
 
-    private AccountArrangementItem getInternalArrangementId(List<AccountArrangementItems> accountArrangementItemsList, String externalArrangementId) {
+    private AccountArrangementItem getInternalArrangementId(List<AccountArrangementItem> accountArrangementItemsList, String externalArrangementId) {
 
         return accountArrangementItemsList.stream()
-            .flatMap(a -> a.getArrangementElements().stream())
             .filter(b -> b.getExternalArrangementId().equalsIgnoreCase(externalArrangementId))
             .findFirst()
             .orElse(null);
@@ -260,7 +255,7 @@ public class PaymentOrderUnitOfWorkExecutor extends UnitOfWorkExecutor<PaymentOr
                 .map(paymentType -> new AccessFilter()
                         .paymentType(paymentType)
                         .arrangementIds(arrangementIds))
-                .collect(Collectors.toList());
+                .collect(toList());
         paymentOrderPostFilterRequest.setAccessFilters(accessFilters);
         paymentOrderPostFilterRequest.setStatuses(FILTER);
 
@@ -277,7 +272,7 @@ public class PaymentOrderUnitOfWorkExecutor extends UnitOfWorkExecutor<PaymentOr
             });
     }
 
-    private boolean isEmptyArrangmetIds(List<AccountArrangementItems> arrangementItems) {
+    private boolean isEmptyArrangmetIds(List<AccountArrangementItem> arrangementItems) {
         return arrangementItems == null || arrangementItems.isEmpty();
     }
 


### PR DESCRIPTION
## Description

Change the payment order ingestion to retrieve arrangements once per request instead of per payment order.

## Checklist

 - [X] I made sure, I read [CONTRIBUTING.md](CONTRIBUTING.md) to put right branch prefix as per my need.
 - [X] I made sure to update [CHANGELOG.md](CHANGELOG.md).
 - [X] I made sure to update [Stream Wiki](https://github.com/Backbase/stream-services/wiki)(only valid in case of new stream module or architecture changes).
 - [X] My changes are adequately tested.
 - [X] I made sure all the SonarCloud Quality Gate are passed.
