### PR TITLE
Performance Improvement to use getUserById when internalId is available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [6.10.0](https://github.com/Backbase/stream-services/compare/6.9.0...6.10.0)
+### Fixed
+- Performance improvement on retrieving the user information by calling getUserById (8 ms) Vs getUserByExternalId (50 ms)
+- Update ArrangementUpdateException Logger to handle PII data
+
 ## [6.9.0](https://github.com/Backbase/stream-services/compare/6.8.0...6.9.0)
 ### Changed
 - fix the logic of setting the job role type for ingestion - see Maint 32629 for more details

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,14 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
-## [6.10.0](https://github.com/Backbase/stream-services/compare/6.9.0...6.10.0)
+## [6.11.0](https://github.com/Backbase/stream-services/compare/6.10.0...6.11.0)
 ### Fixed
 - Performance improvement on retrieving the user information by calling getUserById (8 ms) Vs getUserByExternalId (50 ms)
 - Update ArrangementUpdateException Logger to handle PII data
+
+## [6.10.0](https://github.com/Backbase/stream-services/compare/6.9.0...6.10.0)
+### Fixed
+- LegalEntitySaga: Fix periodic limits bounds setQuarterly
 
 ## [6.9.0](https://github.com/Backbase/stream-services/compare/6.8.0...6.9.0)
 ### Changed

--- a/stream-access-control/access-control-core/src/test/java/com/backbase/stream/service/UserServiceTest.java
+++ b/stream-access-control/access-control-core/src/test/java/com/backbase/stream/service/UserServiceTest.java
@@ -589,4 +589,32 @@ class UserServiceTest {
             .expectError(WebClientResponseException.class)
             .verify();
     }
+
+    @Test
+    void getUserByInternalId() {
+        final String userInternalId = UUID.randomUUID().toString();
+        final String externalId = "someExternalId";
+        final String fullName = "someName";
+        GetUser getUser = new GetUser().externalId(externalId)
+            .fullName(fullName).id(userInternalId);
+
+        when(usersApi.getUserById(userInternalId, true)).thenReturn(Mono.just(getUser));
+
+        Mono<User> userById = subject.getUserById(userInternalId);
+        StepVerifier.create(userById)
+            .assertNext(Assertions::assertNotNull)
+            .verifyComplete();
+
+    }
+
+    @Test
+    void getUserByInternalIdNotFound() {
+        final String userInternalId = UUID.randomUUID().toString();
+        when(usersApi.getUserById(userInternalId, true)).thenReturn(Mono.error(WebClientResponseException.NotFound.create(404, "not found", new HttpHeaders(), new byte[0], null)));
+
+        Mono<User> userById = subject.getUserById(userInternalId);
+        StepVerifier.create(userById)
+            .expectNextCount(0)
+            .verifyComplete();
+    }
 }

