### PR TITLE
feature/ANDR-2851-add-endpoints-for-custom-approval-type-and-policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [7.6.0](https://github.com/Backbase/stream-services/compare/7.5.0...7.6.0)
+### Changed
+- Extended stream-approvals openapi.yaml in case of 'scope' property for the Policy and ApprovalType
+- The logic of ApprovalsIntegrationService.createApprovalType() and ApprovalsIntegrationService.createPolicy() was extended to use different endpoints in case scope property presents
+- Unit test has been updated accordingly
+
 ## [7.5.0](https://github.com/Backbase/stream-services/compare/7.4.0...7.5.0)
 ### Changed
 - Added CustomerAccessGroupSaga

--- a/api/stream-approvals/openapi.yaml
+++ b/api/stream-approvals/openapi.yaml
@@ -91,6 +91,8 @@ components:
           type: string
         rank:
           type: number
+        scope:
+          type: string
     Policy:
       type: object
       title: "Approval Policy configuration"
@@ -103,6 +105,10 @@ components:
         name:
           type: string
         description:
+          type: string
+        scope:
+          type: string
+        serviceAgreementId:
           type: string
         logicalItems:
           type: array

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>com.backbase.stream</groupId>
     <artifactId>stream-services</artifactId>
-    <version>7.3.0</version>
+    <version>7.4.0</version>
 
     <packaging>pom</packaging>
     <name>Stream :: Services</name>

--- a/stream-approvals/approvals-core/src/main/java/com/backbase/stream/mapper/ApprovalMapper.java
+++ b/stream-approvals/approvals-core/src/main/java/com/backbase/stream/mapper/ApprovalMapper.java
@@ -1,6 +1,7 @@
 package com.backbase.stream.mapper;
 
 import com.backbase.dbs.approval.api.service.v2.model.PostApprovalTypeRequest;
+import com.backbase.dbs.approval.api.service.v2.model.PostScopedApprovalTypeRequest;
 import com.backbase.dbs.approval.api.service.v2.model.PresentationPostBulkApprovalTypeAssignmentRequest;
 import com.backbase.stream.approval.model.ApprovalType;
 import com.backbase.stream.approval.model.PolicyAssignment;
@@ -11,6 +12,8 @@ import org.mapstruct.Mapping;
 public interface ApprovalMapper {
 
     PostApprovalTypeRequest mapApprovalType(ApprovalType approvalType);
+
+    PostScopedApprovalTypeRequest mapScopedApprovalType(ApprovalType approvalType);
 
     @Mapping(source = "approvalTypeAssignments", target = "approvalTypeAssignments")
     PresentationPostBulkApprovalTypeAssignmentRequest mapApprovalTypeAssignment(PolicyAssignment policyAssignment);

--- a/stream-approvals/approvals-core/src/main/java/com/backbase/stream/mapper/PolicyMapper.java
+++ b/stream-approvals/approvals-core/src/main/java/com/backbase/stream/mapper/PolicyMapper.java
@@ -1,6 +1,7 @@
 package com.backbase.stream.mapper;
 
 import com.backbase.dbs.approval.api.service.v2.model.PostPolicyRequest;
+import com.backbase.dbs.approval.api.service.v2.model.PostPolicyServiceApiRequest;
 import com.backbase.dbs.approval.api.service.v2.model.PresentationPostPolicyAssignmentBulkRequest;
 import com.backbase.stream.approval.model.Policy;
 import com.backbase.stream.approval.model.PolicyAssignment;
@@ -16,6 +17,8 @@ import org.mapstruct.MappingTarget;
 public interface PolicyMapper {
 
     PostPolicyRequest mapPolicy(Policy policy);
+
+    PostPolicyServiceApiRequest mapScopedPolicy(Policy policy);
 
     @Mapping(source = "policyAssignmentItems", target = "policyAssignments")
     PresentationPostPolicyAssignmentBulkRequest mapPolicyAssignments(PolicyAssignment policyAssignment);

--- a/stream-approvals/approvals-core/src/test/java/com/backbase/stream/ApprovalsIntegrationServiceTest.java
+++ b/stream-approvals/approvals-core/src/test/java/com/backbase/stream/ApprovalsIntegrationServiceTest.java
@@ -1,0 +1,302 @@
+package com.backbase.stream;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.backbase.dbs.approval.api.service.v2.ApprovalTypesApi;
+import com.backbase.dbs.approval.api.service.v2.PoliciesApi;
+import com.backbase.dbs.approval.api.service.v2.model.ApprovalTypeDto;
+import com.backbase.dbs.approval.api.service.v2.model.ApprovalTypeScope;
+import com.backbase.dbs.approval.api.service.v2.model.PolicyDetailsDto;
+import com.backbase.dbs.approval.api.service.v2.model.PolicyScope;
+import com.backbase.dbs.approval.api.service.v2.model.PolicyServiceApiResponseDto;
+import com.backbase.dbs.approval.api.service.v2.model.PostApprovalTypeRequest;
+import com.backbase.dbs.approval.api.service.v2.model.PostApprovalTypeResponse;
+import com.backbase.dbs.approval.api.service.v2.model.PostPolicyRequest;
+import com.backbase.dbs.approval.api.service.v2.model.PostPolicyResponse;
+import com.backbase.dbs.approval.api.service.v2.model.PostPolicyServiceApiRequest;
+import com.backbase.dbs.approval.api.service.v2.model.PostPolicyServiceApiResponse;
+import com.backbase.dbs.approval.api.service.v2.model.PostScopedApprovalTypeRequest;
+import com.backbase.stream.approval.model.ApprovalType;
+import com.backbase.stream.approval.model.Policy;
+import com.backbase.stream.exceptions.ApprovalTypeException;
+import com.backbase.stream.exceptions.PolicyException;
+import com.backbase.stream.service.ApprovalsIntegrationService;
+import java.math.BigDecimal;
+import java.util.UUID;
+import org.apache.commons.lang3.ObjectUtils;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+@ExtendWith(MockitoExtension.class)
+class ApprovalsIntegrationServiceTest {
+
+    @Mock
+    private PoliciesApi policiesApi;
+
+    @Mock
+    private ApprovalTypesApi approvalTypesApi;
+
+    @InjectMocks
+    private ApprovalsIntegrationService approvalsIntegrationService;
+
+    private static final String TEST_APPROVAL_TYPE_NAME = "TestApprovalType";
+    private static final String TEST_POLICY_NAME = "High-Value Payment Policy";
+    private static final String INTERNAL_SERVER_ERROR = "Internal Server Error";
+    private static final String INTERNAL_SERVER_ERROR_500 = "500 Internal Server Error";
+    private static final String BAD_REQUEST = "Bad Request";
+    private static final String BAD_REQUEST_400 = "400 Bad Request";
+
+    @Test
+    void shouldCreateApprovalType() {
+        final ApprovalType inputApprovalType = new ApprovalType()
+            .name(TEST_APPROVAL_TYPE_NAME)
+            .rank(new BigDecimal(1));
+
+        final PostApprovalTypeRequest mappedApprovalTypeItem = new PostApprovalTypeRequest()
+            .name(TEST_APPROVAL_TYPE_NAME)
+            .rank(1);
+
+        final PostApprovalTypeResponse apiResponse = new PostApprovalTypeResponse()
+            .approvalType(new ApprovalTypeDto().name(TEST_APPROVAL_TYPE_NAME));
+
+        when(approvalTypesApi.postApprovalType(mappedApprovalTypeItem)).thenReturn(Mono.just(apiResponse));
+
+        final Mono<ApprovalType> resultMono = approvalsIntegrationService.createApprovalType(inputApprovalType);
+
+        StepVerifier.create(resultMono)
+            .expectNextMatches(createdApprovalType -> {
+                assertThat(createdApprovalType.getName()).isEqualTo(TEST_APPROVAL_TYPE_NAME);
+                assertThat(ObjectUtils.isEmpty(createdApprovalType.getScope())).isTrue();
+                return true;
+            })
+            .verifyComplete();
+
+        verify(approvalTypesApi, times(1)).postApprovalType(mappedApprovalTypeItem);
+        verify(approvalTypesApi, never()).postScopedApprovalType(any());
+    }
+
+    @Test
+    void shouldCreateScopedApprovalType() {
+        final ApprovalType inputApprovalType = new ApprovalType()
+            .name(TEST_APPROVAL_TYPE_NAME)
+            .rank(new BigDecimal(2))
+            .scope(ApprovalTypeScope.LOCAL.getValue());
+
+        final PostScopedApprovalTypeRequest mappedApprovalTypeItem = new PostScopedApprovalTypeRequest()
+            .name(TEST_APPROVAL_TYPE_NAME)
+            .scope(ApprovalTypeScope.LOCAL)
+            .rank(2);
+
+        final PostApprovalTypeResponse apiResponse = new PostApprovalTypeResponse()
+            .approvalType(new ApprovalTypeDto().name(TEST_APPROVAL_TYPE_NAME).scope(ApprovalTypeScope.LOCAL));
+
+        when(approvalTypesApi.postScopedApprovalType(mappedApprovalTypeItem)).thenReturn(Mono.just(apiResponse));
+
+        final Mono<ApprovalType> resultMono = approvalsIntegrationService.createApprovalType(inputApprovalType);
+
+        StepVerifier.create(resultMono)
+            .expectNextMatches(createdApprovalType -> {
+                assertThat(createdApprovalType.getName()).isEqualTo(TEST_APPROVAL_TYPE_NAME);
+                assertThat(createdApprovalType.getScope()).isEqualTo(ApprovalTypeScope.LOCAL.getValue());
+                return true;
+            })
+            .verifyComplete();
+
+        verify(approvalTypesApi, times(1)).postScopedApprovalType(mappedApprovalTypeItem);
+        verify(approvalTypesApi, never()).postApprovalType(any());
+    }
+
+    @Test
+    void shouldNotCreateApprovalTypeAndThrowBadRequest() {
+        final ApprovalType inputApprovalType = new ApprovalType()
+            .name(TEST_APPROVAL_TYPE_NAME);
+
+        final PostApprovalTypeRequest mappedApprovalTypeItem = new PostApprovalTypeRequest()
+            .name(TEST_APPROVAL_TYPE_NAME);
+
+        final WebClientResponseException webClientException = new WebClientResponseException(
+            HttpStatus.BAD_REQUEST.value(),
+            BAD_REQUEST,
+            null, null, null);
+
+        when(approvalTypesApi.postApprovalType(mappedApprovalTypeItem)).thenReturn(Mono.error(webClientException));
+
+        final Mono<ApprovalType> resultMono = approvalsIntegrationService.createApprovalType(inputApprovalType);
+
+        StepVerifier.create(resultMono)
+            .expectErrorMatches(throwable ->
+                throwable instanceof ApprovalTypeException &&
+                    throwable.getMessage().contains(BAD_REQUEST_400) &&
+                    throwable.getCause() instanceof WebClientResponseException &&
+                    ((WebClientResponseException) throwable.getCause()).getStatusCode() == HttpStatus.BAD_REQUEST)
+            .verify();
+
+        verify(approvalTypesApi, times(1)).postApprovalType(mappedApprovalTypeItem);
+        verify(approvalTypesApi, never()).postScopedApprovalType(any());
+    }
+
+    @Test
+    void shouldNotCreateScopedApprovalTypeAndThrowInternalServerError() {
+        final ApprovalType inputApprovalType = new ApprovalType()
+            .name(TEST_APPROVAL_TYPE_NAME)
+            .scope(ApprovalTypeScope.LOCAL.getValue());
+
+        final PostScopedApprovalTypeRequest mappedApprovalTypeItem = new
+            PostScopedApprovalTypeRequest().name(TEST_APPROVAL_TYPE_NAME).scope(ApprovalTypeScope.LOCAL);
+
+        final WebClientResponseException webClientException = new WebClientResponseException(
+            HttpStatus.INTERNAL_SERVER_ERROR.value(),
+            INTERNAL_SERVER_ERROR,
+            null, null, null);
+
+        when(approvalTypesApi.postScopedApprovalType(mappedApprovalTypeItem)).thenReturn(
+            Mono.error(webClientException));
+
+        final Mono<ApprovalType> resultMono = approvalsIntegrationService.createApprovalType(inputApprovalType);
+
+        StepVerifier.create(resultMono)
+            .expectErrorMatches(throwable ->
+                throwable instanceof ApprovalTypeException &&
+                    throwable.getMessage().contains(INTERNAL_SERVER_ERROR_500) &&
+                    throwable.getCause() instanceof WebClientResponseException &&
+                    ((WebClientResponseException) throwable.getCause()).getStatusCode()
+                        == HttpStatus.INTERNAL_SERVER_ERROR)
+            .verify();
+
+        verify(approvalTypesApi, times(1)).postScopedApprovalType(mappedApprovalTypeItem);
+        verify(approvalTypesApi, never()).postApprovalType(any());
+    }
+
+    @Test
+    void shouldCreatePolicy() {
+        final Policy inputPolicy = new Policy()
+            .name(TEST_POLICY_NAME);
+
+        final PostPolicyRequest expectedMappedRequest = new PostPolicyRequest().name(TEST_POLICY_NAME);
+
+        final PostPolicyResponse apiResponse = new PostPolicyResponse()
+            .policy(new PolicyDetailsDto().name(TEST_POLICY_NAME));
+
+        when(policiesApi.postPolicy(expectedMappedRequest)).thenReturn(Mono.just(apiResponse));
+
+        final Mono<Policy> resultMono = approvalsIntegrationService.createPolicy(inputPolicy);
+
+        StepVerifier.create(resultMono)
+            .expectNextMatches(createdPolicy -> {
+                assertThat(createdPolicy.getName()).isEqualTo(TEST_POLICY_NAME);
+                assertThat(ObjectUtils.isEmpty(createdPolicy.getScope())).isTrue();
+                return true;
+            })
+            .verifyComplete();
+
+        verify(policiesApi, times(1)).postPolicy(expectedMappedRequest);
+        verify(policiesApi, never()).postScopedPolicy(any());
+    }
+
+    @Test
+    void shouldCreateScopedPolicy() {
+        final String serviceAgreementId = UUID.randomUUID().toString();
+
+        final Policy inputPolicy = new Policy()
+            .name(TEST_POLICY_NAME)
+            .scope(ApprovalTypeScope.LOCAL.getValue())
+            .serviceAgreementId(serviceAgreementId);
+
+        final PostPolicyServiceApiRequest expectedMappedRequest = new PostPolicyServiceApiRequest()
+            .name(TEST_POLICY_NAME)
+            .scope(PolicyScope.LOCAL)
+            .serviceAgreementId(serviceAgreementId);
+
+        final PostPolicyServiceApiResponse apiResponse = new PostPolicyServiceApiResponse()
+            .policy(new PolicyServiceApiResponseDto().name(TEST_POLICY_NAME).scope(PolicyScope.LOCAL));
+
+        when(policiesApi.postScopedPolicy(expectedMappedRequest)).thenReturn(Mono.just(apiResponse));
+
+        final Mono<Policy> resultMono = approvalsIntegrationService.createPolicy(inputPolicy);
+
+        StepVerifier.create(resultMono)
+            .expectNextMatches(createdPolicy -> {
+                assertThat(createdPolicy.getName()).isEqualTo(TEST_POLICY_NAME);
+                assertThat(createdPolicy.getScope()).isEqualTo(ApprovalTypeScope.LOCAL.getValue());
+                return true;
+            })
+            .verifyComplete();
+
+        verify(policiesApi, times(1)).postScopedPolicy(expectedMappedRequest);
+        verify(policiesApi, never()).postPolicy(any());
+    }
+
+    @Test
+    void shouldNotCreatePolicyAndThrowBadRequest() {
+        final Policy inputPolicy = new Policy().name(TEST_POLICY_NAME);
+        final PostPolicyRequest expectedMappedRequest = new PostPolicyRequest().name(TEST_POLICY_NAME);
+
+        final WebClientResponseException webClientException = new WebClientResponseException(
+            HttpStatus.BAD_REQUEST.value(),
+            BAD_REQUEST,
+            null, null, null);
+
+        when(policiesApi.postPolicy(expectedMappedRequest)).thenReturn(Mono.error(webClientException));
+
+        final Mono<Policy> resultMono = approvalsIntegrationService.createPolicy(inputPolicy);
+
+        StepVerifier.create(resultMono)
+            .expectErrorMatches(throwable ->
+                throwable instanceof PolicyException &&
+                    throwable.getMessage().contains(BAD_REQUEST_400) &&
+                    throwable.getCause() instanceof WebClientResponseException &&
+                    ((WebClientResponseException) throwable.getCause()).getStatusCode() == HttpStatus.BAD_REQUEST)
+            .verify();
+
+        verify(policiesApi, times(1)).postPolicy(expectedMappedRequest);
+        verify(policiesApi, never()).postScopedPolicy(any());
+    }
+
+    @Test
+    void shouldNotCreateScopedPolicyAndThrowInternalServerError() {
+        final String serviceAgreementId = UUID.randomUUID().toString();
+
+        final Policy inputPolicy = new Policy()
+            .name(TEST_POLICY_NAME)
+            .scope(ApprovalTypeScope.LOCAL.getValue())
+            .serviceAgreementId(serviceAgreementId);
+
+        final PostPolicyServiceApiRequest expectedMappedRequest = new PostPolicyServiceApiRequest()
+            .name(TEST_POLICY_NAME)
+            .scope(PolicyScope.LOCAL)
+            .serviceAgreementId(serviceAgreementId);
+
+        final WebClientResponseException webClientException = new WebClientResponseException(
+            HttpStatus.INTERNAL_SERVER_ERROR.value(),
+            INTERNAL_SERVER_ERROR,
+            null, null, null);
+
+        when(policiesApi.postScopedPolicy(expectedMappedRequest)).thenReturn(Mono.error(webClientException));
+
+        final Mono<Policy> resultMono = approvalsIntegrationService.createPolicy(inputPolicy);
+
+        StepVerifier.create(resultMono)
+            .expectErrorMatches(throwable ->
+                throwable instanceof PolicyException &&
+                    throwable.getMessage().contains(INTERNAL_SERVER_ERROR_500) &&
+                    throwable.getCause() instanceof WebClientResponseException &&
+                    ((WebClientResponseException) throwable.getCause()).getStatusCode()
+                        == HttpStatus.INTERNAL_SERVER_ERROR)
+            .verify();
+
+        verify(policiesApi, times(1)).postScopedPolicy(expectedMappedRequest);
+        verify(policiesApi, never()).postPolicy(any());
+    }
+}


### PR DESCRIPTION
## Description

Extended stream-approvals openapi.yaml in case of 'scope' property for the Policy and ApprovalType.
The logic of ApprovalsIntegrationService.createApprovalType() and ApprovalsIntegrationService.createPolicy() was extended to use different endpoints in case scope property presents.
Unit test has been updated accordingly.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
  
  Add N/A to the task if they are not relevant to the current PR(validation will be skipped). 
  e.g. [ ] My changes are adequately tested ~ N/A
-->

 - [x] I made sure, I read [CONTRIBUTING.md](CONTRIBUTING.md) to put right branch prefix as per my need.
 - [x] I made sure to update [CHANGELOG.md](CHANGELOG.md).
 - [n/a ] I made sure to update [Stream Wiki](https://github.com/Backbase/stream-services/wiki)(only valid in case of new stream module or architecture changes).
 - [x] My changes are adequately tested.
 - [x] I made sure all the SonarCloud Quality Gate are passed.
