### PR TITLE
Add new Data Group types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [6.18.0](https://github.com/Backbase/stream-services/compare/6.17.0...6.18.0)
+### Added
+- Extended the data group types to include; `CASE_DEFINITION`, `CASE_INSTANCE`, `PROCESS_DEFINITION`, `PROCESS_INSTANCE`, `TASK_DEFINITION`, `TASK_INSTANCE`. 
+
 ## [6.17.0](https://github.com/Backbase/stream-services/compare/6.16.0...6.17.0)
 ### Added
 - Improved logging for Job Roles ingestion

--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ You can find listed here the API specification containing the opinionated model 
 
 | Stream [version](https://github.com/Backbase/stream-services/releases) | Banking Services   | Java | Spring Boot |
 |------------------------------------------------------------------------|--------------------|------|-------------|
-| 6.2.0 to latest                                                        | 2024.10            | 21   | 3.3         |
+| 6.18.0 to latest                                                       | 2025.04            | 21   | 3.3         |
+| 6.2.0 to 6.17.0                                                        | 2024.10            | 21   | 3.3         |
 | 6.0.0 to 6.1.0                                                         | 2024.10            | 21   | 3.2         |
 | 5.10.0 to 5.16.0                                                       | 2024.09-LTS        | 21   | 3.2         |
 | 5.0.0 to 5.9.x                                                         | 2024.04            | 21   | 3.2         |

--- a/api/stream-legal-entity/openapi.yaml
+++ b/api/stream-legal-entity/openapi.yaml
@@ -254,6 +254,12 @@ components:
             - REPOSITORIES
             - CUSTOMERS
             - CUSTOM
+            - TASK_INSTANCE
+            - TASK_DEFINITION
+            - CASE_DEFINITION
+            - CASE_INSTANCE
+            - PROCESS_DEFINITION
+            - PROCESS_INSTANCE
         name:
           maxLength: 128
           minLength: 1

--- a/stream-compositions/events/events/product/base-product-group.json
+++ b/stream-compositions/events/events/product/base-product-group.json
@@ -8,7 +8,7 @@
     "productGroupType" : {
       "type" : "string",
       "default" : "ARRANGEMENTS",
-      "enum" : [ "ARRANGEMENTS", "JOURNEYS", "REPOSITORIES", "CUSTOMERS", "CUSTOM" ]
+      "enum" : [ "ARRANGEMENTS", "JOURNEYS", "REPOSITORIES", "CUSTOMERS", "CUSTOM","TASK_INSTANCE", "TASK_DEFINITION", "CASE_DEFINITION", "CASE_INSTANCE", "PROCESS_DEFINITION", "PROCESS_INSTANCE" ]
     },
     "name" : {
       "maxLength" : 128,


### PR DESCRIPTION
## Description

Adds new data group types that are supported by Access Control as of `2025.04`.

## Checklist

 - [x] I made sure, I read [CONTRIBUTING.md](CONTRIBUTING.md) to put right branch prefix as per my need.
 - [x] I made sure to update [CHANGELOG.md](CHANGELOG.md).
 - [N/A] I made sure to update [Stream Wiki](https://github.com/Backbase/stream-services/wiki)(only valid in case of new stream module or architecture changes).
 - [N/A] My changes are adequately tested.
 - [x] I made sure all the SonarCloud Quality Gate are passed.
