### PR TITLE
LegalEntitySaga:BatchProductIngestionSaga, passing BatchProductIngest…

### DIFF
--- a/stream-legal-entity/legal-entity-core/src/main/java/com/backbase/stream/LegalEntitySaga.java
+++ b/stream-legal-entity/legal-entity-core/src/main/java/com/backbase/stream/LegalEntitySaga.java
@@ -484,7 +484,7 @@ public class LegalEntitySaga implements StreamTaskExecutor<LegalEntityTask> {
 
         return Flux.fromIterable(legalEntity.getProductGroups())
             .map(actual -> createProductGroupTask(streamTask, actual))
-            .concatMap(productGroupStreamTask -> batchProductIngestionSaga.process(productGroupStreamTask)
+            .concatMap(productGroupStreamTask -> batchProductIngestionSaga.process(productGroupStreamTask,streamTask.getIngestionMode())
                 .onErrorResume(throwable -> {
                     String message = throwable.getMessage();
                     if (throwable.getClass().isAssignableFrom(WebClientResponseException.class)) {

--- a/stream-legal-entity/legal-entity-core/src/test/java/com/backbase/stream/LegalEntitySagaTest.java
+++ b/stream-legal-entity/legal-entity-core/src/test/java/com/backbase/stream/LegalEntitySagaTest.java
@@ -56,6 +56,7 @@ import com.backbase.stream.limit.LimitsSaga;
 import com.backbase.stream.limit.LimitsTask;
 import com.backbase.stream.product.BatchProductIngestionSaga;
 import com.backbase.stream.product.task.BatchProductGroupTask;
+import com.backbase.stream.product.task.BatchProductIngestionMode;
 import com.backbase.stream.product.task.ProductGroupTask;
 import com.backbase.stream.service.AccessGroupService;
 import com.backbase.stream.service.LegalEntityService;
@@ -171,7 +172,7 @@ class LegalEntitySagaTest {
         when(userService.getUserByExternalId(eq(regularUserExId))).thenReturn(Mono.just(regularUser.getUser()));
         when(userService.getUserByExternalId(eq(adminExId))).thenReturn(Mono.just(adminUser));
         when(userService.createUser(any(), any(), any())).thenReturn(Mono.empty());
-        when(batchProductIngestionSaga.process(any(ProductGroupTask.class))).thenReturn(productGroupTaskMono);
+        when(batchProductIngestionSaga.process(any(ProductGroupTask.class),any())).thenReturn(productGroupTaskMono);
         when(userService.setupRealm(any())).thenReturn(Mono.just(new Realm()));
         when(userService.linkLegalEntityToRealm(any())).thenReturn(Mono.just(new LegalEntity()));
         when(userService.updateUser(any())).thenReturn(Mono.just(regularUser.getUser()));
@@ -222,7 +223,7 @@ class LegalEntitySagaTest {
             .thenReturn(Mono.just(customSa));
         when(accessGroupService.getServiceAgreementParticipants(any(), any()))
             .thenReturn(Flux.just(new ServiceAgreementParticipantsGetResponseBody().externalId(customSaExId)));
-        when(batchProductIngestionSaga.process(any(ProductGroupTask.class)))
+        when(batchProductIngestionSaga.process(any(ProductGroupTask.class),any()))
             .thenReturn(productGroupTaskMono);
         when(userService.setupRealm(task.getLegalEntity()))
             .thenReturn(Mono.just(new Realm()));
@@ -263,7 +264,7 @@ class LegalEntitySagaTest {
         when(legalEntityService.getMasterServiceAgreementForInternalLegalEntityId(eq(leInternalId))).thenReturn(Mono.just(sa));
         when(legalEntityService.createLegalEntity(any())).thenReturn(Mono.just(legalEntity));
         when(accessGroupService.setupJobRole(any(), any(), any())).thenReturn(Mono.just(jobRole));
-        when(batchProductIngestionSaga.process(any(ProductGroupTask.class)))
+        when(batchProductIngestionSaga.process(any(ProductGroupTask.class),any()))
             .thenReturn(productGroupTaskMono);
         when(userService.setupRealm(task.getLegalEntity()))
             .thenReturn(Mono.just(new Realm()));
@@ -311,7 +312,7 @@ class LegalEntitySagaTest {
         when(legalEntityService.createLegalEntity(any())).thenReturn(Mono.just(legalEntity));
         when(accessGroupService.setupJobRole(any(), any(), any())).thenReturn(Mono.just(jobRole));
         when(accessGroupService.createServiceAgreement(any(), any())).thenReturn(Mono.just(sa));
-        when(batchProductIngestionSaga.process(any(ProductGroupTask.class)))
+        when(batchProductIngestionSaga.process(any(ProductGroupTask.class),any()))
             .thenReturn(productGroupTaskMono);
         when(userService.setupRealm(task.getLegalEntity()))
             .thenReturn(Mono.just(new Realm()));
@@ -474,7 +475,7 @@ class LegalEntitySagaTest {
             .thenReturn(Mono.just(new GetUser().externalId("john.doe").id("internalId")));
         when(limitsSaga.executeTask(any())).thenReturn(Mono.just(new LimitsTask("1", new CreateLimitRequestBody())));
  //       when(contactsSaga.executeTask(any())).thenReturn(Mono.just(new ContactsTask("1", new ContactsBulkPostRequestBody())));
-        when(batchProductIngestionSaga.process(any(ProductGroupTask.class)))
+        when(batchProductIngestionSaga.process(any(ProductGroupTask.class),any()))
             .thenAnswer((Answer<Mono<ProductGroupTask>>) invocationOnMock -> {
                 ProductGroupTask productGroupTask = invocationOnMock.getArgument(0);
                 Duration delay = productGroupTask.getName().contains("100000-Default PG")
@@ -622,7 +623,7 @@ class LegalEntitySagaTest {
         when(userService.getUserByExternalId(eq(regularUserExId))).thenReturn(Mono.just(regularUser.getUser()));
         when(userService.getUserByExternalId(eq(adminExId))).thenReturn(Mono.just(adminUser));
         when(userService.createUser(any(), any(), any())).thenReturn(Mono.empty());
-        when(batchProductIngestionSaga.process(any(ProductGroupTask.class))).thenReturn(productGroupTaskMono);
+        when(batchProductIngestionSaga.process(any(ProductGroupTask.class),any())).thenReturn(productGroupTaskMono);
         when(userService.setupRealm(any())).thenReturn(Mono.just(new Realm()));
         when(userService.linkLegalEntityToRealm(any())).thenReturn(Mono.just(new LegalEntity()));
         when(userService.updateUser(any())).thenReturn(Mono.empty());
@@ -680,7 +681,7 @@ class LegalEntitySagaTest {
         when(userService.getUserByExternalId(eq(adminExId))).thenReturn(Mono.just(adminUser));
         when(userService.createUser(any(), any(), any())).thenReturn(Mono.just(adminUser));
         when(userService.updateUser(any())).thenReturn(Mono.empty());
-        when(batchProductIngestionSaga.process(any(ProductGroupTask.class))).thenReturn(productGroupTaskMono);
+        when(batchProductIngestionSaga.process(any(ProductGroupTask.class),any())).thenReturn(productGroupTaskMono);
         when(userService.setupRealm(any())).thenReturn(Mono.just(new Realm()));
         when(userService.linkLegalEntityToRealm(any())).thenReturn(Mono.just(new LegalEntity()));
         when(userService.updateUser(any())).thenReturn(Mono.just(newRegularUser.getUser()));
@@ -739,7 +740,7 @@ class LegalEntitySagaTest {
         when(userService.getUserByExternalId(regularUserExId)).thenReturn(Mono.just(regularUser.getUser()));
         when(userService.getUserByExternalId(adminExId)).thenReturn(Mono.just(adminUser));
         when(userService.createUser(any(), any(), any())).thenReturn(Mono.empty());
-        when(batchProductIngestionSaga.process(any(ProductGroupTask.class))).thenReturn(productGroupTaskMono);
+        when(batchProductIngestionSaga.process(any(ProductGroupTask.class),any())).thenReturn(productGroupTaskMono);
         when(userService.setupRealm(any())).thenReturn(Mono.just(new Realm()));
         when(userService.linkLegalEntityToRealm(any())).thenReturn(Mono.just(new LegalEntity()));
         when(userService.updateUser(any())).thenReturn(Mono.just(regularUser.getUser()));
@@ -805,7 +806,7 @@ class LegalEntitySagaTest {
         when(accessGroupService.updateServiceAgreementRegularUsers(any(), eq(customSa), any())).thenReturn(Mono.just(customSa));
         when(userService.getUserByExternalId(adminExId)).thenReturn(Mono.just(adminUser));
         when(userService.createUser(any(), any(), any())).thenReturn(Mono.empty());
-        when(batchProductIngestionSaga.process(any(ProductGroupTask.class))).thenReturn(productGroupTaskMono);
+        when(batchProductIngestionSaga.process(any(ProductGroupTask.class),any())).thenReturn(productGroupTaskMono);
         when(userService.setupRealm(any())).thenReturn(Mono.just(new Realm()));
         when(userService.linkLegalEntityToRealm(any())).thenReturn(Mono.just(new LegalEntity()));
         when(userService.updateUser(any())).thenReturn(Mono.just(regularUser.getUser()));
@@ -1000,6 +1001,7 @@ class LegalEntitySagaTest {
         when(task.getData()).thenReturn(legalEntity);
         when(task.data(any())).thenReturn(task);
         when(task.addHistory(any())).thenReturn(task);
+        when(task.getIngestionMode()).thenReturn(BatchProductIngestionMode.UPSERT);
         return task;
     }
 

--- a/stream-product/product-ingestion-saga/src/main/java/com/backbase/stream/product/BatchProductIngestionSaga.java
+++ b/stream-product/product-ingestion-saga/src/main/java/com/backbase/stream/product/BatchProductIngestionSaga.java
@@ -42,7 +42,6 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 import java.util.function.Predicate;
-import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import lombok.extern.slf4j.Slf4j;

--- a/stream-product/product-ingestion-saga/src/main/java/com/backbase/stream/product/BatchProductIngestionSaga.java
+++ b/stream-product/product-ingestion-saga/src/main/java/com/backbase/stream/product/BatchProductIngestionSaga.java
@@ -1,5 +1,6 @@
 package com.backbase.stream.product;
 
+import static com.backbase.stream.product.task.BatchProductIngestionMode.UPSERT;
 import static java.util.Comparator.comparing;
 import static java.util.Comparator.naturalOrder;
 import static java.util.Comparator.nullsFirst;
@@ -21,6 +22,7 @@ import com.backbase.stream.loan.LoansTask;
 import com.backbase.stream.product.configuration.ProductIngestionSagaConfigurationProperties;
 import com.backbase.stream.product.service.ArrangementService;
 import com.backbase.stream.product.task.BatchProductGroupTask;
+import com.backbase.stream.product.task.BatchProductIngestionMode;
 import com.backbase.stream.product.task.ProductGroupTask;
 import com.backbase.stream.product.utils.StreamUtils;
 import com.backbase.stream.service.AccessGroupService;
@@ -40,6 +42,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 import java.util.function.Predicate;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import lombok.extern.slf4j.Slf4j;
@@ -66,6 +69,22 @@ public class BatchProductIngestionSaga extends ProductIngestionSaga {
         ProductGroup productGroup = streamTask.getProductGroup();
 
         BatchProductGroupTask batchProductGroupTask = new BatchProductGroupTask();
+        batchProductGroupTask.setBatchProductGroup(new BatchProductGroup()
+            .serviceAgreement(productGroup.getServiceAgreement())
+            .addProductGroupsItem(productGroup));
+
+        return process(batchProductGroupTask)
+            .map(batchProductGroup -> {
+                streamTask.addHistory(batchProductGroup.getHistory());
+               return streamTask;
+            });
+    }
+
+    public Mono<ProductGroupTask> process(ProductGroupTask streamTask, BatchProductIngestionMode ingestionMode) {
+
+        ProductGroup productGroup = streamTask.getProductGroup();
+        BatchProductGroupTask batchProductGroupTask = new BatchProductGroupTask();
+        batchProductGroupTask.setIngestionMode(Optional.ofNullable(ingestionMode).orElse(UPSERT));
         batchProductGroupTask.setBatchProductGroup(new BatchProductGroup()
             .serviceAgreement(productGroup.getServiceAgreement())
             .addProductGroupsItem(productGroup));


### PR DESCRIPTION

## Description
fixed missing ingestion mode propagation for BatchProductGroupTask
we've found an issue for which, even if we set the IngestionMode when calling LegalEntitySaga, this wasn't propagated to the BatchProductGroupTask resulting in a default UPSERT strategy
the change includes the IngestionMode from the LegalEntitySaga when calling BatchProductIngestionSaga and defaults, as previously, in UPSERT strategy if the IngestionMode is null

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
  
  Add N/A to the task if they are not relevant to the current PR(validation will be skipped). 
  e.g. [ ] My changes are adequately tested ~ N/A
-->

 - [x] I made sure, I read [CONTRIBUTING.md](CONTRIBUTING.md) to put right branch prefix as per my need.
 - [ ] I made sure to update [CHANGELOG.md](CHANGELOG.md).
 - [ ] I made sure to update [Stream Wiki](https://github.com/Backbase/stream-services/wiki)(only valid in case of new stream module or architecture changes).
 - [ ] My changes are adequately tested.
 - [ ] I made sure all the SonarCloud Quality Gate are passed.
