### PR TITLE
Performance Improvement to use getUserById when internalId is available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 All notable changes to this project will be documented in this file.
+## [4.1.11](https://github.com/Backbase/stream-services/compare/4.1.10...4.1.11)
+### Changed
+- Performance improvement on retrieving the user information. getUserById (8 ms) Vs getUserByExternalId (50 ms)
+
 ## [4.1.10](https://github.com/Backbase/stream-services/compare/4.1.9...4.1.10)
 ### Changed
 - Enhance Legal Entity level Limit Object to set Limit based on Privilege, Business Function and User.

--- a/stream-access-control/access-control-core/src/test/java/com/backbase/stream/service/UserServiceTest.java
+++ b/stream-access-control/access-control-core/src/test/java/com/backbase/stream/service/UserServiceTest.java
@@ -79,18 +79,18 @@ class UserServiceTest {
         String realm = "someRealm";
         String email = "some@email.com";
 
-        EnhancedUserRepresentation eur = new EnhancedUserRepresentation().id(internalId).email(email).enabled(true);
+        EnhancedUserRepresentation eur = new EnhancedUserRepresentation().id(internalId).email(email).enabled(Boolean.TRUE);
         when(identityIntegrationApi.getUserById(realm, internalId)).thenReturn(Mono.just(eur));
         when(identityIntegrationApi.updateUserById(eq(realm), eq(internalId), any())).thenReturn(Mono.empty().then());
 
 
-        User user = new User().internalId(internalId).locked(true);
+        User user = new User().internalId(internalId).locked(Boolean.TRUE);
         Mono<User> result = subject.updateUserState(user, realm);
 
 
         result.subscribe(assertEqualsTo(user));
         verify(identityIntegrationApi).getUserById(eq(realm), eq(internalId));
-        UserRequestBody expectedUser = new UserRequestBody().id(internalId).email(email).enabled(false)
+        UserRequestBody expectedUser = new UserRequestBody().id(internalId).email(email).enabled(Boolean.FALSE)
                 .credentials(Collections.emptyList());
         verify(identityIntegrationApi).updateUserById(eq(realm), eq(internalId), eq(expectedUser));
     }
@@ -101,18 +101,18 @@ class UserServiceTest {
         String realm = "someRealm";
         String email = "some@email.com";
 
-        EnhancedUserRepresentation eur = new EnhancedUserRepresentation().id(internalId).email(email).enabled(false);
+        EnhancedUserRepresentation eur = new EnhancedUserRepresentation().id(internalId).email(email).enabled(Boolean.FALSE);
         when(identityIntegrationApi.getUserById(realm, internalId)).thenReturn(Mono.just(eur));
         when(identityIntegrationApi.updateUserById(eq(realm), eq(internalId), any())).thenReturn(Mono.empty().then());
 
 
-        User user = new User().internalId(internalId).locked(false);
+        User user = new User().internalId(internalId).locked(Boolean.FALSE);
         Mono<User> result = subject.updateUserState(user, realm);
 
 
         result.subscribe(assertEqualsTo(user));
         verify(identityIntegrationApi).getUserById(eq(realm), eq(internalId));
-        UserRequestBody expectedUser = new UserRequestBody().id(internalId).email(email).enabled(true)
+        UserRequestBody expectedUser = new UserRequestBody().id(internalId).email(email).enabled(Boolean.TRUE)
                 .credentials(Collections.emptyList());
         verify(identityIntegrationApi).updateUserById(eq(realm), eq(internalId), eq(expectedUser));
     }
