### PR TITLE
Dummy commit to trigger build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -139,5 +139,4 @@
             </plugin>
         </plugins>
     </build>
-
 </project>


### PR DESCRIPTION
Triggering build because previous commit contains `[skip bump] version bump` commit message.