### PR TITLE
MAINT-32325 - fix the place to set the internal id for creatorLE fro SA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [6.4.0](https://github.com/Backbase/stream-services/compare/6.3.0...6.4.0)
+### Fixed
+- Fixed setting internal id for creatorLE before creating SA
+
 ## [6.3.0](https://github.com/Backbase/stream-services/compare/6.2.0...6.3.0)
 ### Fixed
 - Fixed missing explicit state mappings for BaseProduct related classes


### PR DESCRIPTION
## Description

Fixed setting internal id for creatorLE before creating SA

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
  
  Add N/A to the task if they are not relevant to the current PR(validation will be skipped). 
  e.g. [ ] My changes are adequately tested ~ N/A
-->

 - [x] I made sure, I read [CONTRIBUTING.md](CONTRIBUTING.md) to put right branch prefix as per my need.
 - [x] I made sure to update [CHANGELOG.md](CHANGELOG.md).
 - [x] I made sure to update [Stream Wiki](https://github.com/Backbase/stream-services/wiki)(only valid in case of new stream module or architecture changes).
 - [x] My changes are adequately tested.
 - [x] I made sure all the SonarCloud Quality Gate are passed.
