### PR TITLE
Fix - Modified invocation of the putArrangementById API to provide the internal ID of the arrangement instead of the external ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [6.6.0](https://github.com/Backbase/stream-services/compare/6.5.0...6.6.0)
+### Fixed
+- Fixed invocation of [putArrangementById](https://backbase.io/developers/apis/specs/arrangement-manager/arrangement-service-api/3.0.5/operations/Arrangements/putArrangementById/) in `ArrangementService` to pass in the arrangement's internalId.
+  The arrangement's externalId was erroneously being provided to this method.
+- 
 ## [6.5.0](https://github.com/Backbase/stream-services/compare/6.4.0...6.5.0)
 ### Fixed
 - Fixed productTypeName mapping when ingesting Product data into arrangement-manager

--- a/stream-compositions/services/product-composition-service/src/main/java/com/backbase/stream/compositions/product/core/service/impl/ArrangementIngestionServiceImpl.java
+++ b/stream-compositions/services/product-composition-service/src/main/java/com/backbase/stream/compositions/product/core/service/impl/ArrangementIngestionServiceImpl.java
@@ -81,7 +81,7 @@ public class ArrangementIngestionServiceImpl implements ArrangementIngestionServ
     }
 
     private Mono<ArrangementIngestResponse> sendToDbs(ArrangementIngestResponse res) {
-        return arrangementService.updateArrangement(res.getArrangement())
+        return arrangementService.updateArrangement(res.getArrangementInternalId(), res.getArrangement())
                 .map(item -> ArrangementIngestResponse.builder()
                         .arrangement(res.getArrangement())
                         .arrangementInternalId(res.getArrangementInternalId())

--- a/stream-compositions/services/product-composition-service/src/test/java/com/backbase/stream/compositions/product/http/ProductControllerIT.java
+++ b/stream-compositions/services/product-composition-service/src/test/java/com/backbase/stream/compositions/product/http/ProductControllerIT.java
@@ -217,7 +217,7 @@ class ProductControllerIT extends IntegrationTest {
 
     @Test
     void pullIngestArrangement_Success() throws Exception {
-        when(arrangementService.updateArrangement(any()))
+        when(arrangementService.updateArrangement(any(), any()))
                 .thenReturn(Mono.just(new ArrangementPutItem()));
 
         ArrangementPullIngestionRequest pullIngestionRequest =
@@ -237,7 +237,7 @@ class ProductControllerIT extends IntegrationTest {
 
     @Test
     void pullIngestArrangement_Fail() throws Exception {
-        when(arrangementService.updateArrangement(any()))
+        when(arrangementService.updateArrangement(any(), any()))
                 .thenThrow(new RuntimeException());
 
         ArrangementPullIngestionRequest pullIngestionRequest =
@@ -263,7 +263,7 @@ class ProductControllerIT extends IntegrationTest {
         com.backbase.stream.compositions.product.api.model.AccountArrangementItemPut arrangementItemPut =
                 mapper.treeToValue(node, com.backbase.stream.compositions.product.api.model.AccountArrangementItemPut.class);
 
-        when(arrangementService.updateArrangement(any()))
+        when(arrangementService.updateArrangement(any(), any()))
                 .thenReturn(Mono.just(new ArrangementPutItem()));
 
         ArrangementPushIngestionRequest pushIngestionRequest =

--- a/stream-product/product-core/src/main/java/com/backbase/stream/product/service/ArrangementService.java
+++ b/stream-product/product-core/src/main/java/com/backbase/stream/product/service/ArrangementService.java
@@ -61,12 +61,12 @@ public class ArrangementService {
 
     }
 
-    public Mono<ArrangementPutItem> updateArrangement(ArrangementPutItem arrangementPutItem) {
+    public Mono<ArrangementPutItem> updateArrangement(String arrangementId, ArrangementPutItem arrangementPutItem) {
         log.info("Updating Arrangement: {}", arrangementPutItem.getExternalArrangementId());
         if(arrangementPutItem.getDebitCards() == null) {
             arrangementPutItem.setDebitCards(emptyList());
         }
-        return arrangementsApi.putArrangementById(arrangementPutItem.getExternalArrangementId(), arrangementPutItem)
+        return arrangementsApi.putArrangementById(arrangementId, arrangementPutItem)
             .doOnEach(aVoid -> log.info("Updated Arrangement: {}", arrangementPutItem.getExternalArrangementId()))
             .thenReturn(fromCallable(() -> arrangementPutItem))
             .thenReturn(arrangementPutItem)

--- a/stream-product/product-core/src/test/java/com/backbase/stream/product/service/ArrangementServiceTest.java
+++ b/stream-product/product-core/src/test/java/com/backbase/stream/product/service/ArrangementServiceTest.java
@@ -27,6 +27,7 @@ import com.backbase.stream.product.exception.ArrangementUpdateException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
+import java.util.UUID;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -122,35 +123,37 @@ class ArrangementServiceTest {
 
     @Test
     void updateArrangement() {
+        String arrangementId = UUID.randomUUID().toString();
         ArrangementPutItem request = buildArrangementPutItem();
 
-        when(arrangementsApi.putArrangementById(request.getExternalArrangementId(), request)).thenReturn(Mono.empty());
+        when(arrangementsApi.putArrangementById(arrangementId, request)).thenReturn(Mono.empty());
 
-        StepVerifier.create(arrangementService.updateArrangement(request))
+        StepVerifier.create(arrangementService.updateArrangement(arrangementId, request))
             .assertNext(response -> {
                 Assertions.assertNotNull(response);
                 Assertions.assertEquals(request.getExternalArrangementId(), response.getExternalArrangementId());
                 Assertions.assertEquals(request.getProductId(), response.getProductId());
             }).verifyComplete();
 
-        verify(arrangementsApi).putArrangementById(request.getExternalArrangementId(), request);
+        verify(arrangementsApi).putArrangementById(arrangementId, request);
     }
 
     @Test
     void updateArrangement_Failure() {
+        String arrangementId = UUID.randomUUID().toString();
         ArrangementPutItem request = buildArrangementPutItem();
 
         WebClientResponseException webClientResponseException = buildWebClientResponseException(HttpStatus.BAD_REQUEST, "Bad Request for update arrangement");
-        when(arrangementsApi.putArrangementById(request.getExternalArrangementId(), request)).thenReturn(Mono.error(webClientResponseException));
+        when(arrangementsApi.putArrangementById(arrangementId, request)).thenReturn(Mono.error(webClientResponseException));
 
-        StepVerifier.create(arrangementService.updateArrangement(request))
+        StepVerifier.create(arrangementService.updateArrangement(arrangementId, request))
             .consumeErrorWith(e -> {
                 Assertions.assertInstanceOf(ArrangementUpdateException.class, e);
                 Assertions.assertEquals("Failed to update Arrangement: %s".formatted(request.getExternalArrangementId()), e.getMessage());
                 Assertions.assertEquals(webClientResponseException.getMessage(), e.getCause().getMessage());
             }).verify();
 
-        verify(arrangementsApi).putArrangementById(request.getExternalArrangementId(), request);
+        verify(arrangementsApi).putArrangementById(arrangementId, request);
     }
 
     @Test


### PR DESCRIPTION
## Description

Fix - Modified invocation of the putArrangementById API to provide the internal ID of the arrangement instead of the external ID

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
  
  Add N/A to the task if they are not relevant to the current PR(validation will be skipped). 
  e.g. [ ] My changes are adequately tested ~ N/A
-->

 - [x] I made sure, I read [CONTRIBUTING.md](CONTRIBUTING.md) to put right branch prefix as per my need.
 - [x] I made sure to update [CHANGELOG.md](CHANGELOG.md).
 - [x] I made sure to update [Stream Wiki](https://github.com/Backbase/stream-services/wiki)(only valid in case of new stream module or architecture changes).
 - [x] My changes are adequately tested.
 - [x] I made sure all the SonarCloud Quality Gate are passed.
