### PR TITLE
Fix - Modified invocation of the putArrangementById API to provide the internal ID of the arrangement instead of the external ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 ## [6.5.0](https://github.com/Backbase/stream-services/compare/6.4.0...6.5.0)
 ### Fixed
 - Fixed productTypeName mapping when ingesting Product data into arrangement-manager
+## [6.4.2](https://github.com/Backbase/stream-services/compare/6.4.1...6.4.2)
+### Fixed
+- Fixed invocation of [putArrangementById](https://backbase.io/developers/apis/specs/arrangement-manager/arrangement-service-api/3.0.5/operations/Arrangements/putArrangementById/) in `ArrangementService` to pass in the arrangement's internalId. 
+The arrangement's externalId was erroneously being provided to this method.
 
 ## [6.4.0](https://github.com/Backbase/stream-services/compare/6.3.0...6.4.0)
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [6.5.0](https://github.com/Backbase/stream-services/compare/6.4.0...6.5.0)
+### Fixed
+- Fixed productTypeName mapping when ingesting Product data into arrangement-manager
+
 ## [6.4.0](https://github.com/Backbase/stream-services/compare/6.3.0...6.4.0)
 ### Fixed
 - Fixed setting internal id for creatorLE before creating SA

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>com.backbase.stream</groupId>
     <artifactId>stream-services</artifactId>
-    <version>6.4.1</version>
+    <version>6.5.0</version>
 
     <packaging>pom</packaging>
     <name>Stream :: Services</name>

--- a/stream-access-control/access-control-core/pom.xml
+++ b/stream-access-control/access-control-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.backbase.stream</groupId>
         <artifactId>stream-access-control</artifactId>
-        <version>6.4.1</version>
+        <version>6.5.0</version>
     </parent>
 
     <artifactId>access-control-core</artifactId>

--- a/stream-access-control/pom.xml
+++ b/stream-access-control/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.backbase.stream</groupId>
         <artifactId>stream-services</artifactId>
-        <version>6.4.1</version>
+        <version>6.5.0</version>
     </parent>
 
     <artifactId>stream-access-control</artifactId>

--- a/stream-approvals/approvals-bootstrap-task/pom.xml
+++ b/stream-approvals/approvals-bootstrap-task/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.backbase.stream</groupId>
         <artifactId>stream-task-starter-parent</artifactId>
-        <version>6.4.1</version>
+        <version>6.5.0</version>
         <relativePath>../../stream-sdk/stream-starter-parents/stream-task-starter-parent</relativePath>
     </parent>
 

--- a/stream-approvals/approvals-core/pom.xml
+++ b/stream-approvals/approvals-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.backbase.stream</groupId>
         <artifactId>stream-approvals</artifactId>
-        <version>6.4.1</version>
+        <version>6.5.0</version>
     </parent>
 
     <artifactId>approvals-core</artifactId>

--- a/stream-approvals/pom.xml
+++ b/stream-approvals/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.backbase.stream</groupId>
         <artifactId>stream-services</artifactId>
-        <version>6.4.1</version>
+        <version>6.5.0</version>
     </parent>
 
     <artifactId>stream-approvals</artifactId>

--- a/stream-audiences/audiences-core/pom.xml
+++ b/stream-audiences/audiences-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.backbase.stream</groupId>
         <artifactId>stream-audiences</artifactId>
-        <version>6.4.1</version>
+        <version>6.5.0</version>
     </parent>
 
     <artifactId>audiences-core</artifactId>

--- a/stream-audiences/pom.xml
+++ b/stream-audiences/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.backbase.stream</groupId>
         <artifactId>stream-services</artifactId>
-        <version>6.4.1</version>
+        <version>6.5.0</version>
     </parent>
 
     <artifactId>stream-audiences</artifactId>

--- a/stream-compositions/api/cursors-api/pom.xml
+++ b/stream-compositions/api/cursors-api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>api</artifactId>
         <groupId>com.backbase.stream.compositions</groupId>
-        <version>6.4.1</version>
+        <version>6.5.0</version>
     </parent>
 
     <artifactId>cursors-api</artifactId>

--- a/stream-compositions/api/cursors-api/transaction-cursor-api/pom.xml
+++ b/stream-compositions/api/cursors-api/transaction-cursor-api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>cursors-api</artifactId>
         <groupId>com.backbase.stream.compositions</groupId>
-        <version>6.4.1</version>
+        <version>6.5.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/stream-compositions/api/integrations-api/legal-entity-integration-api/pom.xml
+++ b/stream-compositions/api/integrations-api/legal-entity-integration-api/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>integrations-api</artifactId>
         <groupId>com.backbase.stream.compositions</groupId>
-        <version>6.4.1</version>
+        <version>6.5.0</version>
     </parent>
 
     <groupId>com.backbase.stream.compositions.api</groupId>

--- a/stream-compositions/api/integrations-api/payment-order-integration-api/pom.xml
+++ b/stream-compositions/api/integrations-api/payment-order-integration-api/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>integrations-api</artifactId>
         <groupId>com.backbase.stream.compositions</groupId>
-        <version>6.4.1</version>
+        <version>6.5.0</version>
     </parent>
 
     <groupId>com.backbase.stream.compositions.api</groupId>

--- a/stream-compositions/api/integrations-api/pom.xml
+++ b/stream-compositions/api/integrations-api/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>api</artifactId>
         <groupId>com.backbase.stream.compositions</groupId>
-        <version>6.4.1</version>
+        <version>6.5.0</version>
     </parent>
 
     <artifactId>integrations-api</artifactId>

--- a/stream-compositions/api/integrations-api/product-catalog-integration-api/pom.xml
+++ b/stream-compositions/api/integrations-api/product-catalog-integration-api/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>integrations-api</artifactId>
         <groupId>com.backbase.stream.compositions</groupId>
-        <version>6.4.1</version>
+        <version>6.5.0</version>
     </parent>
 
     <groupId>com.backbase.stream.compositions.api</groupId>

--- a/stream-compositions/api/integrations-api/product-integration-api/pom.xml
+++ b/stream-compositions/api/integrations-api/product-integration-api/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>integrations-api</artifactId>
         <groupId>com.backbase.stream.compositions</groupId>
-        <version>6.4.1</version>
+        <version>6.5.0</version>
     </parent>
 
     <groupId>com.backbase.stream.compositions.api</groupId>

--- a/stream-compositions/api/integrations-api/transaction-integration-api/pom.xml
+++ b/stream-compositions/api/integrations-api/transaction-integration-api/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>integrations-api</artifactId>
         <groupId>com.backbase.stream.compositions</groupId>
-        <version>6.4.1</version>
+        <version>6.5.0</version>
     </parent>
 
     <groupId>com.backbase.stream.compositions.api</groupId>

--- a/stream-compositions/api/pom.xml
+++ b/stream-compositions/api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.backbase.stream</groupId>
         <artifactId>stream-compositions</artifactId>
-        <version>6.4.1</version>
+        <version>6.5.0</version>
     </parent>
 
     <groupId>com.backbase.stream.compositions</groupId>

--- a/stream-compositions/api/service-api/legal-entity-composition-api/pom.xml
+++ b/stream-compositions/api/service-api/legal-entity-composition-api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.backbase.stream.compositions</groupId>
         <artifactId>service-api</artifactId>
-        <version>6.4.1</version>
+        <version>6.5.0</version>
     </parent>
 
     <groupId>com.backbase.stream.compositions.api</groupId>

--- a/stream-compositions/api/service-api/payment-order-composition-api/pom.xml
+++ b/stream-compositions/api/service-api/payment-order-composition-api/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>service-api</artifactId>
         <groupId>com.backbase.stream.compositions</groupId>
-        <version>6.4.1</version>
+        <version>6.5.0</version>
     </parent>
 
     <groupId>com.backbase.stream.compositions.api</groupId>

--- a/stream-compositions/api/service-api/pom.xml
+++ b/stream-compositions/api/service-api/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.backbase.stream.compositions</groupId>
         <artifactId>api</artifactId>
-        <version>6.4.1</version>
+        <version>6.5.0</version>
     </parent>
 
     <artifactId>service-api</artifactId>

--- a/stream-compositions/api/service-api/product-catalog-composition-api/pom.xml
+++ b/stream-compositions/api/service-api/product-catalog-composition-api/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>service-api</artifactId>
         <groupId>com.backbase.stream.compositions</groupId>
-        <version>6.4.1</version>
+        <version>6.5.0</version>
     </parent>
 
     <groupId>com.backbase.stream.compositions.api</groupId>

--- a/stream-compositions/api/service-api/product-composition-api/pom.xml
+++ b/stream-compositions/api/service-api/product-composition-api/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>service-api</artifactId>
         <groupId>com.backbase.stream.compositions</groupId>
-        <version>6.4.1</version>
+        <version>6.5.0</version>
     </parent>
 
     <groupId>com.backbase.stream.compositions.api</groupId>

--- a/stream-compositions/api/service-api/transaction-composition-api/pom.xml
+++ b/stream-compositions/api/service-api/transaction-composition-api/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>service-api</artifactId>
         <groupId>com.backbase.stream.compositions</groupId>
-        <version>6.4.1</version>
+        <version>6.5.0</version>
     </parent>
 
     <groupId>com.backbase.stream.compositions.api</groupId>

--- a/stream-compositions/cursors/pom.xml
+++ b/stream-compositions/cursors/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>stream-compositions</artifactId>
     <groupId>com.backbase.stream</groupId>
-    <version>6.4.1</version>
+    <version>6.5.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/stream-compositions/cursors/transaction-cursor/pom.xml
+++ b/stream-compositions/cursors/transaction-cursor/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.backbase.stream.compositions</groupId>
     <artifactId>cursors</artifactId>
-    <version>6.4.1</version>
+    <version>6.5.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/stream-compositions/events/grandcentral/pom.xml
+++ b/stream-compositions/events/grandcentral/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>events</artifactId>
         <groupId>com.backbase.stream.compositions</groupId>
-        <version>6.4.1</version>
+        <version>6.5.0</version>
     </parent>
 
     <groupId>com.backbase.stream.compositions.events</groupId>

--- a/stream-compositions/events/legal-entity-egress/pom.xml
+++ b/stream-compositions/events/legal-entity-egress/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>events</artifactId>
         <groupId>com.backbase.stream.compositions</groupId>
-        <version>6.4.1</version>
+        <version>6.5.0</version>
     </parent>
 
     <groupId>com.backbase.stream.compositions.events</groupId>

--- a/stream-compositions/events/legal-entity-ingress/pom.xml
+++ b/stream-compositions/events/legal-entity-ingress/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>events</artifactId>
         <groupId>com.backbase.stream.compositions</groupId>
-        <version>6.4.1</version>
+        <version>6.5.0</version>
     </parent>
 
     <groupId>com.backbase.stream.compositions.events</groupId>

--- a/stream-compositions/events/pom.xml
+++ b/stream-compositions/events/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.backbase.stream</groupId>
         <artifactId>stream-compositions</artifactId>
-        <version>6.4.1</version>
+        <version>6.5.0</version>
     </parent>
 
     <groupId>com.backbase.stream.compositions</groupId>

--- a/stream-compositions/events/product-catalog-egress/pom.xml
+++ b/stream-compositions/events/product-catalog-egress/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>events</artifactId>
         <groupId>com.backbase.stream.compositions</groupId>
-        <version>6.4.1</version>
+        <version>6.5.0</version>
     </parent>
 
     <groupId>com.backbase.stream.compositions.events</groupId>

--- a/stream-compositions/events/product-catalog-ingress/pom.xml
+++ b/stream-compositions/events/product-catalog-ingress/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>events</artifactId>
         <groupId>com.backbase.stream.compositions</groupId>
-        <version>6.4.1</version>
+        <version>6.5.0</version>
     </parent>
 
     <groupId>com.backbase.stream.compositions.events</groupId>

--- a/stream-compositions/events/product-egress/pom.xml
+++ b/stream-compositions/events/product-egress/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>events</artifactId>
         <groupId>com.backbase.stream.compositions</groupId>
-        <version>6.4.1</version>
+        <version>6.5.0</version>
     </parent>
 
     <groupId>com.backbase.stream.compositions.events</groupId>

--- a/stream-compositions/events/product-ingress/pom.xml
+++ b/stream-compositions/events/product-ingress/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>events</artifactId>
         <groupId>com.backbase.stream.compositions</groupId>
-        <version>6.4.1</version>
+        <version>6.5.0</version>
     </parent>
 
     <groupId>com.backbase.stream.compositions.events</groupId>

--- a/stream-compositions/events/transaction-egress/pom.xml
+++ b/stream-compositions/events/transaction-egress/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>events</artifactId>
         <groupId>com.backbase.stream.compositions</groupId>
-        <version>6.4.1</version>
+        <version>6.5.0</version>
     </parent>
 
     <groupId>com.backbase.stream.compositions.events</groupId>

--- a/stream-compositions/events/transaction-ingress/pom.xml
+++ b/stream-compositions/events/transaction-ingress/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>events</artifactId>
         <groupId>com.backbase.stream.compositions</groupId>
-        <version>6.4.1</version>
+        <version>6.5.0</version>
     </parent>
 
     <groupId>com.backbase.stream.compositions.events</groupId>

--- a/stream-compositions/pom.xml
+++ b/stream-compositions/pom.xml
@@ -7,13 +7,13 @@
     <parent>
         <groupId>com.backbase.stream</groupId>
         <artifactId>stream-starter</artifactId>
-        <version>6.4.1</version>
+        <version>6.5.0</version>
         <relativePath>../stream-sdk/stream-starter</relativePath>
     </parent>
 
     <groupId>com.backbase.stream</groupId>
     <artifactId>stream-compositions</artifactId>
-    <version>6.4.1</version>
+    <version>6.5.0</version>
 
     <packaging>pom</packaging>
     <name>Stream :: Compositions</name>

--- a/stream-compositions/services/legal-entity-composition-service/pom.xml
+++ b/stream-compositions/services/legal-entity-composition-service/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.backbase.stream.compositions</groupId>
         <artifactId>services</artifactId>
-        <version>6.4.1</version>
+        <version>6.5.0</version>
     </parent>
 
     <artifactId>legal-entity-composition-service</artifactId>

--- a/stream-compositions/services/payment-order-composition-service/pom.xml
+++ b/stream-compositions/services/payment-order-composition-service/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.backbase.stream.compositions</groupId>
         <artifactId>services</artifactId>
-        <version>6.4.1</version>
+        <version>6.5.0</version>
     </parent>
 
     <artifactId>payment-order-composition-service</artifactId>

--- a/stream-compositions/services/pom.xml
+++ b/stream-compositions/services/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.backbase.stream</groupId>
         <artifactId>stream-compositions</artifactId>
-        <version>6.4.1</version>
+        <version>6.5.0</version>
     </parent>
 
     <groupId>com.backbase.stream.compositions</groupId>

--- a/stream-compositions/services/product-catalog-composition-service/pom.xml
+++ b/stream-compositions/services/product-catalog-composition-service/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.backbase.stream.compositions</groupId>
         <artifactId>services</artifactId>
-        <version>6.4.1</version>
+        <version>6.5.0</version>
     </parent>
 
     <artifactId>product-catalog-composition-service</artifactId>

--- a/stream-compositions/services/product-composition-service/pom.xml
+++ b/stream-compositions/services/product-composition-service/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.backbase.stream.compositions</groupId>
         <artifactId>services</artifactId>
-        <version>6.4.1</version>
+        <version>6.5.0</version>
     </parent>
 
     <artifactId>product-composition-service</artifactId>

--- a/stream-compositions/services/product-composition-service/src/main/java/com/backbase/stream/compositions/product/core/service/impl/ArrangementIngestionServiceImpl.java
+++ b/stream-compositions/services/product-composition-service/src/main/java/com/backbase/stream/compositions/product/core/service/impl/ArrangementIngestionServiceImpl.java
@@ -81,7 +81,7 @@ public class ArrangementIngestionServiceImpl implements ArrangementIngestionServ
     }
 
     private Mono<ArrangementIngestResponse> sendToDbs(ArrangementIngestResponse res) {
-        return arrangementService.updateArrangement(res.getArrangement())
+        return arrangementService.updateArrangement(res.getArrangementInternalId(), res.getArrangement())
                 .map(item -> ArrangementIngestResponse.builder()
                         .arrangement(res.getArrangement())
                         .arrangementInternalId(res.getArrangementInternalId())

--- a/stream-compositions/services/product-composition-service/src/test/java/com/backbase/stream/compositions/product/http/ProductControllerIT.java
+++ b/stream-compositions/services/product-composition-service/src/test/java/com/backbase/stream/compositions/product/http/ProductControllerIT.java
@@ -217,7 +217,7 @@ class ProductControllerIT extends IntegrationTest {
 
     @Test
     void pullIngestArrangement_Success() throws Exception {
-        when(arrangementService.updateArrangement(any()))
+        when(arrangementService.updateArrangement(any(), any()))
                 .thenReturn(Mono.just(new ArrangementPutItem()));
 
         ArrangementPullIngestionRequest pullIngestionRequest =
@@ -237,7 +237,7 @@ class ProductControllerIT extends IntegrationTest {
 
     @Test
     void pullIngestArrangement_Fail() throws Exception {
-        when(arrangementService.updateArrangement(any()))
+        when(arrangementService.updateArrangement(any(), any()))
                 .thenThrow(new RuntimeException());
 
         ArrangementPullIngestionRequest pullIngestionRequest =
@@ -263,7 +263,7 @@ class ProductControllerIT extends IntegrationTest {
         com.backbase.stream.compositions.product.api.model.AccountArrangementItemPut arrangementItemPut =
                 mapper.treeToValue(node, com.backbase.stream.compositions.product.api.model.AccountArrangementItemPut.class);
 
-        when(arrangementService.updateArrangement(any()))
+        when(arrangementService.updateArrangement(any(), any()))
                 .thenReturn(Mono.just(new ArrangementPutItem()));
 
         ArrangementPushIngestionRequest pushIngestionRequest =

--- a/stream-compositions/services/transaction-composition-service/pom.xml
+++ b/stream-compositions/services/transaction-composition-service/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.backbase.stream.compositions</groupId>
         <artifactId>services</artifactId>
-        <version>6.4.1</version>
+        <version>6.5.0</version>
     </parent>
 
     <artifactId>transaction-composition-service</artifactId>

--- a/stream-compositions/test-utils/pom.xml
+++ b/stream-compositions/test-utils/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>stream-compositions</artifactId>
         <groupId>com.backbase.stream</groupId>
-        <version>6.4.1</version>
+        <version>6.5.0</version>
     </parent>
 
     <groupId>com.backbase.stream.compositions</groupId>

--- a/stream-contacts/contacts-core/pom.xml
+++ b/stream-contacts/contacts-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.backbase.stream</groupId>
         <artifactId>stream-contacts</artifactId>
-        <version>6.4.1</version>
+        <version>6.5.0</version>
     </parent>
 
     <artifactId>contacts-core</artifactId>

--- a/stream-contacts/pom.xml
+++ b/stream-contacts/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.backbase.stream</groupId>
         <artifactId>stream-services</artifactId>
-        <version>6.4.1</version>
+        <version>6.5.0</version>
     </parent>
 
     <artifactId>stream-contacts</artifactId>

--- a/stream-cursor/cursor-core/pom.xml
+++ b/stream-cursor/cursor-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.backbase.stream</groupId>
         <artifactId>stream-cursor</artifactId>
-        <version>6.4.1</version>
+        <version>6.5.0</version>
     </parent>
 
     <artifactId>cursor-core</artifactId>

--- a/stream-cursor/cursor-http/pom.xml
+++ b/stream-cursor/cursor-http/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.backbase.stream</groupId>
         <artifactId>stream-http-starter-parent</artifactId>
-        <version>6.4.1</version>
+        <version>6.5.0</version>
         <relativePath>../../stream-sdk/stream-starter-parents/stream-http-starter-parent</relativePath>
     </parent>
 

--- a/stream-cursor/cursor-publishers/pom.xml
+++ b/stream-cursor/cursor-publishers/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.backbase.stream</groupId>
         <artifactId>stream-cursor</artifactId>
-        <version>6.4.1</version>
+        <version>6.5.0</version>
     </parent>
 
     <artifactId>cursor-publishers</artifactId>

--- a/stream-cursor/cursor-store/pom.xml
+++ b/stream-cursor/cursor-store/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.backbase.stream</groupId>
         <artifactId>stream-cursor</artifactId>
-        <version>6.4.1</version>
+        <version>6.5.0</version>
     </parent>
 
     <artifactId>cursor-store</artifactId>

--- a/stream-cursor/pom.xml
+++ b/stream-cursor/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.backbase.stream</groupId>
         <artifactId>stream-services</artifactId>
-        <version>6.4.1</version>
+        <version>6.5.0</version>
     </parent>
 
     <artifactId>stream-cursor</artifactId>

--- a/stream-dbs-clients/pom.xml
+++ b/stream-dbs-clients/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.backbase.stream</groupId>
         <artifactId>stream-services</artifactId>
-        <version>6.4.1</version>
+        <version>6.5.0</version>
     </parent>
 
     <artifactId>stream-dbs-clients</artifactId>

--- a/stream-legal-entity/legal-entity-bootstrap-task/pom.xml
+++ b/stream-legal-entity/legal-entity-bootstrap-task/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.backbase.stream</groupId>
         <artifactId>stream-task-starter-parent</artifactId>
-        <version>6.4.1</version>
+        <version>6.5.0</version>
         <relativePath>../../stream-sdk/stream-starter-parents/stream-task-starter-parent</relativePath>
     </parent>
 

--- a/stream-legal-entity/legal-entity-core/pom.xml
+++ b/stream-legal-entity/legal-entity-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.backbase.stream</groupId>
         <artifactId>stream-legal-entity</artifactId>
-        <version>6.4.1</version>
+        <version>6.5.0</version>
     </parent>
 
     <artifactId>legal-entity-core</artifactId>

--- a/stream-legal-entity/legal-entity-http/pom.xml
+++ b/stream-legal-entity/legal-entity-http/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.backbase.stream</groupId>
         <artifactId>stream-http-starter-parent</artifactId>
-        <version>6.4.1</version>
+        <version>6.5.0</version>
         <relativePath>../../stream-sdk/stream-starter-parents/stream-http-starter-parent</relativePath>
     </parent>
 

--- a/stream-legal-entity/pom.xml
+++ b/stream-legal-entity/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.backbase.stream</groupId>
         <artifactId>stream-services</artifactId>
-        <version>6.4.1</version>
+        <version>6.5.0</version>
     </parent>
 
     <artifactId>stream-legal-entity</artifactId>

--- a/stream-limits/limits-core/pom.xml
+++ b/stream-limits/limits-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.backbase.stream</groupId>
         <artifactId>stream-limits</artifactId>
-        <version>6.4.1</version>
+        <version>6.5.0</version>
     </parent>
 
     <artifactId>limits-core</artifactId>

--- a/stream-limits/pom.xml
+++ b/stream-limits/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.backbase.stream</groupId>
         <artifactId>stream-services</artifactId>
-        <version>6.4.1</version>
+        <version>6.5.0</version>
     </parent>
 
     <artifactId>stream-limits</artifactId>

--- a/stream-loans/loans-core/pom.xml
+++ b/stream-loans/loans-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.backbase.stream</groupId>
         <artifactId>stream-loans</artifactId>
-        <version>6.4.1</version>
+        <version>6.5.0</version>
     </parent>
 
     <artifactId>loans-core</artifactId>

--- a/stream-loans/pom.xml
+++ b/stream-loans/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.backbase.stream</groupId>
         <artifactId>stream-services</artifactId>
-        <version>6.4.1</version>
+        <version>6.5.0</version>
     </parent>
 
     <artifactId>stream-loans</artifactId>

--- a/stream-models/approval-model/pom.xml
+++ b/stream-models/approval-model/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.backbase.stream</groupId>
         <artifactId>stream-models</artifactId>
-        <version>6.4.1</version>
+        <version>6.5.0</version>
     </parent>
 
     <artifactId>approval-model</artifactId>

--- a/stream-models/legal-entity-model/pom.xml
+++ b/stream-models/legal-entity-model/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.backbase.stream</groupId>
         <artifactId>stream-models</artifactId>
-        <version>6.4.1</version>
+        <version>6.5.0</version>
     </parent>
 
     <artifactId>legal-entity-model</artifactId>

--- a/stream-models/pom.xml
+++ b/stream-models/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.backbase.stream</groupId>
         <artifactId>stream-services</artifactId>
-        <version>6.4.1</version>
+        <version>6.5.0</version>
     </parent>
 
     <artifactId>stream-models</artifactId>

--- a/stream-models/portfolio-model/pom.xml
+++ b/stream-models/portfolio-model/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.backbase.stream</groupId>
         <artifactId>stream-models</artifactId>
-        <version>6.4.1</version>
+        <version>6.5.0</version>
     </parent>
 
     <artifactId>portfolio-model</artifactId>

--- a/stream-models/product-catalog-model/pom.xml
+++ b/stream-models/product-catalog-model/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.backbase.stream</groupId>
         <artifactId>stream-models</artifactId>
-        <version>6.4.1</version>
+        <version>6.5.0</version>
     </parent>
 
     <artifactId>product-catalog-model</artifactId>

--- a/stream-payment-order/payment-order-core/pom.xml
+++ b/stream-payment-order/payment-order-core/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.backbase.stream</groupId>
         <artifactId>stream-payment-order</artifactId>
-        <version>6.4.1</version>
+        <version>6.5.0</version>
     </parent>
 
     <artifactId>payment-order-core</artifactId>

--- a/stream-payment-order/pom.xml
+++ b/stream-payment-order/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.backbase.stream</groupId>
         <artifactId>stream-services</artifactId>
-        <version>6.4.1</version>
+        <version>6.5.0</version>
     </parent>
 
     <artifactId>stream-payment-order</artifactId>

--- a/stream-plan-manager/plan-manager-core/pom.xml
+++ b/stream-plan-manager/plan-manager-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.backbase.stream</groupId>
         <artifactId>stream-plan-manager</artifactId>
-        <version>6.4.1</version>
+        <version>6.5.0</version>
     </parent>
 
     <artifactId>plan-manager-core</artifactId>

--- a/stream-plan-manager/pom.xml
+++ b/stream-plan-manager/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.backbase.stream</groupId>
         <artifactId>stream-services</artifactId>
-        <version>6.4.1</version>
+        <version>6.5.0</version>
     </parent>
 
     <artifactId>stream-plan-manager</artifactId>

--- a/stream-portfolio/pom.xml
+++ b/stream-portfolio/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.backbase.stream</groupId>
         <artifactId>stream-services</artifactId>
-        <version>6.4.1</version>
+        <version>6.5.0</version>
     </parent>
 
     <artifactId>stream-portfolio</artifactId>

--- a/stream-portfolio/portfolio-bootstrap-task/pom.xml
+++ b/stream-portfolio/portfolio-bootstrap-task/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.backbase.stream</groupId>
         <artifactId>stream-task-starter-parent</artifactId>
-        <version>6.4.1</version>
+        <version>6.5.0</version>
         <relativePath>../../stream-sdk/stream-starter-parents/stream-task-starter-parent</relativePath>
     </parent>
 

--- a/stream-portfolio/portfolio-core/pom.xml
+++ b/stream-portfolio/portfolio-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.backbase.stream</groupId>
         <artifactId>stream-portfolio</artifactId>
-        <version>6.4.1</version>
+        <version>6.5.0</version>
     </parent>
 
     <artifactId>portfolio-core</artifactId>

--- a/stream-portfolio/portfolio-http/pom.xml
+++ b/stream-portfolio/portfolio-http/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.backbase.stream</groupId>
         <artifactId>stream-http-starter-parent</artifactId>
-        <version>6.4.1</version>
+        <version>6.5.0</version>
         <relativePath>../../stream-sdk/stream-starter-parents/stream-http-starter-parent</relativePath>
     </parent>
 

--- a/stream-product-catalog/pom.xml
+++ b/stream-product-catalog/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.backbase.stream</groupId>
         <artifactId>stream-services</artifactId>
-        <version>6.4.1</version>
+        <version>6.5.0</version>
     </parent>
 
     <artifactId>stream-product-catalog</artifactId>

--- a/stream-product-catalog/product-catalog-core/pom.xml
+++ b/stream-product-catalog/product-catalog-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.backbase.stream</groupId>
         <artifactId>stream-product-catalog</artifactId>
-        <version>6.4.1</version>
+        <version>6.5.0</version>
     </parent>
 
     <artifactId>product-catalog-core</artifactId>

--- a/stream-product-catalog/product-catalog-core/src/main/java/com/backbase/stream/productcatalog/ReactiveProductCatalogService.java
+++ b/stream-product-catalog/product-catalog-core/src/main/java/com/backbase/stream/productcatalog/ReactiveProductCatalogService.java
@@ -63,25 +63,14 @@ public class ReactiveProductCatalogService {
      */
     public Mono<ProductCatalog> setupProductCatalog(ProductCatalog productCatalog) {
         return getProductCatalog().flatMap(existingProductCatalog -> {
-
-            List<ProductKind> newProductKinds = new ArrayList<>();
-            if (productCatalog.getProductKinds() != null) {
-                newProductKinds = productCatalog.getProductKinds().stream()
-                    .filter(newProductKind -> existingProductCatalog.getProductKinds().stream()
-                        .noneMatch(productKind ->
-                            productKind.getExternalKindId().equals(newProductKind.getExternalKindId())))
-                    .collect(Collectors.toList());
-            }
             List<ProductType> newProductTypes = new ArrayList<>();
             if (productCatalog.getProductTypes() != null) {
                 newProductTypes = productCatalog.getProductTypes().stream()
                     .filter(newProductType -> existingProductCatalog.getProductTypes().stream()
                         .noneMatch(productType ->
-                            productType.getExternalProductId().equals(newProductType.getExternalProductId())))
-                    .collect(Collectors.toList());
+                            productType.getExternalProductId().equals(newProductType.getExternalProductId()))).toList();
             }
 
-            // Ensure products kinds are created first
             List<ProductType> finalNewProductTypes = newProductTypes;
             return getProductKindFlux().collectList().flatMap(productKinds -> createProductTypes(finalNewProductTypes, productKinds).collectList().flatMap(productTypes -> {
                 productCatalog.setProductTypes(productTypes);
@@ -170,7 +159,7 @@ public class ReactiveProductCatalogService {
 
                 arrangementProductItemBase.setExternalProductKindId(productKind.getExternalKindId());
                 arrangementProductItemBase.setProductKindName(productKind.getKindName());
-                arrangementProductItemBase.setTypeName(productType.getTypeName());
+                arrangementProductItemBase.setProductTypeName(productType.getTypeName());
                 arrangementProductItemBase.setExternalTypeId(productType.getExternalTypeId());
 
                 return arrangementProductItemBase;

--- a/stream-product-catalog/product-catalog-http/pom.xml
+++ b/stream-product-catalog/product-catalog-http/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.backbase.stream</groupId>
         <artifactId>stream-http-starter-parent</artifactId>
-        <version>6.4.1</version>
+        <version>6.5.0</version>
         <relativePath>../../stream-sdk/stream-starter-parents/stream-http-starter-parent</relativePath>
     </parent>
 

--- a/stream-product-catalog/product-catalog-task/pom.xml
+++ b/stream-product-catalog/product-catalog-task/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.backbase.stream</groupId>
         <artifactId>stream-task-starter-parent</artifactId>
-        <version>6.4.1</version>
+        <version>6.5.0</version>
         <relativePath>../../stream-sdk/stream-starter-parents/stream-task-starter-parent</relativePath>
     </parent>
 

--- a/stream-product-catalog/product-catalog-task/src/test/resources/mappings/arrangement-manager-stubs.json
+++ b/stream-product-catalog/product-catalog-task/src/test/resources/mappings/arrangement-manager-stubs.json
@@ -8,7 +8,7 @@
         "method": "POST",
         "bodyPatterns": [
           {
-            "equalToJson": "{\"externalId\":null,\"externalTypeId\":null,\"typeName\":\"Savings Accounts\",\"externalProductId\":\"savings-account\",\"externalProductKindId\":\"kind2\",\"productKindName\":\"Savings Account\",\"externalProductTypeId\":null,\"productTypeName\":\"savings-account\",\"productKind\":null,\"translations\":[],\"additions\":{}}",
+            "equalToJson": "{\"externalId\":null,\"externalTypeId\":null,\"typeName\":\"Savings Accounts\",\"externalProductId\":\"savings-account\",\"externalProductKindId\":\"kind2\",\"productKindName\":\"Savings Account\",\"externalProductTypeId\":null,\"productTypeName\":\"Savings Accounts\",\"productKind\":null,\"translations\":[],\"additions\":{}}",
             "ignoreArrayOrder": true,
             "ignoreExtraElements": true
           }
@@ -43,7 +43,7 @@
         "method": "POST",
         "bodyPatterns": [
           {
-            "equalToJson": "{\"externalId\":null,\"externalTypeId\":null,\"typeName\":\"Current Account\",\"externalProductId\":\"current-account\",\"externalProductKindId\":\"kind1\",\"productKindName\":\"Current Account\",\"externalProductTypeId\":null,\"productTypeName\":\"current-account\",\"productKind\":null,\"translations\":[],\"additions\":{}}",
+            "equalToJson": "{\"externalId\":null,\"externalTypeId\":null,\"typeName\":\"Current Account\",\"externalProductId\":\"current-account\",\"externalProductKindId\":\"kind1\",\"productKindName\":\"Current Account\",\"externalProductTypeId\":null,\"productTypeName\":\"Current Account\",\"productKind\":null,\"translations\":[],\"additions\":{}}",
             "ignoreArrayOrder": true,
             "ignoreExtraElements": true
           }

--- a/stream-product/pom.xml
+++ b/stream-product/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.backbase.stream</groupId>
         <artifactId>stream-services</artifactId>
-        <version>6.4.1</version>
+        <version>6.5.0</version>
     </parent>
 
     <artifactId>stream-product</artifactId>

--- a/stream-product/product-core/pom.xml
+++ b/stream-product/product-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.backbase.stream</groupId>
         <artifactId>stream-product</artifactId>
-        <version>6.4.1</version>
+        <version>6.5.0</version>
     </parent>
 
     <artifactId>product-core</artifactId>

--- a/stream-product/product-core/src/main/java/com/backbase/stream/product/service/ArrangementService.java
+++ b/stream-product/product-core/src/main/java/com/backbase/stream/product/service/ArrangementService.java
@@ -61,12 +61,12 @@ public class ArrangementService {
 
     }
 
-    public Mono<ArrangementPutItem> updateArrangement(ArrangementPutItem arrangementPutItem) {
+    public Mono<ArrangementPutItem> updateArrangement(String arrangementId, ArrangementPutItem arrangementPutItem) {
         log.info("Updating Arrangement: {}", arrangementPutItem.getExternalArrangementId());
         if(arrangementPutItem.getDebitCards() == null) {
             arrangementPutItem.setDebitCards(emptyList());
         }
-        return arrangementsApi.putArrangementById(arrangementPutItem.getExternalArrangementId(), arrangementPutItem)
+        return arrangementsApi.putArrangementById(arrangementId, arrangementPutItem)
             .doOnEach(aVoid -> log.info("Updated Arrangement: {}", arrangementPutItem.getExternalArrangementId()))
             .thenReturn(fromCallable(() -> arrangementPutItem))
             .thenReturn(arrangementPutItem)

--- a/stream-product/product-core/src/test/java/com/backbase/stream/product/service/ArrangementServiceTest.java
+++ b/stream-product/product-core/src/test/java/com/backbase/stream/product/service/ArrangementServiceTest.java
@@ -27,6 +27,7 @@ import com.backbase.stream.product.exception.ArrangementUpdateException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
+import java.util.UUID;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -122,35 +123,37 @@ class ArrangementServiceTest {
 
     @Test
     void updateArrangement() {
+        String arrangementId = UUID.randomUUID().toString();
         ArrangementPutItem request = buildArrangementPutItem();
 
-        when(arrangementsApi.putArrangementById(request.getExternalArrangementId(), request)).thenReturn(Mono.empty());
+        when(arrangementsApi.putArrangementById(arrangementId, request)).thenReturn(Mono.empty());
 
-        StepVerifier.create(arrangementService.updateArrangement(request))
+        StepVerifier.create(arrangementService.updateArrangement(arrangementId, request))
             .assertNext(response -> {
                 Assertions.assertNotNull(response);
                 Assertions.assertEquals(request.getExternalArrangementId(), response.getExternalArrangementId());
                 Assertions.assertEquals(request.getProductId(), response.getProductId());
             }).verifyComplete();
 
-        verify(arrangementsApi).putArrangementById(request.getExternalArrangementId(), request);
+        verify(arrangementsApi).putArrangementById(arrangementId, request);
     }
 
     @Test
     void updateArrangement_Failure() {
+        String arrangementId = UUID.randomUUID().toString();
         ArrangementPutItem request = buildArrangementPutItem();
 
         WebClientResponseException webClientResponseException = buildWebClientResponseException(HttpStatus.BAD_REQUEST, "Bad Request for update arrangement");
-        when(arrangementsApi.putArrangementById(request.getExternalArrangementId(), request)).thenReturn(Mono.error(webClientResponseException));
+        when(arrangementsApi.putArrangementById(arrangementId, request)).thenReturn(Mono.error(webClientResponseException));
 
-        StepVerifier.create(arrangementService.updateArrangement(request))
+        StepVerifier.create(arrangementService.updateArrangement(arrangementId, request))
             .consumeErrorWith(e -> {
                 Assertions.assertInstanceOf(ArrangementUpdateException.class, e);
                 Assertions.assertEquals("Failed to update Arrangement: %s".formatted(request.getExternalArrangementId()), e.getMessage());
                 Assertions.assertEquals(webClientResponseException.getMessage(), e.getCause().getMessage());
             }).verify();
 
-        verify(arrangementsApi).putArrangementById(request.getExternalArrangementId(), request);
+        verify(arrangementsApi).putArrangementById(arrangementId, request);
     }
 
     @Test

--- a/stream-product/product-ingestion-saga/pom.xml
+++ b/stream-product/product-ingestion-saga/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.backbase.stream</groupId>
         <artifactId>stream-product</artifactId>
-        <version>6.4.1</version>
+        <version>6.5.0</version>
     </parent>
 
     <artifactId>product-ingestion-saga</artifactId>

--- a/stream-product/product-ingestion-saga/src/main/java/com/backbase/stream/product/ProductIngestionSaga.java
+++ b/stream-product/product-ingestion-saga/src/main/java/com/backbase/stream/product/ProductIngestionSaga.java
@@ -297,8 +297,8 @@ public class ProductIngestionSaga {
                 String internalIds = String.join(",", internalIdList);
                 log.info("Arrangement already exists: {}", internalIdList);
                 streamTask.info(ARRANGEMENT, UPSERT_ARRANGEMENT, EXISTS, postArrangement.getId(), internalIds, "Arrangement %s already exists", postArrangement.getId());
-                ArrangementPutItem arrangemenItemBase = productMapper.toArrangementItemPut(postArrangement);
-                return arrangementService.updateArrangement(arrangemenItemBase)
+                ArrangementPutItem arrangementItemBase = productMapper.toArrangementItemPut(postArrangement);
+                return arrangementService.updateArrangement(postArrangement.getId(), arrangementItemBase)
                     .onErrorResume(ArrangementUpdateException.class, e -> {
                         streamTask.error(ARRANGEMENT, UPDATE_ARRANGEMENT, FAILED, postArrangement.getId(), internalIds, e, e.getHttpResponse(), "Failed to update arrangement: %s", postArrangement.getId());
                         return Mono.error(new StreamTaskException(streamTask, e.getCause(),

--- a/stream-sdk/pom.xml
+++ b/stream-sdk/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.backbase.stream</groupId>
     <artifactId>stream-sdk</artifactId>
-    <version>6.4.1</version>
+    <version>6.5.0</version>
     <packaging>pom</packaging>
 
     <name>Stream :: SDK</name>

--- a/stream-sdk/stream-parent/pom.xml
+++ b/stream-sdk/stream-parent/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>com.backbase.stream</groupId>
     <artifactId>stream-parent</artifactId>
-    <version>6.4.1</version>
+    <version>6.5.0</version>
     <packaging>pom</packaging>
     <name>Stream :: SDK :: Parent</name>
     <description>Parent for all Stream SDK modules</description>

--- a/stream-sdk/stream-parent/stream-context-propagation/pom.xml
+++ b/stream-sdk/stream-parent/stream-context-propagation/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.backbase.stream</groupId>
         <artifactId>stream-parent</artifactId>
-        <version>6.4.1</version>
+        <version>6.5.0</version>
     </parent>
 
     <artifactId>stream-context-propagation</artifactId>

--- a/stream-sdk/stream-parent/stream-dbs-web-client/pom.xml
+++ b/stream-sdk/stream-parent/stream-dbs-web-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.backbase.stream</groupId>
         <artifactId>stream-parent</artifactId>
-        <version>6.4.1</version>
+        <version>6.5.0</version>
     </parent>
 
     <artifactId>stream-dbs-web-client</artifactId>

--- a/stream-sdk/stream-parent/stream-openapi-support/pom.xml
+++ b/stream-sdk/stream-parent/stream-openapi-support/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.backbase.stream</groupId>
         <artifactId>stream-parent</artifactId>
-        <version>6.4.1</version>
+        <version>6.5.0</version>
     </parent>
 
     <artifactId>stream-openapi-support</artifactId>

--- a/stream-sdk/stream-parent/stream-test-support/pom.xml
+++ b/stream-sdk/stream-parent/stream-test-support/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.backbase.stream</groupId>
         <artifactId>stream-parent</artifactId>
-        <version>6.4.1</version>
+        <version>6.5.0</version>
     </parent>
 
     <artifactId>stream-test-support</artifactId>

--- a/stream-sdk/stream-parent/stream-worker/pom.xml
+++ b/stream-sdk/stream-parent/stream-worker/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.backbase.stream</groupId>
         <artifactId>stream-parent</artifactId>
-        <version>6.4.1</version>
+        <version>6.5.0</version>
     </parent>
 
     <artifactId>stream-worker</artifactId>

--- a/stream-sdk/stream-starter-parents/pom.xml
+++ b/stream-sdk/stream-starter-parents/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.backbase.stream</groupId>
         <artifactId>stream-parent</artifactId>
-        <version>6.4.1</version>
+        <version>6.5.0</version>
         <relativePath>../stream-parent</relativePath>
     </parent>
 

--- a/stream-sdk/stream-starter-parents/stream-http-starter-parent/pom.xml
+++ b/stream-sdk/stream-starter-parents/stream-http-starter-parent/pom.xml
@@ -6,13 +6,13 @@
     <parent>
         <groupId>com.backbase.stream</groupId>
         <artifactId>stream-starter</artifactId>
-        <version>6.4.1</version>
+        <version>6.5.0</version>
         <relativePath>../../stream-starter</relativePath>
     </parent>
 
     <groupId>com.backbase.stream</groupId>
     <artifactId>stream-http-starter-parent</artifactId>
-    <version>6.4.1</version>
+    <version>6.5.0</version>
     <packaging>pom</packaging>
     <name>Stream :: SDK :: HTTP Services Starter</name>
     <description>Parent for Stream HTTP Services</description>

--- a/stream-sdk/stream-starter-parents/stream-task-starter-parent/pom.xml
+++ b/stream-sdk/stream-starter-parents/stream-task-starter-parent/pom.xml
@@ -5,13 +5,13 @@
     <parent>
         <groupId>com.backbase.stream</groupId>
         <artifactId>stream-starter</artifactId>
-        <version>6.4.1</version>
+        <version>6.5.0</version>
         <relativePath>../../stream-starter</relativePath>
     </parent>
 
     <groupId>com.backbase.stream</groupId>
     <artifactId>stream-task-starter-parent</artifactId>
-    <version>6.4.1</version>
+    <version>6.5.0</version>
     <packaging>pom</packaging>
     <name>Stream :: SDK :: Task Starter</name>
     <description>Parent for Stream Executable Tasks</description>

--- a/stream-sdk/stream-starter/pom.xml
+++ b/stream-sdk/stream-starter/pom.xml
@@ -10,7 +10,7 @@
     <groupId>com.backbase.stream</groupId>
     <artifactId>stream-starter</artifactId>
     <name>Stream :: SDK :: stream-starter</name>
-    <version>6.4.1</version>
+    <version>6.5.0</version>
     <packaging>pom</packaging>
 
     <organization>

--- a/stream-transactions/pom.xml
+++ b/stream-transactions/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.backbase.stream</groupId>
         <artifactId>stream-services</artifactId>
-        <version>6.4.1</version>
+        <version>6.5.0</version>
     </parent>
 
     <artifactId>stream-transactions</artifactId>

--- a/stream-transactions/transactions-core/pom.xml
+++ b/stream-transactions/transactions-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.backbase.stream</groupId>
         <artifactId>stream-transactions</artifactId>
-        <version>6.4.1</version>
+        <version>6.5.0</version>
     </parent>
 
     <artifactId>transactions-core</artifactId>

--- a/stream-transactions/transactions-item-writer/pom.xml
+++ b/stream-transactions/transactions-item-writer/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.backbase.stream</groupId>
         <artifactId>stream-parent</artifactId>
-        <version>6.4.1</version>
+        <version>6.5.0</version>
         <relativePath>../../stream-sdk/stream-parent</relativePath>
     </parent>
 


### PR DESCRIPTION
## Description

Fix - Modified invocation of the putArrangementById API to provide the internal ID of the arrangement instead of the external ID

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
  
  Add N/A to the task if they are not relevant to the current PR(validation will be skipped). 
  e.g. [ ] My changes are adequately tested ~ N/A
-->

 - [x] I made sure, I read [CONTRIBUTING.md](CONTRIBUTING.md) to put right branch prefix as per my need.
 - [x] I made sure to update [CHANGELOG.md](CHANGELOG.md).
 - [x] I made sure to update [Stream Wiki](https://github.com/Backbase/stream-services/wiki)(only valid in case of new stream module or architecture changes).
 - [x] My changes are adequately tested.
 - [x] I made sure all the SonarCloud Quality Gate are passed.