@@ -123,7 +123,7 @@ class UserServiceTest {
         String realm = "someRealm";
         String email = "some@email.com";
 
-        EnhancedUserRepresentation eur = new EnhancedUserRepresentation().id(internalId).email(email).enabled(false);
+        EnhancedUserRepresentation eur = new EnhancedUserRepresentation().id(internalId).email(email).enabled(Boolean.FALSE);
         when(identityIntegrationApi.getUserById(realm, internalId)).thenReturn(Mono.just(eur));
 
 
@@ -384,7 +384,7 @@ class UserServiceTest {
         GetUser getUser = new GetUser().externalId(externalId)
                 .fullName(fullName);
 
-        when(usersApi.getUserByExternalId(externalId, true)).thenReturn(Mono.just(getUser));
+        when(usersApi.getUserByExternalId(externalId, Boolean.TRUE)).thenReturn(Mono.just(getUser));
 
         Mono<User> userByExternalId = subject.getUserByExternalId(externalId);
         StepVerifier.create(userByExternalId)
@@ -397,12 +397,24 @@ class UserServiceTest {
     void getUserByExternalIdNotFound() {
         final String externalId = "someExternalId";
         final String fullName = "someName";
-        when(usersApi.getUserByExternalId(externalId, true)).thenReturn(Mono.error(WebClientResponseException.NotFound.create(404, "not found", new HttpHeaders(), new byte[0], null)));
+        when(usersApi.getUserByExternalId(externalId, Boolean.TRUE)).thenReturn(Mono.error(WebClientResponseException.NotFound.create(404, "not found", new HttpHeaders(), new byte[0], null)));
 
         Mono<User> userByExternalId = subject.getUserByExternalId(externalId);
         StepVerifier.create(userByExternalId)
                 .expectNextCount(0)
                 .verifyComplete();
+    }
+
+    @Test
+    void getUserByInternalIdNotFound() {
+        final String internalId = "someInternalId";
+        final String fullName = "someName";
+        when(usersApi.getUserById(internalId, Boolean.TRUE)).thenReturn(Mono.error(WebClientResponseException.NotFound.create(404, "not found", new HttpHeaders(), new byte[0], null)));
+
+        Mono<User> userByInternalId = subject.getUserById(internalId);
+        StepVerifier.create(userByInternalId)
+            .expectNextCount(0)
+            .verifyComplete();
     }
 
     @Test
@@ -449,7 +461,7 @@ class UserServiceTest {
         BatchResponseItem batchResponseItem = new BatchResponseItem().status(BatchResponseItem.StatusEnum._200);
 
         when(usersApi.updateUserInBatch(any())).thenReturn(Flux.just(batchResponseItem));
-        when(usersApi.getUserByExternalId(externalId, true)).thenReturn(Mono.just(getUser));
+        when(usersApi.getUserByExternalId(externalId, Boolean.TRUE)).thenReturn(Mono.just(getUser));
 
         User user = new User().externalId(externalId).fullName("oldName");
         Mono<User> result = subject.updateUser(user);
@@ -469,7 +481,7 @@ class UserServiceTest {
                 .fullName(fullName);
 
         when(usersApi.updateUserInBatch(any())).thenReturn(Flux.error(WebClientResponseException.create(500,"", new HttpHeaders(), "Error response".getBytes(StandardCharsets.UTF_8), null)));
-        when(usersApi.getUserByExternalId(externalId, true)).thenReturn(Mono.just(getUser));
+        when(usersApi.getUserByExternalId(externalId, Boolean.TRUE)).thenReturn(Mono.just(getUser));
 
         User user = new User().externalId(externalId).fullName("oldName");
         Mono<User> result = subject.updateUser(user);
@@ -488,7 +500,7 @@ class UserServiceTest {
         BatchResponseItem batchResponseItem = new BatchResponseItem().status(BatchResponseItem.StatusEnum._400);
 
         when(usersApi.updateUserInBatch(any())).thenReturn(Flux.just(batchResponseItem));
-        when(usersApi.getUserByExternalId(externalId, true)).thenReturn(Mono.just(getUser));
+        when(usersApi.getUserByExternalId(externalId, Boolean.TRUE)).thenReturn(Mono.just(getUser));
 
         User user = new User().externalId(externalId).fullName("oldName");
         Mono<User> result = subject.updateUser(user);

--- a/stream-legal-entity/legal-entity-http/src/test/java/com/backbase/stream/it/LegalEntitySagaIT.java
+++ b/stream-legal-entity/legal-entity-http/src/test/java/com/backbase/stream/it/LegalEntitySagaIT.java
@@ -73,6 +73,7 @@ class LegalEntitySagaIT {
                                 new JobProfileUser()
                                     .user(
                                         new User()
+                                            .internalId("9ac44fca")
                                             .externalId("john.doe")
                                             .fullName("John Doe")
                                             .identityLinkStrategy(IdentityUserLinkStrategy.IDENTITY_AGNOSTIC)
@@ -94,6 +95,7 @@ class LegalEntitySagaIT {
                                 new JobProfileUser()
                                     .user(
                                         new User()
+                                            .internalId("9ac44fca")
                                             .externalId("john.doe")
                                             .fullName("John Doe")
                                             .identityLinkStrategy(IdentityUserLinkStrategy.IDENTITY_AGNOSTIC)
@@ -114,7 +116,7 @@ class LegalEntitySagaIT {
                         new JobProfileUser()
                             .user(
                                 new User()
-                                    .internalId("internal-id")
+                                    .internalId("9ac44fca")
                                     .externalId("john.doe")
                                     .fullName("John Doe")
                                     .identityLinkStrategy(IdentityUserLinkStrategy.CREATE_IN_IDENTITY)
@@ -200,6 +202,13 @@ class LegalEntitySagaIT {
                 .willReturn(WireMock.aResponse()
                     .withHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE)
                                 .withBody("{\"id\":\"9ac44fca\",\"externalId\":\"john.doe\",\"legalEntityId\":\"500000\",\"fullName\":\"John Doe\"}"))
+        );
+
+        stubFor(
+            WireMock.get("/user-manager/service-api/v2/users/9ac44fca?skipHierarchyCheck=true")
+                .willReturn(WireMock.aResponse()
+                    .withHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                    .withBody("{\"id\":\"9ac44fca\",\"externalId\":\"john.doe\",\"legalEntityId\":\"500000\",\"fullName\":\"John Doe\"}"))
         );
 
         stubFor(

--- a/stream-product/product-core/src/main/java/com/backbase/stream/product/service/ArrangementService.java
+++ b/stream-product/product-core/src/main/java/com/backbase/stream/product/service/ArrangementService.java
@@ -86,7 +86,7 @@ public class ArrangementService {
                     return r;
                 })
                 .onErrorResume(WebClientResponseException.class, throwable ->
-                        Mono.error(new ArrangementUpdateException(throwable, "Batch arrangement update failed: " + arrangementItems)));
+                        Mono.error(new ArrangementUpdateException(throwable, "Batch arrangement update failed")));
     }
 
     public Mono<Void> updateUserPreferences(AccountUserPreferencesItemPut userPreferencesItemPut){

--- a/stream-product/product-core/src/test/java/com/backbase/stream/product/service/ArrangementServiceTest.java
+++ b/stream-product/product-core/src/test/java/com/backbase/stream/product/service/ArrangementServiceTest.java
@@ -221,7 +221,7 @@ public class ArrangementServiceTest {
         StepVerifier.create(arrangementService.upsertBatchArrangements(List.of(request)))
             .consumeErrorWith(e -> {
                 Assertions.assertTrue(e instanceof ArrangementUpdateException);
-                Assertions.assertEquals("Batch arrangement update failed: " + List.of(request), e.getMessage());
+                Assertions.assertEquals("Batch arrangement update failed", e.getMessage());
                 Assertions.assertEquals(webClientResponseException.getMessage(), e.getCause().getMessage());
             })
             .verify();

--- a/stream-product/product-ingestion-saga/pom.xml
+++ b/stream-product/product-ingestion-saga/pom.xml
@@ -44,6 +44,12 @@
         </dependency>
 
         <dependency>
+            <groupId>io.projectreactor</groupId>
+            <artifactId>reactor-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>com.backbase.buildingblocks</groupId>
             <artifactId>service-sdk-starter-test</artifactId>
             <scope>test</scope>

--- a/stream-product/product-ingestion-saga/src/main/java/com/backbase/stream/product/ProductIngestionSaga.java
+++ b/stream-product/product-ingestion-saga/src/main/java/com/backbase/stream/product/ProductIngestionSaga.java
@@ -218,7 +218,7 @@ public class ProductIngestionSaga {
     private Mono<User> upsertUser(StreamTask streamTask, JobProfileUser jobProfileUser) {
         User user = jobProfileUser.getUser();
         LegalEntityReference legalEntityReference = jobProfileUser.getLegalEntityReference();
-        Mono<User> getExistingUser = userService.getUserByExternalId(user.getExternalId())
+        Mono<User> getExistingUser = Objects.nonNull(user.getInternalId())? userService.getUserById(user.getInternalId()): userService.getUserByExternalId(user.getExternalId())
             .doOnNext(existingUser -> streamTask.info(USER, EXISTS, user.getExternalId(), user.getInternalId(), "User %s already exists", existingUser.getExternalId()));
         Mono<User> createNewUser = userService.createUser(user, legalEntityReference.getExternalId(), streamTask)
             .doOnNext(existingUser -> streamTask.info(USER, CREATED, user.getExternalId(), user.getInternalId(), "User %s created", existingUser.getExternalId()));
@@ -229,7 +229,7 @@ public class ProductIngestionSaga {
     private Mono<User> upsertIdentityUser(StreamTask streamTask, JobProfileUser jobProfileUser) {
         User user = jobProfileUser.getUser();
         LegalEntityReference legalEntityReference = jobProfileUser.getLegalEntityReference();
-        Mono<User> getExistingIdentityUser = userService.getUserByExternalId(user.getExternalId())
+        Mono<User> getExistingIdentityUser = Objects.nonNull(user.getInternalId())? userService.getUserById(user.getInternalId()): userService.getUserByExternalId(user.getExternalId())
             .doOnNext(existingUser -> streamTask.info(IDENTITY_USER, EXISTS, user.getExternalId(), user.getInternalId(), "User %s already exists", existingUser.getExternalId()));
         Mono<User> createNewIdentityUser = userService.createOrImportIdentityUser(user, legalEntityReference.getInternalId(), streamTask)
             .doOnNext(existingUser -> streamTask.info(IDENTITY_USER, CREATED, user.getExternalId(), user.getInternalId(), "User %s created", existingUser.getExternalId()));

--- a/stream-product/product-ingestion-saga/src/test/java/com/backbase/stream/product/BatchProductIngestionSagaTest.java
+++ b/stream-product/product-ingestion-saga/src/test/java/com/backbase/stream/product/BatchProductIngestionSagaTest.java
@@ -1,0 +1,116 @@
+package com.backbase.stream.product;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.when;
+
+import com.backbase.dbs.arrangement.api.service.v2.model.AccountBatchResponseItemExtended;
+import com.backbase.dbs.arrangement.api.service.v2.model.BatchResponseStatusCode;
+import com.backbase.loan.inbound.api.service.v1.LoansApi;
+import com.backbase.stream.legalentity.model.BaseProductGroup;
+import com.backbase.stream.legalentity.model.BatchProductGroup;
+import com.backbase.stream.legalentity.model.ProductGroup;
+import com.backbase.stream.loan.LoansSaga;
+import com.backbase.stream.loan.LoansTask;
+import com.backbase.stream.product.configuration.ProductIngestionSagaConfigurationProperties;
+import com.backbase.stream.product.service.ArrangementService;
+import com.backbase.stream.product.task.BatchProductGroupTask;
+import com.backbase.stream.service.AccessGroupService;
+import com.backbase.stream.service.UserService;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+@ExtendWith(MockitoExtension.class)
+class BatchProductIngestionSagaTest {
+
+  @InjectMocks
+  BatchProductIngestionSaga batchProductIngestionSaga;
+  @Mock
+  ArrangementService arrangementService;
+  @Mock
+  AccessGroupService accessGroupService;
+  @Mock
+  UserService userService;
+  @Mock
+  ProductIngestionSagaConfigurationProperties configurationProperties;
+  @Mock
+  LoansSaga loansSaga;
+  @Mock
+  LoansApi loansApi;
+
+  BatchProductGroupTask batchProductGroupTask;
+
+  @BeforeEach
+  void setUp() {
+    batchProductGroupTask = mockBatchProductGroupTask();
+    when(arrangementService.upsertBatchArrangements(anyList()))
+        .thenReturn(Flux.just(new AccountBatchResponseItemExtended()
+            .arrangementId("arr_id")
+            .resourceId("resource_id")
+            .status(BatchResponseStatusCode.HTTP_STATUS_OK)));
+    when(accessGroupService.getExistingDataGroups(
+        batchProductGroupTask.getData().getServiceAgreement()
+            .getInternalId(), null))
+        .thenReturn(Flux.just(MockUtil.buildDataGroupItem()));
+    when(accessGroupService.createArrangementDataAccessGroup(any(), any(), any()))
+        .thenReturn(Mono.just(new BaseProductGroup()));
+    when(accessGroupService.updateExistingDataGroupsBatch(batchProductGroupTask,
+        List.of(MockUtil.buildDataGroupItem()),
+        batchProductGroupTask.getData().getProductGroups()))
+        .thenReturn(Mono.just(batchProductGroupTask));
+    when(accessGroupService.getFunctionGroupsForServiceAgreement("sa_internalId"))
+        .thenReturn(Mono.just(List.of(MockUtil.buildFunctionGroupItem())));
+    when(accessGroupService.setupFunctionGroups(batchProductGroupTask,
+        batchProductGroupTask.getData().getServiceAgreement(),
+        MockUtil.buildBusinessFunctionGroupList()))
+        .thenReturn(Mono.just(MockUtil.buildBusinessFunctionGroupList()));
+    when(accessGroupService.assignPermissionsBatch(any(), any())).thenReturn(
+        Mono.just(batchProductGroupTask));
+    LoansTask loansTask = new LoansTask(
+        String.format(batchProductGroupTask.getData().getServiceAgreement().getExternalId(),
+            batchProductGroupTask.getId()), List.of(MockUtil.buildLoanAccount()));
+    when(loansSaga.executeTask(loansTask)).thenReturn(Mono.just(loansTask));
+  }
+
+  @Test
+  void test_processProductBatchUsers_withUserInternalId() {
+    when(userService.getUserById("someRegularUserInId")).thenReturn(
+        Mono.just(MockUtil.buildUser()));
+    when(userService.createUser(any(), any(), any()))
+        .thenReturn(Mono.just(MockUtil.buildUser()));
+    StepVerifier.create(batchProductIngestionSaga.process(batchProductGroupTask))
+        .expectNext(batchProductGroupTask)
+        .expectComplete()
+        .verify();
+  }
+
+  @Test
+  void test_processProductBatchUsers_withUserExternalId() {
+    batchProductGroupTask.getBatchProductGroup().getProductGroups().get(0).getUsers().get(0)
+        .getUser().setInternalId(null);
+    when(userService.getUserByExternalId("someRegularUserExId")).thenReturn(
+        Mono.just(MockUtil.buildUser()));
+    when(userService.createUser(any(), any(), any()))
+        .thenReturn(Mono.just(MockUtil.buildUser()));
+    StepVerifier.create(batchProductIngestionSaga.process(batchProductGroupTask))
+        .expectNext(batchProductGroupTask)
+        .expectComplete()
+        .verify();
+  }
+
+  BatchProductGroupTask mockBatchProductGroupTask() {
+    ProductGroup productGroup = MockUtil.createProductGroup();
+    return new BatchProductGroupTask()
+        .data(new BatchProductGroup().productGroups(List.of(productGroup))
+            .serviceAgreement(productGroup.getServiceAgreement()));
+
+  }
+}

--- a/stream-product/product-ingestion-saga/src/test/java/com/backbase/stream/product/MockUtil.java
+++ b/stream-product/product-ingestion-saga/src/test/java/com/backbase/stream/product/MockUtil.java
@@ -1,0 +1,137 @@
+package com.backbase.stream.product;
+
+import com.backbase.dbs.accesscontrol.api.service.v3.model.DataGroupItem;
+import com.backbase.dbs.accesscontrol.api.service.v3.model.FunctionGroupItem;
+import com.backbase.stream.legalentity.model.AvailableBalance;
+import com.backbase.stream.legalentity.model.BaseProductGroup;
+import com.backbase.stream.legalentity.model.BookedBalance;
+import com.backbase.stream.legalentity.model.BusinessFunctionGroup;
+import com.backbase.stream.legalentity.model.BusinessFunctionGroup.TypeEnum;
+import com.backbase.stream.legalentity.model.CreditCard;
+import com.backbase.stream.legalentity.model.CurrentAccount;
+import com.backbase.stream.legalentity.model.JobProfileUser;
+import com.backbase.stream.legalentity.model.LegalEntityReference;
+import com.backbase.stream.legalentity.model.Loan;
+import com.backbase.stream.legalentity.model.ProductGroup;
+import com.backbase.stream.legalentity.model.SavingsAccount;
+import com.backbase.stream.legalentity.model.ServiceAgreement;
+import com.backbase.stream.legalentity.model.TermDeposit;
+import com.backbase.stream.legalentity.model.TermUnit;
+import com.backbase.stream.legalentity.model.User;
+import java.math.BigDecimal;
+import java.util.Collections;
+import java.util.List;
+import org.jetbrains.annotations.NotNull;
+
+public class MockUtil {
+
+
+  @NotNull
+  public static TermDeposit buildTermDeposit() {
+    TermDeposit termDeposit = new TermDeposit()
+        .termNumber(BigDecimal.valueOf(21212))
+        .termUnit(TermUnit.DAILY)
+        .BBAN("777151235")
+        .accountHolderName("John Doe")
+        .bookedBalance(new BookedBalance().amount(BigDecimal.valueOf(50)));
+    termDeposit.externalId("termExtId").productTypeExternalId("Term Deposit").currency("GBP")
+        .legalEntities(List.of(new LegalEntityReference().externalId("termInternalId")));
+    return termDeposit;
+  }
+
+  @NotNull
+  public static CreditCard buildCreditCard() {
+    CreditCard creditCard = new CreditCard()
+        .availableBalance(new AvailableBalance().amount(BigDecimal.valueOf(100)))
+        .BBAN("777151236")
+        .accountHolderName("John Doe")
+        .bookedBalance(new BookedBalance().amount(BigDecimal.valueOf(50)));
+    creditCard.externalId("ccExtId").productTypeExternalId("Credit Card").currency("GBP")
+        .legalEntities(List.of(new LegalEntityReference().externalId("ccInternalId")));
+    return creditCard;
+  }
+
+  @NotNull
+  public static SavingsAccount buildSavingsAccount() {
+    SavingsAccount savingsAccount = new SavingsAccount();
+    savingsAccount.externalId("someAccountExId").productTypeExternalId("Account").currency("GBP")
+        .legalEntities(List.of(new LegalEntityReference().externalId("savInternalId")));
+    return savingsAccount;
+  }
+
+  @NotNull
+  public static CurrentAccount buildCurrentAccount() {
+    CurrentAccount currentAccount = new CurrentAccount()
+        .availableBalance(new AvailableBalance().amount(BigDecimal.valueOf(100)))
+        .BBAN("777151234")
+        .accountHolderName("John Doe")
+        .bookedBalance(new BookedBalance().amount(BigDecimal.valueOf(50)));
+    currentAccount.externalId("currentAccountExtId").productTypeExternalId("Current Account")
+        .currency("GBP")
+        .legalEntities(List.of(new LegalEntityReference().externalId("currInternalId")));
+    return currentAccount;
+  }
+
+  @NotNull
+  public static Loan buildLoanAccount() {
+    Loan loan = new Loan().availableBalance(new AvailableBalance().amount(BigDecimal.valueOf(100)))
+        .BBAN("777151238")
+        .accountHolderName("John Doe")
+        .bookedBalance(new BookedBalance().amount(BigDecimal.valueOf(50)));
+    loan.externalId("loanAccountExtId").productTypeExternalId("Loan").currency("GBP")
+        .legalEntities(List.of(new LegalEntityReference().externalId("loanInternalId")));
+    return loan;
+  }
+
+  public static JobProfileUser buildJobProfile() {
+    return new JobProfileUser().user(
+            new User().internalId("someRegularUserInId")
+                .externalId("someRegularUserExId"))
+        .legalEntityReference(new LegalEntityReference().externalId("someLeExternalId"))
+        .referenceJobRoleNames(List.of("someJR"));
+  }
+
+  public static DataGroupItem buildDataGroupItem() {
+    return new DataGroupItem().id("someDgItemExId1In").name("somePgName");
+  }
+
+  public static FunctionGroupItem buildFunctionGroupItem() {
+    return new FunctionGroupItem().id("some-fg1").name("someJR").type(
+        FunctionGroupItem.TypeEnum.DEFAULT);
+  }
+
+  public static List<BusinessFunctionGroup> buildBusinessFunctionGroupList() {
+    return List.of(
+        new BusinessFunctionGroup().name("someJR").id("some-fg1").type(TypeEnum.DEFAULT));
+  }
+
+  public static User buildUser() {
+    return new User().internalId("someRegularUserInId")
+        .externalId("someRegularUserExId");
+  }
+
+  public static ProductGroup createProductGroup() {
+
+    SavingsAccount savingsAccount = buildSavingsAccount();
+    CurrentAccount currentAccount = buildCurrentAccount();
+    Loan loan = buildLoanAccount();
+    TermDeposit termDeposit = buildTermDeposit();
+    CreditCard creditCard = buildCreditCard();
+
+    ProductGroup productGroup = new ProductGroup();
+    productGroup.setServiceAgreement(
+        new ServiceAgreement().internalId("sa_internalId").externalId("externalId"));
+
+    productGroup.productGroupType(BaseProductGroup.ProductGroupTypeEnum.ARRANGEMENTS)
+        .name("somePgName")
+        .description("somePgDescription")
+        .savingAccounts(Collections.singletonList(savingsAccount))
+        .currentAccounts(Collections.singletonList(currentAccount))
+        .loans(Collections.singletonList(loan))
+        .termDeposits(Collections.singletonList(termDeposit))
+        .creditCards(Collections.singletonList(creditCard))
+        .users(List.of(buildJobProfile()));
+
+    return productGroup;
+  }
+}

--- a/stream-product/product-ingestion-saga/src/test/java/com/backbase/stream/product/ProductIngestionSagaTest.java
+++ b/stream-product/product-ingestion-saga/src/test/java/com/backbase/stream/product/ProductIngestionSagaTest.java
@@ -1,0 +1,99 @@
+package com.backbase.stream.product;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+import com.backbase.dbs.arrangement.api.service.v2.model.AccountArrangementItem;
+import com.backbase.dbs.arrangement.api.service.v2.model.AccountArrangementItemPut;
+import com.backbase.loan.inbound.api.service.v1.LoansApi;
+import com.backbase.stream.legalentity.model.ProductGroup;
+import com.backbase.stream.loan.LoansSaga;
+import com.backbase.stream.product.configuration.ProductIngestionSagaConfigurationProperties;
+import com.backbase.stream.product.service.ArrangementService;
+import com.backbase.stream.product.task.ProductGroupTask;
+import com.backbase.stream.service.AccessGroupService;
+import com.backbase.stream.service.UserService;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+@ExtendWith(MockitoExtension.class)
+class ProductIngestionSagaTest {
+
+  @InjectMocks
+  ProductIngestionSaga productIngestionSaga;
+  @Mock
+  ArrangementService arrangementService;
+  @Mock
+  AccessGroupService accessGroupService;
+  @Mock
+  UserService userService;
+  @Mock
+  ProductIngestionSagaConfigurationProperties configurationProperties;
+  @Mock
+  LoansSaga loansSaga;
+  @Mock
+  LoansApi loansApi;
+
+  ProductGroupTask productGroupTask;
+
+  @BeforeEach
+  void setUp() {
+    productGroupTask = mockProductGroupTask();
+    when(arrangementService.getArrangementInternalId(anyString()))
+        .thenReturn(Mono.just("internal_id"));
+    when(arrangementService.createArrangement(any()))
+        .thenReturn(Mono.just(new AccountArrangementItem()));
+    when(arrangementService.updateArrangement(any()))
+        .thenReturn(Mono.just(new AccountArrangementItemPut()
+            .externalArrangementId("currentAccountExtId")));
+    when(accessGroupService.setupProductGroups(productGroupTask))
+        .thenReturn(Mono.just(productGroupTask));
+    when(accessGroupService.getFunctionGroupsForServiceAgreement("sa_internalId"))
+        .thenReturn(Mono.just(List.of(MockUtil.buildFunctionGroupItem())));
+    when(accessGroupService.setupFunctionGroups(productGroupTask,
+        productGroupTask.getData().getServiceAgreement(),
+        MockUtil.buildBusinessFunctionGroupList()))
+        .thenReturn(Mono.just(MockUtil.buildBusinessFunctionGroupList()));
+    when(accessGroupService.assignPermissions(any(), any())).thenReturn(
+        Mono.just(MockUtil.buildJobProfile()));
+  }
+
+  @Test
+  void test_processProductsUsers_withUserInternalId() {
+    when(userService.getUserById("someRegularUserInId")).thenReturn(
+        Mono.just(MockUtil.buildUser()));
+    when(userService.createUser(any(), any(), any()))
+        .thenReturn(Mono.just(MockUtil.buildUser()));
+    StepVerifier.create(productIngestionSaga.process(productGroupTask))
+        .expectNext(productGroupTask)
+        .expectComplete()
+        .verify();
+  }
+
+  @Test
+  void test_processProductsUsers_withUserExternalId() {
+    productGroupTask.getProductGroup().getUsers().get(0).getUser().setInternalId(null);
+    when(userService.getUserByExternalId("someRegularUserExId")).thenReturn(
+        Mono.just(MockUtil.buildUser()));
+    when(userService.createUser(any(), any(), any()))
+        .thenReturn(Mono.just(MockUtil.buildUser()));
+    StepVerifier.create(productIngestionSaga.process(productGroupTask))
+        .expectNext(productGroupTask)
+        .expectComplete()
+        .verify();
+  }
+
+  ProductGroupTask mockProductGroupTask() {
+    ProductGroup productGroup = MockUtil.createProductGroup();
+    return new ProductGroupTask()
+        .data(productGroup);
+  }
+}


### PR DESCRIPTION
## Description

Perfomance fix during upsertUser processing. If the internalId is available, call getUserById (8 ms response time) instead of getUserByExternalId (~ 50 ms response time).

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
  
  Add N/A to the task if they are not relevant to the current PR(validation will be skipped). 
  e.g. [ ] My changes are adequately tested ~ N/A
-->

 - [NA] I made sure, I read [CONTRIBUTING.md](CONTRIBUTING.md) to put right branch prefix as per my need.
 - [x] I made sure to update [CHANGELOG.md](CHANGELOG.md).
 - [NA] I made sure to update [Stream Wiki](https://github.com/Backbase/stream-services/wiki)(only valid in case of new stream module or architecture changes).
 - [x] My changes are adequately tested.
 - [x] I made sure all the SonarCloud Quality Gate are passed.