--- a/stream-legal-entity/legal-entity-http/src/test/java/com/backbase/stream/it/LegalEntitySagaIT.java
+++ b/stream-legal-entity/legal-entity-http/src/test/java/com/backbase/stream/it/LegalEntitySagaIT.java
@@ -73,6 +73,7 @@ class LegalEntitySagaIT {
                                 new JobProfileUser()
                                     .user(
                                         new User()
+                                            .internalId("9ac44fca")
                                             .externalId("john.doe")
                                             .fullName("John Doe")
                                             .identityLinkStrategy(IdentityUserLinkStrategy.IDENTITY_AGNOSTIC)
@@ -94,6 +95,7 @@ class LegalEntitySagaIT {
                                 new JobProfileUser()
                                     .user(
                                         new User()
+                                            .internalId("9ac44fca")
                                             .externalId("john.doe")
                                             .fullName("John Doe")
                                             .identityLinkStrategy(IdentityUserLinkStrategy.IDENTITY_AGNOSTIC)
@@ -114,6 +116,7 @@ class LegalEntitySagaIT {
                         new JobProfileUser()
                             .user(
                                 new User()
+                                    .internalId("9ac44fca")
                                     .externalId("john.doe")
                                     .fullName("John Doe")
                                     .identityLinkStrategy(IdentityUserLinkStrategy.CREATE_IN_IDENTITY)
@@ -316,6 +319,13 @@ class LegalEntitySagaIT {
                         .willReturn(WireMock.aResponse().withStatus(HttpStatus.CREATED.value())
                                 .withHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE)
                                 .withBody(""))
+        );
+
+        stubFor(
+            WireMock.get("/user-manager/service-api/v2/users/9ac44fca?skipHierarchyCheck=true")
+                .willReturn(WireMock.aResponse()
+                    .withHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                    .withBody("{\"id\":\"9ac44fca\",\"externalId\":\"john.doe\",\"legalEntityId\":\"500000\",\"fullName\":\"John Doe\"}"))
         );
     }
 

--- a/stream-product/product-core/src/main/java/com/backbase/stream/product/service/ArrangementService.java
+++ b/stream-product/product-core/src/main/java/com/backbase/stream/product/service/ArrangementService.java
@@ -24,6 +24,7 @@ import com.backbase.stream.product.exception.ArrangementUpdateException;
 import com.backbase.stream.product.mapping.ProductMapper;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
 import org.mapstruct.factory.Mappers;
@@ -86,7 +87,14 @@ public class ArrangementService {
                 }
                 sink.next(r);
             }).onErrorResume(WebClientResponseException.class, throwable ->
-                error(new ArrangementUpdateException(throwable, "Batch arrangement update failed: " + arrangementItems)));
+                Mono.error(new ArrangementUpdateException(throwable,
+                    "Batch arrangement update failed for arrangements : "
+                        + arrangementItems.stream()
+                        .map(arrangementItem -> {
+                            String uniqueIdentifier = Objects.nonNull(arrangementItem.getBBAN())? arrangementItem.getBBAN(): arrangementItem.getId();
+                            return arrangementItem.getName() + " | "
+                                + uniqueIdentifier.substring(uniqueIdentifier.length() - 4);
+                        }).toList())));
     }
 
     /**

--- a/stream-product/product-ingestion-saga/pom.xml
+++ b/stream-product/product-ingestion-saga/pom.xml
@@ -44,6 +44,12 @@
         </dependency>
 
         <dependency>
+            <groupId>io.projectreactor</groupId>
+            <artifactId>reactor-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>com.backbase.buildingblocks</groupId>
             <artifactId>service-sdk-starter-test</artifactId>
             <scope>test</scope>

--- a/stream-product/product-ingestion-saga/src/main/java/com/backbase/stream/product/ProductIngestionSaga.java
+++ b/stream-product/product-ingestion-saga/src/main/java/com/backbase/stream/product/ProductIngestionSaga.java
@@ -214,7 +214,7 @@ public class ProductIngestionSaga {
     private Mono<User> upsertUser(StreamTask streamTask, JobProfileUser jobProfileUser) {
         User user = jobProfileUser.getUser();
         LegalEntityReference legalEntityReference = jobProfileUser.getLegalEntityReference();
-        Mono<User> getExistingUser = userService.getUserByExternalId(user.getExternalId())
+        Mono<User> getExistingUser = Objects.nonNull(user.getInternalId())? userService.getUserById(user.getInternalId()): userService.getUserByExternalId(user.getExternalId())
             .doOnNext(existingUser -> streamTask.info(USER, EXISTS, user.getExternalId(), user.getInternalId(), "User %s already exists", existingUser.getExternalId()));
         Mono<User> createNewUser = userService.createUser(user, legalEntityReference.getExternalId(), streamTask)
             .doOnNext(existingUser -> streamTask.info(USER, CREATED, user.getExternalId(), user.getInternalId(), "User %s created", existingUser.getExternalId()));
@@ -225,7 +225,7 @@ public class ProductIngestionSaga {
     private Mono<User> upsertIdentityUser(StreamTask streamTask, JobProfileUser jobProfileUser) {
         User user = jobProfileUser.getUser();
         LegalEntityReference legalEntityReference = jobProfileUser.getLegalEntityReference();
-        Mono<User> getExistingIdentityUser = userService.getUserByExternalId(user.getExternalId())
+        Mono<User> getExistingIdentityUser = Objects.nonNull(user.getInternalId())? userService.getUserById(user.getInternalId()): userService.getUserByExternalId(user.getExternalId())
             .doOnNext(existingUser -> streamTask.info(IDENTITY_USER, EXISTS, user.getExternalId(), user.getInternalId(), "User %s already exists", existingUser.getExternalId()));
         Mono<User> createNewIdentityUser = userService.createOrImportIdentityUser(user, legalEntityReference.getInternalId(), streamTask)
             .doOnNext(existingUser -> streamTask.info(IDENTITY_USER, CREATED, user.getExternalId(), user.getInternalId(), "User %s created", existingUser.getExternalId()));

--- a/stream-product/product-ingestion-saga/src/test/java/com/backbase/stream/product/BatchProductIngestionSagaTest.java
+++ b/stream-product/product-ingestion-saga/src/test/java/com/backbase/stream/product/BatchProductIngestionSagaTest.java
@@ -1,0 +1,169 @@
+package com.backbase.stream.product;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.when;
+
+import com.backbase.dbs.arrangement.api.integration.v2.model.BatchResponseItemExtended;
+import com.backbase.dbs.arrangement.api.integration.v2.model.BatchResponseStatusCode;
+import com.backbase.loan.inbound.api.service.v1.LoansApi;
+import com.backbase.stream.legalentity.model.BaseProductGroup;
+import com.backbase.stream.legalentity.model.BatchProductGroup;
+import com.backbase.stream.legalentity.model.IdentityUserLinkStrategy;
+import com.backbase.stream.legalentity.model.ProductGroup;
+import com.backbase.stream.legalentity.model.User;
+import com.backbase.stream.loan.LoansSaga;
+import com.backbase.stream.loan.LoansTask;
+import com.backbase.stream.product.configuration.ProductIngestionSagaConfigurationProperties;
+import com.backbase.stream.product.service.ArrangementService;
+import com.backbase.stream.product.task.BatchProductGroupTask;
+import com.backbase.stream.service.AccessGroupService;
+import com.backbase.stream.service.UserService;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+@ExtendWith(MockitoExtension.class)
+class BatchProductIngestionSagaTest {
+
+  @InjectMocks
+  BatchProductIngestionSaga batchProductIngestionSaga;
+  @Mock
+  ArrangementService arrangementService;
+  @Mock
+  AccessGroupService accessGroupService;
+  @Mock
+  UserService userService;
+  @Mock
+  ProductIngestionSagaConfigurationProperties configurationProperties;
+  @Mock
+  LoansSaga loansSaga;
+  @Mock
+  LoansApi loansApi;
+
+  BatchProductGroupTask batchProductGroupTask;
+
+  @BeforeEach
+  void setUp() {
+    batchProductGroupTask = mockBatchProductGroupTask();
+    BatchResponseItemExtended batchResponseItemExtended = new BatchResponseItemExtended();
+    batchResponseItemExtended.setResourceId("resource_id");
+    batchResponseItemExtended.setStatus(BatchResponseStatusCode.HTTP_STATUS_OK);
+    when(arrangementService.upsertBatchArrangements(anyList()))
+        .thenReturn(Flux.just(batchResponseItemExtended
+            .arrangementId("arr_id")));
+    when(accessGroupService.getExistingDataGroups(
+        batchProductGroupTask.getData().getServiceAgreement()
+            .getInternalId(), null))
+        .thenReturn(Flux.just(MockUtil.buildDataGroupItem()));
+    when(accessGroupService.createArrangementDataAccessGroup(any(), any(), any()))
+        .thenReturn(Mono.just(new BaseProductGroup()));
+    when(accessGroupService.updateExistingDataGroupsBatch(batchProductGroupTask,
+        List.of(MockUtil.buildDataGroupItem()),
+        batchProductGroupTask.getData().getProductGroups()))
+        .thenReturn(Mono.just(batchProductGroupTask));
+    when(accessGroupService.getFunctionGroupsForServiceAgreement("sa_internalId"))
+        .thenReturn(Mono.just(List.of(MockUtil.buildFunctionGroupItem())));
+    when(accessGroupService.setupFunctionGroups(batchProductGroupTask,
+        batchProductGroupTask.getData().getServiceAgreement(),
+        MockUtil.buildBusinessFunctionGroupList()))
+        .thenReturn(Mono.just(MockUtil.buildBusinessFunctionGroupList()));
+    when(accessGroupService.assignPermissionsBatch(any(), any())).thenReturn(
+        Mono.just(batchProductGroupTask));
+    LoansTask loansTask = new LoansTask(
+        String.format(batchProductGroupTask.getData().getServiceAgreement().getExternalId(),
+            batchProductGroupTask.getId()), List.of(MockUtil.buildLoanAccount()));
+    when(loansSaga.executeTask(loansTask)).thenReturn(Mono.just(loansTask));
+  }
+
+  @Test
+  void test_processProductBatchUsers_withUserInternalId() {
+    when(userService.getUserById("someRegularUserInId")).thenReturn(
+        Mono.just(MockUtil.buildUser()));
+    when(userService.createUser(any(), any(), any()))
+        .thenReturn(Mono.just(MockUtil.buildUser()));
+    StepVerifier.create(batchProductIngestionSaga.process(batchProductGroupTask))
+        .expectNext(batchProductGroupTask)
+        .expectComplete()
+        .verify();
+  }
+
+  @Test
+  void test_processProductBatchUsers_withUserExternalId() {
+    batchProductGroupTask.getBatchProductGroup().getProductGroups().get(0).getUsers().get(0)
+        .getUser().setInternalId(null);
+    when(userService.getUserByExternalId("someRegularUserExId")).thenReturn(
+        Mono.just(MockUtil.buildUser()));
+    when(userService.createUser(any(), any(), any()))
+        .thenReturn(Mono.just(MockUtil.buildUser()));
+    StepVerifier.create(batchProductIngestionSaga.process(batchProductGroupTask))
+        .expectNext(batchProductGroupTask)
+        .expectComplete()
+        .verify();
+  }
+
+  @Test
+  void test_processProductBatchExistingIdentityUser_withUserInternalId() {
+    when(configurationProperties.isIdentityEnabled()).thenReturn(true);
+    User user = MockUtil.buildUser();
+    batchProductGroupTask.getBatchProductGroup().getProductGroups().get(0).getUsers()
+        .get(0).getUser().setIdentityLinkStrategy(IdentityUserLinkStrategy.CREATE_IN_IDENTITY);
+    batchProductGroupTask.getBatchProductGroup().getProductGroups().get(0).getUsers()
+        .get(0).getUser().setInternalId("someRegularUserInId");
+    when(userService.getUserById("someRegularUserInId")).thenReturn(
+        Mono.just(user));
+    when(userService.createOrImportIdentityUser(any(), any(), any()))
+        .thenReturn(Mono.empty());
+    StepVerifier.create(batchProductIngestionSaga.process(batchProductGroupTask))
+        .expectNext(batchProductGroupTask)
+        .expectComplete()
+        .verify();
+  }
+
+  @Test
+  void test_processProductBatchNewIdentityUser_withUserInternalId() {
+    when(configurationProperties.isIdentityEnabled()).thenReturn(true);
+    User user = MockUtil.buildUser();
+    batchProductGroupTask.getBatchProductGroup().getProductGroups().get(0).getUsers()
+        .get(0).getUser().setIdentityLinkStrategy(IdentityUserLinkStrategy.CREATE_IN_IDENTITY);
+    batchProductGroupTask.getBatchProductGroup().getProductGroups().get(0).getUsers()
+        .get(0).getUser().setInternalId("someRegularUserInId");
+    when(userService.getUserById("someRegularUserInId")).thenReturn(
+        Mono.just(user));
+    when(userService.createOrImportIdentityUser(any(), any(), any()))
+        .thenReturn(Mono.just(user));
+    StepVerifier.create(batchProductIngestionSaga.process(batchProductGroupTask))
+        .expectNext(batchProductGroupTask)
+        .expectComplete()
+        .verify();
+  }
+
+  @Test
+  void test_processProductBatchIdentityUsers_withUserExternalId() {
+    batchProductGroupTask.getBatchProductGroup().getProductGroups().get(0).getUsers().get(0)
+        .getUser().setInternalId(null);
+    when(userService.getUserByExternalId("someRegularUserExId")).thenReturn(
+        Mono.just(MockUtil.buildUser()));
+    when(userService.createUser(any(), any(), any()))
+        .thenReturn(Mono.just(MockUtil.buildUser()));
+    StepVerifier.create(batchProductIngestionSaga.process(batchProductGroupTask))
+        .expectNext(batchProductGroupTask)
+        .expectComplete()
+        .verify();
+  }
+
+  BatchProductGroupTask mockBatchProductGroupTask() {
+    ProductGroup productGroup = MockUtil.createProductGroup();
+    return new BatchProductGroupTask()
+        .data(new BatchProductGroup().productGroups(List.of(productGroup))
+            .serviceAgreement(productGroup.getServiceAgreement()));
+
+  }
+}

--- a/stream-product/product-ingestion-saga/src/test/java/com/backbase/stream/product/MockUtil.java
+++ b/stream-product/product-ingestion-saga/src/test/java/com/backbase/stream/product/MockUtil.java
@@ -1,0 +1,137 @@
+package com.backbase.stream.product;
+
+import com.backbase.dbs.accesscontrol.api.service.v3.model.DataGroupItem;
+import com.backbase.dbs.accesscontrol.api.service.v3.model.FunctionGroupItem;
+import com.backbase.stream.legalentity.model.AvailableBalance;
+import com.backbase.stream.legalentity.model.BaseProductGroup;
+import com.backbase.stream.legalentity.model.BookedBalance;
+import com.backbase.stream.legalentity.model.BusinessFunctionGroup;
+import com.backbase.stream.legalentity.model.BusinessFunctionGroup.TypeEnum;
+import com.backbase.stream.legalentity.model.CreditCard;
+import com.backbase.stream.legalentity.model.CurrentAccount;
+import com.backbase.stream.legalentity.model.JobProfileUser;
+import com.backbase.stream.legalentity.model.LegalEntityReference;
+import com.backbase.stream.legalentity.model.Loan;
+import com.backbase.stream.legalentity.model.ProductGroup;
+import com.backbase.stream.legalentity.model.SavingsAccount;
+import com.backbase.stream.legalentity.model.ServiceAgreement;
+import com.backbase.stream.legalentity.model.TermDeposit;
+import com.backbase.stream.legalentity.model.TermUnit;
+import com.backbase.stream.legalentity.model.User;
+import java.math.BigDecimal;
+import java.util.Collections;
+import java.util.List;
+import org.jetbrains.annotations.NotNull;
+
+public class MockUtil {
+
+
+  @NotNull
+  public static TermDeposit buildTermDeposit() {
+    TermDeposit termDeposit = new TermDeposit()
+        .termNumber(BigDecimal.valueOf(21212))
+        .termUnit(TermUnit.DAILY)
+        .BBAN("777151235")
+        .accountHolderName("John Doe")
+        .bookedBalance(new BookedBalance().amount(BigDecimal.valueOf(50)));
+    termDeposit.externalId("termExtId").productTypeExternalId("Term Deposit").currency("GBP")
+        .legalEntities(List.of(new LegalEntityReference().externalId("termInternalId")));
+    return termDeposit;
+  }
+
+  @NotNull
+  public static CreditCard buildCreditCard() {
+    CreditCard creditCard = new CreditCard()
+        .availableBalance(new AvailableBalance().amount(BigDecimal.valueOf(100)))
+        .BBAN("777151236")
+        .accountHolderName("John Doe")
+        .bookedBalance(new BookedBalance().amount(BigDecimal.valueOf(50)));
+    creditCard.externalId("ccExtId").productTypeExternalId("Credit Card").currency("GBP")
+        .legalEntities(List.of(new LegalEntityReference().externalId("ccInternalId")));
+    return creditCard;
+  }
+
+  @NotNull
+  public static SavingsAccount buildSavingsAccount() {
+    SavingsAccount savingsAccount = new SavingsAccount();
+    savingsAccount.externalId("someAccountExId").productTypeExternalId("Account").currency("GBP")
+        .legalEntities(List.of(new LegalEntityReference().externalId("savInternalId")));
+    return savingsAccount;
+  }
+
+  @NotNull
+  public static CurrentAccount buildCurrentAccount() {
+    CurrentAccount currentAccount = new CurrentAccount()
+        .availableBalance(new AvailableBalance().amount(BigDecimal.valueOf(100)))
+        .BBAN("777151234")
+        .accountHolderName("John Doe")
+        .bookedBalance(new BookedBalance().amount(BigDecimal.valueOf(50)));
+    currentAccount.externalId("currentAccountExtId").productTypeExternalId("Current Account")
+        .currency("GBP")
+        .legalEntities(List.of(new LegalEntityReference().externalId("currInternalId")));
+    return currentAccount;
+  }
+
+  @NotNull
+  public static Loan buildLoanAccount() {
+    Loan loan = new Loan().availableBalance(new AvailableBalance().amount(BigDecimal.valueOf(100)))
+        .BBAN("777151238")
+        .accountHolderName("John Doe")
+        .bookedBalance(new BookedBalance().amount(BigDecimal.valueOf(50)));
+    loan.externalId("loanAccountExtId").productTypeExternalId("Loan").currency("GBP")
+        .legalEntities(List.of(new LegalEntityReference().externalId("loanInternalId")));
+    return loan;
+  }
+
+  public static JobProfileUser buildJobProfile() {
+    return new JobProfileUser().user(
+            new User().internalId("someRegularUserInId")
+                .externalId("someRegularUserExId"))
+        .legalEntityReference(new LegalEntityReference().externalId("someLeExternalId"))
+        .referenceJobRoleNames(List.of("someJR"));
+  }
+
+  public static DataGroupItem buildDataGroupItem() {
+    return new DataGroupItem().id("someDgItemExId1In").name("somePgName");
+  }
+
+  public static FunctionGroupItem buildFunctionGroupItem() {
+    return new FunctionGroupItem().id("some-fg1").name("someJR").type(
+        FunctionGroupItem.TypeEnum.DEFAULT);
+  }
+
+  public static List<BusinessFunctionGroup> buildBusinessFunctionGroupList() {
+    return List.of(
+        new BusinessFunctionGroup().name("someJR").id("some-fg1").type(TypeEnum.DEFAULT));
+  }
+
+  public static User buildUser() {
+    return new User().internalId("someRegularUserInId")
+        .externalId("someRegularUserExId");
+  }
+
+  public static ProductGroup createProductGroup() {
+
+    SavingsAccount savingsAccount = buildSavingsAccount();
+    CurrentAccount currentAccount = buildCurrentAccount();
+    Loan loan = buildLoanAccount();
+    TermDeposit termDeposit = buildTermDeposit();
+    CreditCard creditCard = buildCreditCard();
+
+    ProductGroup productGroup = new ProductGroup();
+    productGroup.setServiceAgreement(
+        new ServiceAgreement().internalId("sa_internalId").externalId("externalId"));
+
+    productGroup.productGroupType(BaseProductGroup.ProductGroupTypeEnum.ARRANGEMENTS)
+        .name("somePgName")
+        .description("somePgDescription")
+        .savingAccounts(Collections.singletonList(savingsAccount))
+        .currentAccounts(Collections.singletonList(currentAccount))
+        .loans(Collections.singletonList(loan))
+        .termDeposits(Collections.singletonList(termDeposit))
+        .creditCards(Collections.singletonList(creditCard))
+        .users(List.of(buildJobProfile()));
+
+    return productGroup;
+  }
+}

--- a/stream-product/product-ingestion-saga/src/test/java/com/backbase/stream/product/ProductIngestionSagaTest.java
+++ b/stream-product/product-ingestion-saga/src/test/java/com/backbase/stream/product/ProductIngestionSagaTest.java
@@ -1,0 +1,99 @@
+package com.backbase.stream.product;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+import com.backbase.dbs.arrangement.api.service.v3.model.ArrangementItem;
+import com.backbase.dbs.arrangement.api.service.v3.model.ArrangementPutItem;
+import com.backbase.loan.inbound.api.service.v1.LoansApi;
+import com.backbase.stream.legalentity.model.ProductGroup;
+import com.backbase.stream.loan.LoansSaga;
+import com.backbase.stream.product.configuration.ProductIngestionSagaConfigurationProperties;
+import com.backbase.stream.product.service.ArrangementService;
+import com.backbase.stream.product.task.ProductGroupTask;
+import com.backbase.stream.service.AccessGroupService;
+import com.backbase.stream.service.UserService;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+@ExtendWith(MockitoExtension.class)
+class ProductIngestionSagaTest {
+
+  @InjectMocks
+  ProductIngestionSaga productIngestionSaga;
+  @Mock
+  ArrangementService arrangementService;
+  @Mock
+  AccessGroupService accessGroupService;
+  @Mock
+  UserService userService;
+  @Mock
+  ProductIngestionSagaConfigurationProperties configurationProperties;
+  @Mock
+  LoansSaga loansSaga;
+  @Mock
+  LoansApi loansApi;
+
+  ProductGroupTask productGroupTask;
+
+  @BeforeEach
+  void setUp() {
+    productGroupTask = mockProductGroupTask();
+    when(arrangementService.getArrangementInternalId(anyString()))
+        .thenReturn(Mono.just("internal_id"));
+    when(arrangementService.createArrangement(any()))
+        .thenReturn(Mono.just(new ArrangementItem()));
+    when(arrangementService.updateArrangement(anyString(), any()))
+        .thenReturn(Mono.just(new ArrangementPutItem()
+            .externalArrangementId("currentAccountExtId")));
+    when(accessGroupService.setupProductGroups(productGroupTask))
+        .thenReturn(Mono.just(productGroupTask));
+    when(accessGroupService.getFunctionGroupsForServiceAgreement("sa_internalId"))
+        .thenReturn(Mono.just(List.of(MockUtil.buildFunctionGroupItem())));
+    when(accessGroupService.setupFunctionGroups(productGroupTask,
+        productGroupTask.getData().getServiceAgreement(),
+        MockUtil.buildBusinessFunctionGroupList()))
+        .thenReturn(Mono.just(MockUtil.buildBusinessFunctionGroupList()));
+    when(accessGroupService.assignPermissions(any(), any())).thenReturn(
+        Mono.just(MockUtil.buildJobProfile()));
+  }
+
+  @Test
+  void test_processProductsUsers_withUserInternalId() {
+    when(userService.getUserById("someRegularUserInId")).thenReturn(
+        Mono.just(MockUtil.buildUser()));
+    when(userService.createUser(any(), any(), any()))
+        .thenReturn(Mono.just(MockUtil.buildUser()));
+    StepVerifier.create(productIngestionSaga.process(productGroupTask))
+        .expectNext(productGroupTask)
+        .expectComplete()
+        .verify();
+  }
+
+  @Test
+  void test_processProductsUsers_withUserExternalId() {
+    productGroupTask.getProductGroup().getUsers().get(0).getUser().setInternalId(null);
+    when(userService.getUserByExternalId("someRegularUserExId")).thenReturn(
+        Mono.just(MockUtil.buildUser()));
+    when(userService.createUser(any(), any(), any()))
+        .thenReturn(Mono.just(MockUtil.buildUser()));
+    StepVerifier.create(productIngestionSaga.process(productGroupTask))
+        .expectNext(productGroupTask)
+        .expectComplete()
+        .verify();
+  }
+
+  ProductGroupTask mockProductGroupTask() {
+    ProductGroup productGroup = MockUtil.createProductGroup();
+    return new ProductGroupTask()
+        .data(productGroup);
+  }
+}


### PR DESCRIPTION
## Description
Updating Performance fixes to Master, that were implemented on support/4.1.x branch 
- Perfomance fix during upsertUser processing. If the internalId is available, call getUserById (8 ms response time) instead of getUserByExternalId (~ 50 ms response time).
- Update ArrangementUpdateException Logger to handle PII data

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
  
  Add N/A to the task if they are not relevant to the current PR(validation will be skipped). 
  e.g. [x] My changes are adequately tested ~ N/A
-->

 - [N/A] I made sure, I read [CONTRIBUTING.md](CONTRIBUTING.md) to put right branch prefix as per my need.
 - [x] I made sure to update [CHANGELOG.md](CHANGELOG.md).
 - [N/A] I made sure to update [Stream Wiki](https://github.com/Backbase/stream-services/wiki)(only valid in case of new stream module or architecture changes).
 - [x] My changes are adequately tested.
 - [x] I made sure all the SonarCloud Quality Gate are passed.
