### PR TITLE
APEX-1122: Adds LoB header to user kind segmentation saga in stream a…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [6.12.0](https://github.com/Backbase/stream-services/compare/6.11.0...6.12.0)
+### Fixed
+- Adds LoB header to user kind segmentation saga in stream audiences
+
 ## [6.11.0](https://github.com/Backbase/stream-services/compare/6.10.0...6.11.0)
 ### Fixed
 - Performance improvement on retrieving the user information by calling getUserById (8 ms) Vs getUserByExternalId (50 ms)

--- a/stream-audiences/audiences-core/src/main/java/com/backbase/stream/audiences/UserKindSegmentationSaga.java
+++ b/stream-audiences/audiences-core/src/main/java/com/backbase/stream/audiences/UserKindSegmentationSaga.java
@@ -3,10 +3,12 @@ package com.backbase.stream.audiences;
 import com.backbase.audiences.collector.api.service.ApiClient;
 import com.backbase.audiences.collector.api.service.v1.HandlersServiceApi;
 import com.backbase.audiences.collector.api.service.v1.model.CustomerOnboardedRequest;
+import com.backbase.audiences.collector.api.service.v1.model.CustomerOnboardedRequest.UserKindEnum;
 import com.backbase.buildingblocks.common.HttpCommunicationConstants;
 import com.backbase.stream.configuration.UserKindSegmentationProperties;
 import com.backbase.stream.worker.StreamTaskExecutor;
 import com.backbase.stream.worker.exception.StreamTaskException;
+import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import reactor.core.publisher.Mono;
 
@@ -35,8 +37,7 @@ public class UserKindSegmentationSaga implements StreamTaskExecutor<UserKindSegm
     public Mono<UserKindSegmentationTask> executeTask(UserKindSegmentationTask streamTask) {
         var request = streamTask.getCustomerOnboardedRequest();
 
-        ApiClient apiClient = handlersServiceApi.getApiClient();
-        addLobHeader(apiClient, request);
+        addLobHeader(handlersServiceApi.getApiClient(), request);
         return handlersServiceApi.customerOnboarded(request)
             .then(Mono.fromCallable(() -> {
                 streamTask.info(ENTITY, INGEST, SUCCESS, null, request.getInternalUserId(), INGESTED_SUCCESSFULLY);
@@ -49,12 +50,17 @@ public class UserKindSegmentationSaga implements StreamTaskExecutor<UserKindSegm
     }
 
     private static void addLobHeader(ApiClient apiClient, CustomerOnboardedRequest request) {
-        if (apiClient != null) {
-        if (request.getUserKind().getValue().equals("RetailCustomer")) {
-            apiClient.addDefaultHeader(HttpCommunicationConstants.LINE_OF_BUSINESS, "RETAIL");
-        } else if (request.getUserKind().getValue().equals("SME")) {
-            apiClient.addDefaultHeader(HttpCommunicationConstants.LINE_OF_BUSINESS, "BUSINESS");
+        if (apiClient == null) {
+            return;
         }
+        if (request.getUserKind() == UserKindEnum.RETAILCUSTOMER) {
+            log.debug("adding header for retail customer");
+            apiClient.addDefaultHeader(HttpCommunicationConstants.LINE_OF_BUSINESS, LineOfBusiness.RETAIL.getValue());
+        } else if (request.getUserKind() == UserKindEnum.SME) {
+            log.debug("adding header for business customer");
+            apiClient.addDefaultHeader(HttpCommunicationConstants.LINE_OF_BUSINESS, LineOfBusiness.BUSINESS.getValue());
+        } else {
+            log.debug("user kind {} is ignored", request.getUserKind());
         }
     }
 
@@ -79,4 +85,15 @@ public class UserKindSegmentationSaga implements StreamTaskExecutor<UserKindSegm
         return userKindSegmentationProperties.defaultCustomerCategory();
     }
 
+    @Getter
+    public enum LineOfBusiness {
+        RETAIL("RETAIL"),
+        BUSINESS("BUSINESS");
+
+        private final String value;
+
+        LineOfBusiness(String lineOfBusiness) {
+            this.value = lineOfBusiness;
+        }
+    }
 }

--- a/stream-audiences/audiences-core/src/main/java/com/backbase/stream/audiences/UserKindSegmentationSaga.java
+++ b/stream-audiences/audiences-core/src/main/java/com/backbase/stream/audiences/UserKindSegmentationSaga.java
@@ -1,6 +1,8 @@
 package com.backbase.stream.audiences;
 
+import com.backbase.audiences.collector.api.service.ApiClient;
 import com.backbase.audiences.collector.api.service.v1.HandlersServiceApi;
+import com.backbase.buildingblocks.common.HttpCommunicationConstants;
 import com.backbase.stream.configuration.UserKindSegmentationProperties;
 import com.backbase.stream.worker.StreamTaskExecutor;
 import com.backbase.stream.worker.exception.StreamTaskException;
@@ -32,6 +34,12 @@ public class UserKindSegmentationSaga implements StreamTaskExecutor<UserKindSegm
     public Mono<UserKindSegmentationTask> executeTask(UserKindSegmentationTask streamTask) {
         var request = streamTask.getCustomerOnboardedRequest();
 
+        ApiClient apiClient = handlersServiceApi.getApiClient();
+        if (request.getUserKind().getValue().equals("RetailCustomer")) {
+            apiClient.addDefaultHeader(HttpCommunicationConstants.LINE_OF_BUSINESS, "RETAIL");
+        } else if (request.getUserKind().getValue().equals("SME")) {
+            apiClient.addDefaultHeader(HttpCommunicationConstants.LINE_OF_BUSINESS, "BUSINESS");
+        }
         return handlersServiceApi.customerOnboarded(request)
             .then(Mono.fromCallable(() -> {
                 streamTask.info(ENTITY, INGEST, SUCCESS, null, request.getInternalUserId(), INGESTED_SUCCESSFULLY);


### PR DESCRIPTION

## Description

For 1rt env, we need to add LoB header to user kind segmentation saga. Otherwise LoB for segments would be null and they cannot be seen in engage app

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
  
  Add N/A to the task if they are not relevant to the current PR(validation will be skipped). 
  e.g. [ ] My changes are adequately tested ~ N/A
-->

 - [x] I made sure, I read [CONTRIBUTING.md](CONTRIBUTING.md) to put right branch prefix as per my need.
 - [x] I made sure to update [CHANGELOG.md](CHANGELOG.md).
 - [ ] I made sure to update [Stream Wiki](https://github.com/Backbase/stream-services/wiki)(only valid in case of new stream module or architecture changes).
 - [x] My changes are adequately tested.
 - [x] I made sure all the SonarCloud Quality Gate are passed.
