### PR TITLE
Added ExecutionDateFrom filter in payment order based on configuration 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [4.1.9](https://github.com/Backbase/stream-services/compare/4.1.9...4.1.9)
+### Changed.
+- Adding configuration to filter payments by ExecutionDateFrom based in offset period days
+
 ## [4.1.8](https://github.com/Backbase/stream-services/compare/4.1.7...4.1.8)
 ### Changed.
 - Adding ingestion mode support for batch product groups
@@ -12,11 +16,11 @@ All notable changes to this project will be documented in this file.
 ## [4.1.6](https://github.com/Backbase/stream-services/compare/4.1.4...4.1.6)
 ### Fix
 - Fix arrangements being retrieved per payment order instead of once per payment order ingestion request.
-- 
+
 ## [4.1.4](https://github.com/Backbase/stream-services/compare/4.1.3...4.1.4)
 ### Fix
 - Fixed deletion of non-repository custom data-group items on data-group update
-- 
+
 ## [4.1.3](https://github.com/Backbase/stream-services/compare/4.1.3...4.1.4)
 ### Changed
 - Query for existing payments by using arrangement IDs instead of user IDs. This will eliminate duplicate payments from being ingested when joint owners are added.

--- a/stream-payment-order/payment-order-core/src/main/java/com/backbase/stream/config/PaymentOrderTypeConfiguration.java
+++ b/stream-payment-order/payment-order-core/src/main/java/com/backbase/stream/config/PaymentOrderTypeConfiguration.java
@@ -15,4 +15,6 @@ public class PaymentOrderTypeConfiguration {
 
     @NotNull
     private List<String> types;
+    
+    private Long startOffsetInDays;
 }

--- a/stream-payment-order/payment-order-core/src/main/java/com/backbase/stream/paymentorder/PaymentOrderUnitOfWorkExecutor.java
+++ b/stream-payment-order/payment-order-core/src/main/java/com/backbase/stream/paymentorder/PaymentOrderUnitOfWorkExecutor.java
@@ -23,6 +23,7 @@ import com.backbase.dbs.arrangement.api.service.v2.model.AccountArrangementsFilt
 import com.backbase.dbs.paymentorder.api.service.v2.model.Status;
 import java.math.BigDecimal;
 import java.time.Duration;
+import java.time.LocalDate;
 import com.backbase.dbs.paymentorder.api.service.v2.model.AccessFilter;
 import com.backbase.stream.config.PaymentOrderTypeConfiguration;
 import java.util.*;
@@ -236,20 +237,21 @@ public class PaymentOrderUnitOfWorkExecutor extends UnitOfWorkExecutor<PaymentOr
     }
 
     private Mono<List<GetPaymentOrderResponse>> pullFromDBS(final @NotNull List<String> arrangementIds) {
-        return defer(() -> retrieveNextPage(0, arrangementIds)
+        LocalDate startDate = paymentOrderTypeConfiguration.getStartOffsetInDays() != null ? LocalDate.now().minusDays(paymentOrderTypeConfiguration.getStartOffsetInDays()) : null;
+        return defer(() -> retrieveNextPage(0, arrangementIds, startDate)
             .expand(page -> {
                 // If there are no more pages, return an empty flux.
                 if (page.next >= page.total || page.requests.isEmpty()) {
                     return empty();
                 } else {
-                    return retrieveNextPage(page.next, arrangementIds);
+                    return retrieveNextPage(page.next, arrangementIds, startDate);
                 }
             }))
             .collectList()
             .map(pages -> pages.stream().flatMap(page -> page.requests.stream()).toList());
     }
 
-    private Mono<DBSPaymentOrderPageResult> retrieveNextPage(int currentCount, final @NotNull List<String> arrangementIds) {
+    private Mono<DBSPaymentOrderPageResult> retrieveNextPage(int currentCount, final @NotNull List<String> arrangementIds, LocalDate executionDateFrom) {
         List<String> paymentTypes = paymentOrderTypeConfiguration.getTypes();
         var paymentOrderPostFilterRequest = new PaymentOrderPostFilterRequest();
         List<AccessFilter> accessFilters = paymentTypes.stream()
@@ -260,7 +262,7 @@ public class PaymentOrderUnitOfWorkExecutor extends UnitOfWorkExecutor<PaymentOr
         paymentOrderPostFilterRequest.setAccessFilters(accessFilters);
         paymentOrderPostFilterRequest.setStatuses(FILTER);
 
-        return paymentOrdersApi.postFilterPaymentOrders(null, null, null, null, null, null, null, null,
+        return paymentOrdersApi.postFilterPaymentOrders(null, null, null, executionDateFrom, null, null, null, null,
                 null, null, null, null, null, null, currentCount / PAGE_SIZE, PAGE_SIZE, null,
                 null, paymentOrderPostFilterRequest)
             .retryWhen(fixedDelay(3, Duration.of(2000, MILLIS)).filter(


### PR DESCRIPTION
## Description

Added configuration to filter payments by ExecutionDateFrom based in offset period days

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
  
  Add N/A to the task if they are not relevant to the current PR(validation will be skipped). 
  e.g. [ ] My changes are adequately tested ~ N/A
-->

 - [X] I made sure, I read [CONTRIBUTING.md](CONTRIBUTING.md) to put right branch prefix as per my need.
 - [x] I made sure to update [CHANGELOG.md](CHANGELOG.md).
 - [X] I made sure to update [Stream Wiki](https://github.com/Backbase/stream-services/wiki)(only valid in case of new stream module or architecture changes).
 - [X] My changes are adequately tested.
 - [x] I made sure all the SonarCloud Quality Gate are passed.
