### PR TITLE
MAINT-32405: Explicitly adding state values into BaseProduct based ma…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
-## [5.0.0](https://github.com/Backbase/stream-services/compare/4.0.0...3.70.0)
-### Changed
-- Bumping Service SDK to **17.0.0**
+## [5.11.0](https://github.com/Backbase/stream-services/compare/5.10.0...5.11.0)
+### Fixed
+- Fixed missing explicit state mappings for BaseProduct related classes
+
 ## [5.10.0](https://github.com/Backbase/stream-services/compare/5.9.1...5.10.0)
 ### Added
 - Introducing Grand Central customer canonical model: Processing the `PartyUpsertEvent` using the Legal Entity Saga via the [legal-entity-composition-service](stream-compositions/services/legal-entity-composition-service)

--- a/stream-product/product-core/src/main/java/com/backbase/stream/product/mapping/ProductMapper.java
+++ b/stream-product/product-core/src/main/java/com/backbase/stream/product/mapping/ProductMapper.java
@@ -56,7 +56,6 @@ public interface ProductMapper {
     @Mapping(source = ProductMapperConstants.ACCOUNT_HOLDER_NAME, target = ProductMapperConstants.ACCOUNT_HOLDER_NAMES)
     PostArrangement toPresentation(Product product);
 
-
     @Mapping(source = ProductMapperConstants.EXTERNAL_ID, target = ProductMapperConstants.EXTERNAL_ARRANGEMENT_ID)
     @Mapping(source = ProductMapperConstants.PRODUCT_TYPE_EXTERNAL_ID, target = ProductMapperConstants.EXTERNAL_PRODUCT_ID)
     @Mapping(source = ProductMapperConstants.LEGAL_ENTITIES, target = ProductMapperConstants.EXTERNAL_LEGAL_ENTITY_IDS)
@@ -71,8 +70,8 @@ public interface ProductMapper {
     @Mapping(source = "debitCardsItems", target = "debitCards")
     @Mapping(source = ProductMapperConstants.ACCOUNT_HOLDER_NAME, target = ProductMapperConstants.ACCOUNT_HOLDER_NAMES)
     @Mapping(source = ProductMapperConstants.PAN_SUFFIX, target = ProductMapperConstants.NUMBER)
+    @Mapping(source = "state.state", target = ProductMapperConstants.STATE_ID)
     PostArrangement toPresentation(CurrentAccount currentAccount);
-
 
     @Mapping(source = ProductMapperConstants.EXTERNAL_ID, target = ProductMapperConstants.ID)
     @Mapping(source = ProductMapperConstants.PRODUCT_TYPE_EXTERNAL_ID, target = ProductMapperConstants.PRODUCT_ID)
@@ -80,24 +79,25 @@ public interface ProductMapper {
     @Mapping(source = ProductMapperConstants.DEBIT_CARDS_ITEMS, target = ProductMapperConstants.DEBIT_CARDS)
     @Mapping(source = ProductMapperConstants.ACCOUNT_HOLDER_NAME, target = ProductMapperConstants.ACCOUNT_HOLDER_NAMES)
     @Mapping(source = ProductMapperConstants.PAN_SUFFIX, target = ProductMapperConstants.NUMBER)
+    @Mapping(source = "state.state", target = ProductMapperConstants.STATE_ID)
     @InheritConfiguration
     PostArrangement toPresentation(SavingsAccount savingsAccount);
-
 
     @Mapping(source = ProductMapperConstants.EXTERNAL_ID, target = ProductMapperConstants.ID)
     @Mapping(source = ProductMapperConstants.PRODUCT_TYPE_EXTERNAL_ID, target = ProductMapperConstants.PRODUCT_ID)
     @Mapping(source = ProductMapperConstants.LEGAL_ENTITIES, target = ProductMapperConstants.LEGAL_ENTITY_IDS)
     @Mapping(source = ProductMapperConstants.ACCOUNT_HOLDER_NAME, target = ProductMapperConstants.ACCOUNT_HOLDER_NAMES)
     @Mapping(source = "debitCard", qualifiedByName = "mapDebitCardNumber", target = ProductMapperConstants.NUMBER)
+    @Mapping(source = "state.state", target = ProductMapperConstants.STATE_ID)
     @InheritConfiguration
     PostArrangement toPresentation(DebitCard debitCard);
-
 
     @Mapping(source = ProductMapperConstants.EXTERNAL_ID, target = ProductMapperConstants.ID)
     @Mapping(source = ProductMapperConstants.PRODUCT_TYPE_EXTERNAL_ID, target = ProductMapperConstants.PRODUCT_ID)
     @Mapping(source = ProductMapperConstants.LEGAL_ENTITIES, target = ProductMapperConstants.LEGAL_ENTITY_IDS)
     @Mapping(source = ProductMapperConstants.ACCOUNT_HOLDER_NAME, target = ProductMapperConstants.ACCOUNT_HOLDER_NAMES)
     @Mapping(source = "creditCard", qualifiedByName = "mapCreditCardNumber", target = ProductMapperConstants.NUMBER)
+    @Mapping(source = "state.state", target = ProductMapperConstants.STATE_ID)
     @InheritConfiguration
     PostArrangement toPresentation(CreditCard creditCard);
 
@@ -106,6 +106,7 @@ public interface ProductMapper {
     @Mapping(source = ProductMapperConstants.LEGAL_ENTITIES, target = ProductMapperConstants.LEGAL_ENTITY_IDS)
     @Mapping(source = ProductMapperConstants.ACCOUNT_HOLDER_NAME, target = ProductMapperConstants.ACCOUNT_HOLDER_NAMES)
     @Mapping(source = ProductMapperConstants.PAN_SUFFIX, target = ProductMapperConstants.NUMBER)
+    @Mapping(source = "state.state", target = ProductMapperConstants.STATE_ID)
     @InheritConfiguration
     PostArrangement toPresentation(TermDeposit termDeposit);
 
@@ -114,6 +115,7 @@ public interface ProductMapper {
     @Mapping(source = ProductMapperConstants.LEGAL_ENTITIES, target = ProductMapperConstants.LEGAL_ENTITY_IDS)
     @Mapping(source = "currentInvestment.amount", target = "currentInvestmentValue")
     @Mapping(source = ProductMapperConstants.PAN_SUFFIX, target = ProductMapperConstants.NUMBER)
+    @Mapping(source = "state.state", target = ProductMapperConstants.STATE_ID)
     @InheritConfiguration
     PostArrangement toPresentation(InvestmentAccount investmentAccount);
 
@@ -123,6 +125,7 @@ public interface ProductMapper {
     @Mapping(source = ProductMapperConstants.LEGAL_ENTITIES, target = ProductMapperConstants.LEGAL_ENTITY_IDS)
     @Mapping(source = ProductMapperConstants.ACCOUNT_HOLDER_NAME, target = ProductMapperConstants.ACCOUNT_HOLDER_NAMES)
     @Mapping(source = ProductMapperConstants.PAN_SUFFIX, target = ProductMapperConstants.NUMBER)
+    @Mapping(source = "state.state", target = ProductMapperConstants.STATE_ID)
     @InheritConfiguration
     PostArrangement toPresentation(Loan loan);
 
@@ -140,6 +143,7 @@ public interface ProductMapper {
     ArrangementItem toArrangementItem(ArrangementPutItem arrangementItemPut);
 
     @Mapping(source = ProductMapperConstants.EXTERNAL_ID, target = ProductMapperConstants.EXTERNAL_ARRANGEMENT_ID)
+    @Mapping(source = "state.state", target = ProductMapperConstants.EXTERNAL_STATE_ID)
     ArrangementItem toPresentationWithWeirdSpellingError(Product product);
 
     @Mapping(source = ProductMapperConstants.EXTERNAL_ARRANGEMENT_ID, target = ProductMapperConstants.EXTERNAL_ID)

--- a/stream-product/product-core/src/test/java/com/backbase/stream/product/mapping/ProductMapperTest.java
+++ b/stream-product/product-core/src/test/java/com/backbase/stream/product/mapping/ProductMapperTest.java
@@ -46,7 +46,10 @@ public class ProductMapperTest {
                 .externalId("prod_ext_id")
                 .productTypeExternalId("prod_type_ext_id")
                 .legalEntities(List.of(buildLegalEntityReference("le_ext_id_1"), buildLegalEntityReference("le_ext_id_2")))
-                .state(new BaseProductState().state("prod_state"))
+                // Here externalStateId and state are set because in arrangement-pull-integration-service
+                // in the AccountStatusMapper, both fields are set with the same state value in the 3
+                // ACTIVE, INACTIVE and CLOSED enums
+                .state(new BaseProductState().externalStateId("prod_state").state("prod_state"))
                 .additions(Map.of("add_prop_1", "add_val_1", "add_prop_2", "add_val_2"))
                 .name("prod_name")
                 .currency("USD")
@@ -266,8 +269,8 @@ public class ProductMapperTest {
     void map_Product_To_AccountArrangementItem() {
         Product source = buildProduct();
         ArrangementItem target = productMapper.toPresentationWithWeirdSpellingError(source);
-        Assertions.assertEquals(target.getExternalArrangementId(), source.getExternalId());
-        Assertions.assertEquals(target.getExternalStateId(), source.getState().getExternalStateId());
+        Assertions.assertEquals(source.getExternalId(), target.getExternalArrangementId());
+        Assertions.assertEquals(source.getState().getExternalStateId(), target.getExternalStateId());
     }
 
     @Test


### PR DESCRIPTION
## Description

Bug fix where explicit state mapping was missing for BaseProduct related classes

## Checklist

 - [X] I made sure, I read [CONTRIBUTING.md](CONTRIBUTING.md) to put right branch prefix as per my need.
 - [X] I made sure to update [CHANGELOG.md](CHANGELOG.md).
 - [ ] I made sure to update [Stream Wiki](https://github.com/Backbase/stream-services/wiki)(only valid in case of new stream module or architecture changes).
 - [X] My changes are adequately tested.
 - [X] I made sure all the SonarCloud Quality Gate are passed.
