### PR TITLE
Implementing openapi-plugin to generate URI Masking template on Access Control Service API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [3.72.7](https://github.com/Backbase/stream-services/compare/3.72.6...3.72.7)
+### Changed
+- Replaced `BOAT` with `openapi-generator-maven-plugin` when generating webclient for access control to fix URI Template Masking.
+
 ## [3.72.6](https://github.com/Backbase/stream-services/compare/3.72.5...3.72.6)
 ### Updated
 - Replaced `openapi-generator-maven-plugin` with `BOAT` when generating webclient for product integration ap

--- a/stream-access-control/access-control-core/src/test/java/com/backbase/stream/mapper/AccessGroupMapperTest.java
+++ b/stream-access-control/access-control-core/src/test/java/com/backbase/stream/mapper/AccessGroupMapperTest.java
@@ -14,6 +14,7 @@ import com.backbase.stream.legalentity.model.LegalEntityParticipant;
 import com.backbase.stream.legalentity.model.LegalEntityStatus;
 import com.backbase.stream.legalentity.model.ServiceAgreement;
 import java.time.LocalDate;
+import java.util.Collections;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -46,7 +47,9 @@ class AccessGroupMapperTest {
             .validFromTime(validFromTime)
             .validUntilDate(LocalDate.parse(validUntilDate))
             .validUntilTime(validUntilTime)
-            .regularUserAps(new ApsIdentifiers().addNameIdentifiersItem(userExId));
+            .regularUserAps(new ApsIdentifiers()
+                .addNameIdentifiersItem(userExId)
+                .idIdentifiers(Collections.emptyList()));
 
 
         ServicesAgreementIngest actual = subject.toPresentation(input);
@@ -104,7 +107,8 @@ class AccessGroupMapperTest {
             .validFromDate(LocalDate.parse(validFromDate))
             .validFromTime(validFromTime)
             .validUntilDate(LocalDate.parse(validUntilDate))
-            .validUntilTime(validUntilTime);
+            .validUntilTime(validUntilTime)
+            .additions(Collections.emptyMap());
 
         assertEquals(expected, actual);
     }
@@ -142,7 +146,8 @@ class AccessGroupMapperTest {
             .validFromTime(validFromTime)
             .validUntilDate(validUntilDate)
             .validUntilTime(validUntilTime)
-            .status(Status.ENABLED);
+            .status(Status.ENABLED)
+            .additions(Collections.emptyMap());
 
         assertEquals(expected, actual);
     }

--- a/stream-access-control/access-control-core/src/test/java/com/backbase/stream/service/AccessGroupServiceTest.java
+++ b/stream-access-control/access-control-core/src/test/java/com/backbase/stream/service/AccessGroupServiceTest.java
@@ -127,8 +127,8 @@ class AccessGroupServiceTest {
         ServiceAgreement expected = new ServiceAgreement().externalId(externalId).additions(Collections.emptyMap());
 
         StepVerifier.create(result)
-            .assertNext(serviceAgreement -> assertEquals(serviceAgreement,expected))
-            .verifyComplete();
+                .assertNext(serviceAgreement -> assertEquals(serviceAgreement,expected))
+                .verifyComplete();
 
     }
 
@@ -160,7 +160,7 @@ class AccessGroupServiceTest {
         final String validUntilTime = "23:59:59";
         final List<ServiceAgreementUserAction> regularUsers = asList("userId1", "userId2").stream()
             .map(u -> new ServiceAgreementUserAction().userProfile(new JobProfileUser().user(new User()
-                    .externalId("ex_" + u).internalId("in_" + u)))
+                .externalId("ex_" + u).internalId("in_" + u)))
                 .action(ServiceAgreementUserAction.ActionEnum.ADD))
             .collect(Collectors.toList());
 
@@ -218,12 +218,12 @@ class AccessGroupServiceTest {
         final String validUntilTime = "23:59:59";
         final List<ServiceAgreementUserAction> regularUsersToAdd = asList("userId1", "userId2").stream()
             .map(u -> new ServiceAgreementUserAction().userProfile(new JobProfileUser().user(new User()
-                    .externalId("ex_" + u).internalId("in_" + u)))
+                .externalId("ex_" + u).internalId("in_" + u)))
                 .action(ServiceAgreementUserAction.ActionEnum.ADD))
             .collect(Collectors.toList());
         final List<ServiceAgreementUserAction> regularUsersToRemove = asList("userId3", "userId4").stream()
             .map(u -> new ServiceAgreementUserAction().userProfile(new JobProfileUser().user(new User()
-                    .externalId("ex_" + u).internalId("in_" + u)))
+                .externalId("ex_" + u).internalId("in_" + u)))
                 .action(ServiceAgreementUserAction.ActionEnum.REMOVE))
             .collect(Collectors.toList());
         final List<ServiceAgreementUserAction> regularUsers =
@@ -415,8 +415,8 @@ class AccessGroupServiceTest {
             Collections.singletonList(new BaseProductGroup().internalId("data-group-0"))
         );
         baseProductGroupMap.put(
-            new BusinessFunctionGroup().id("business-function-group-id-2"),
-            Collections.singletonList(new BaseProductGroup().internalId("data-group-2"))
+             new BusinessFunctionGroup().id("business-function-group-id-2"),
+             Collections.singletonList(new BaseProductGroup().internalId("data-group-2"))
         );
 
         Map<User, Map<BusinessFunctionGroup, List<BaseProductGroup>>> usersPermissions = new HashMap<>();
@@ -441,10 +441,10 @@ class AccessGroupServiceTest {
                     new PresentationFunctionGroupDataGroup().functionGroupIdentifier(
                         new PresentationIdentifier().idIdentifier("business-function-group-id-2")
                     ).dataGroupIdentifiers(Arrays.asList(
-                            new PresentationDataGroupIdentifier().idIdentifier("data-group-2")
-                        )
-                    ))
-                ));
+                        new PresentationDataGroupIdentifier().idIdentifier("data-group-2")
+                    )
+                ))
+        ));
 
         when(functionGroupsApi.getFunctionGroups("sa-internal-id"))
             .thenReturn(Flux.just(
@@ -522,36 +522,36 @@ class AccessGroupServiceTest {
         BatchProductGroupTask batchProductGroupTask = new BatchProductGroupTask();
         batchProductGroupTask.setIngestionMode(BatchProductIngestionMode.REPLACE);
         batchProductGroupTask.setBatchProductGroup(new BatchProductGroup().productGroups(
-            List.of(new BaseProductGroup().name("Test product group"))));
+                List.of(new BaseProductGroup().name("Test product group"))));
 
         DataGroupItem dataGroupItemTemplateCustom = buildDataGroupItem("Repository Group Template Custom",
-            "Repository Group Template Custom", "template-custom");
+                "Repository Group Template Custom", "template-custom");
         DataGroupItem dataGroupItemEngagementTemplateCustom = buildDataGroupItem(
-            "Repository Group Engagement Template Custom",
-            "Repository Group Engagement Template Custom", "engagement-template-custom");
+                "Repository Group Engagement Template Custom",
+                "Repository Group Engagement Template Custom", "engagement-template-custom");
         DataGroupItem dataGroupItemEngagementTemplateNotification = buildDataGroupItem(
-            "Repository Group Engagement Template Notification",
-            "Repository Group Engagement Template Notification", "engagement-template-notification");
+                "Repository Group Engagement Template Notification",
+                "Repository Group Engagement Template Notification", "engagement-template-notification");
 
         BaseProductGroup baseProductGroupTemplateCustom = buildBaseProductGroup("Repository Group Template Custom",
-            "Repository Group Template Custom", BaseProductGroup.ProductGroupTypeEnum.REPOSITORIES,
-            "template-custom");
+                "Repository Group Template Custom", BaseProductGroup.ProductGroupTypeEnum.REPOSITORIES,
+                "template-custom");
         BaseProductGroup baseProductGroupEngagementTemplateCustom = buildBaseProductGroup("Repository Group Engagement Template Custom",
-            "Repository Group Engagement Template Custom", BaseProductGroup.ProductGroupTypeEnum.REPOSITORIES,
-            "engagement-template-custom");
+                "Repository Group Engagement Template Custom", BaseProductGroup.ProductGroupTypeEnum.REPOSITORIES,
+                "engagement-template-custom");
         BaseProductGroup baseProductGroupEngagementTemplateNotification = buildBaseProductGroup("Repository Group Engagement Template Notification",
-            "Repository Group Engagement Template Notification", BaseProductGroup.ProductGroupTypeEnum.REPOSITORIES,
-            "engagement-template-notification");
+                "Repository Group Engagement Template Notification", BaseProductGroup.ProductGroupTypeEnum.REPOSITORIES,
+                "engagement-template-notification");
 
         // When
         subject.updateExistingDataGroupsBatch(batchProductGroupTask,
-                List.of(dataGroupItemTemplateCustom,
-                    dataGroupItemEngagementTemplateCustom,
-                    dataGroupItemEngagementTemplateNotification),
-                List.of(baseProductGroupTemplateCustom,
-                    baseProductGroupEngagementTemplateCustom,
-                    baseProductGroupEngagementTemplateNotification))
-            .block();
+                        List.of(dataGroupItemTemplateCustom,
+                                dataGroupItemEngagementTemplateCustom,
+                                dataGroupItemEngagementTemplateNotification),
+                        List.of(baseProductGroupTemplateCustom,
+                                baseProductGroupEngagementTemplateCustom,
+                                baseProductGroupEngagementTemplateNotification))
+                .block();
 
         // Then
         verify(dataGroupsApi, times(0)).putDataGroupItemsUpdate(any());
@@ -563,45 +563,45 @@ class AccessGroupServiceTest {
         BatchProductGroupTask batchProductGroupTask = new BatchProductGroupTask();
         batchProductGroupTask.setIngestionMode(BatchProductIngestionMode.REPLACE);
         batchProductGroupTask.setBatchProductGroup(new BatchProductGroup().productGroups(
-            List.of(new BaseProductGroup().name("Test product group"))));
+                List.of(new BaseProductGroup().name("Test product group"))));
 
         DataGroupItem dataGroupItemTemplateCustom = buildDataGroupItem("Repository Group Template Custom",
-            "Repository Group Template Custom");
+                "Repository Group Template Custom");
         DataGroupItem dataGroupItemEngagementTemplateCustom = buildDataGroupItem("Repository Group Engagement Template Custom",
-            "Repository Group Engagement Template Custom");
+                "Repository Group Engagement Template Custom");
         DataGroupItem dataGroupItemEngagementTemplateNotification = buildDataGroupItem("Repository Group Engagement Template Notification",
-            "Repository Group Engagement Template Notification");
+                "Repository Group Engagement Template Notification");
 
         BaseProductGroup baseProductGroupTemplateCustom = buildBaseProductGroup("Repository Group Template Custom",
-            "Repository Group Template Custom", BaseProductGroup.ProductGroupTypeEnum.REPOSITORIES,
-            "template-custom");
+                "Repository Group Template Custom", BaseProductGroup.ProductGroupTypeEnum.REPOSITORIES,
+                "template-custom");
         BaseProductGroup baseProductGroupEngagementTemplateCustom = buildBaseProductGroup("Repository Group Engagement Template Custom",
-            "Repository Group Engagement Template Custom", BaseProductGroup.ProductGroupTypeEnum.REPOSITORIES,
-            "engagement-template-custom");
+                "Repository Group Engagement Template Custom", BaseProductGroup.ProductGroupTypeEnum.REPOSITORIES,
+                "engagement-template-custom");
         BaseProductGroup baseProductGroupEngagementTemplateNotification = buildBaseProductGroup("Repository Group Engagement Template Notification",
-            "Repository Group Engagement Template Notification", BaseProductGroup.ProductGroupTypeEnum.REPOSITORIES,
-            "engagement-template-notification");
+                "Repository Group Engagement Template Notification", BaseProductGroup.ProductGroupTypeEnum.REPOSITORIES,
+                "engagement-template-notification");
         when(dataGroupsApi.putDataGroupItemsUpdate(any())).thenReturn(Flux.just(new BatchResponseItemExtended()
-            .status(HTTP_STATUS_OK)
-            .resourceId("test-resource-id")));
+                .status(HTTP_STATUS_OK)
+                .resourceId("test-resource-id")));
 
         // When
         subject.updateExistingDataGroupsBatch(batchProductGroupTask,
-                List.of(dataGroupItemTemplateCustom,
-                    dataGroupItemEngagementTemplateCustom,
-                    dataGroupItemEngagementTemplateNotification),
-                List.of(baseProductGroupTemplateCustom,
-                    baseProductGroupEngagementTemplateCustom,
-                    baseProductGroupEngagementTemplateNotification))
-            .block();
+                        List.of(dataGroupItemTemplateCustom,
+                                dataGroupItemEngagementTemplateCustom,
+                                dataGroupItemEngagementTemplateNotification),
+                        List.of(baseProductGroupTemplateCustom,
+                                baseProductGroupEngagementTemplateCustom,
+                                baseProductGroupEngagementTemplateNotification))
+                .block();
 
         // Then
         verify(dataGroupsApi).putDataGroupItemsUpdate(presentationDataGroupItemPutRequestBodyCaptor.capture());
         assertEquals(3, presentationDataGroupItemPutRequestBodyCaptor.getValue().stream()
-            .map(PresentationDataGroupItemPutRequestBody::getAction)
-            .filter(ADD::equals)
-            .toList()
-            .size());
+                .map(PresentationDataGroupItemPutRequestBody::getAction)
+                .filter(ADD::equals)
+                .toList()
+                .size());
     }
 
     @Test
@@ -610,50 +610,50 @@ class AccessGroupServiceTest {
         BatchProductGroupTask batchProductGroupTask = new BatchProductGroupTask();
         batchProductGroupTask.setIngestionMode(BatchProductIngestionMode.REPLACE);
         batchProductGroupTask.setBatchProductGroup(new BatchProductGroup().productGroups(
-            List.of(new BaseProductGroup().name("Test product group"))));
+                List.of(new BaseProductGroup().name("Test product group"))));
 
         DataGroupItem dataGroupItemTemplateCustom = buildDataGroupItem("Repository Group Template Custom",
-            "Repository Group Template Custom", "template-custom-test");
+                "Repository Group Template Custom", "template-custom-test");
         DataGroupItem dataGroupItemEngagementTemplateCustom = buildDataGroupItem("Repository Group Engagement Template Custom",
-            "Repository Group Engagement Template Custom", "engagement-template-custom-test");
+                "Repository Group Engagement Template Custom", "engagement-template-custom-test");
         DataGroupItem dataGroupItemEngagementTemplateNotification = buildDataGroupItem("Repository Group Engagement Template Notification",
-            "Repository Group Engagement Template Notification", "engagement-template-notification-test");
+                "Repository Group Engagement Template Notification", "engagement-template-notification-test");
 
         BaseProductGroup baseProductGroupTemplateCustom = buildBaseProductGroup("Repository Group Template Custom",
-            "Repository Group Template Custom", BaseProductGroup.ProductGroupTypeEnum.REPOSITORIES,
-            "template-custom");
+                "Repository Group Template Custom", BaseProductGroup.ProductGroupTypeEnum.REPOSITORIES,
+                "template-custom");
         BaseProductGroup baseProductGroupEngagementTemplateCustom = buildBaseProductGroup("Repository Group Engagement Template Custom",
-            "Repository Group Engagement Template Custom", BaseProductGroup.ProductGroupTypeEnum.REPOSITORIES,
-            "engagement-template-custom");
+                "Repository Group Engagement Template Custom", BaseProductGroup.ProductGroupTypeEnum.REPOSITORIES,
+                "engagement-template-custom");
         BaseProductGroup baseProductGroupEngagementTemplateNotification = buildBaseProductGroup("Repository Group Engagement Template Notification",
-            "Repository Group Engagement Template Notification", BaseProductGroup.ProductGroupTypeEnum.REPOSITORIES,
-            "engagement-template-notification");
+                "Repository Group Engagement Template Notification", BaseProductGroup.ProductGroupTypeEnum.REPOSITORIES,
+                "engagement-template-notification");
         when(dataGroupsApi.putDataGroupItemsUpdate(any())).thenReturn(Flux.just(new BatchResponseItemExtended()
-            .status(HTTP_STATUS_OK)
-            .resourceId("test-resource-id")));
+                .status(HTTP_STATUS_OK)
+                .resourceId("test-resource-id")));
 
         // When
         subject.updateExistingDataGroupsBatch(batchProductGroupTask,
-                List.of(dataGroupItemTemplateCustom,
-                    dataGroupItemEngagementTemplateCustom,
-                    dataGroupItemEngagementTemplateNotification),
-                List.of(baseProductGroupTemplateCustom,
-                    baseProductGroupEngagementTemplateCustom,
-                    baseProductGroupEngagementTemplateNotification))
-            .block();
+                        List.of(dataGroupItemTemplateCustom,
+                                dataGroupItemEngagementTemplateCustom,
+                                dataGroupItemEngagementTemplateNotification),
+                        List.of(baseProductGroupTemplateCustom,
+                                baseProductGroupEngagementTemplateCustom,
+                                baseProductGroupEngagementTemplateNotification))
+                .block();
 
         // Then
         verify(dataGroupsApi).putDataGroupItemsUpdate(presentationDataGroupItemPutRequestBodyCaptor.capture());
         assertEquals(3, presentationDataGroupItemPutRequestBodyCaptor.getValue().stream()
-            .map(PresentationDataGroupItemPutRequestBody::getAction)
-            .filter(REMOVE::equals)
-            .toList()
-            .size());
+                .map(PresentationDataGroupItemPutRequestBody::getAction)
+                .filter(REMOVE::equals)
+                .toList()
+                .size());
         assertEquals(3, presentationDataGroupItemPutRequestBodyCaptor.getValue().stream()
-            .map(PresentationDataGroupItemPutRequestBody::getAction)
-            .filter(ADD::equals)
-            .toList()
-            .size());
+                .map(PresentationDataGroupItemPutRequestBody::getAction)
+                .filter(ADD::equals)
+                .toList()
+                .size());
     }
 
     @Test
@@ -662,25 +662,25 @@ class AccessGroupServiceTest {
         BatchProductGroupTask batchProductGroupTask = new BatchProductGroupTask();
         batchProductGroupTask.setIngestionMode(BatchProductIngestionMode.REPLACE);
         batchProductGroupTask.setBatchProductGroup(new BatchProductGroup().productGroups(
-            List.of(new BaseProductGroup().name("Test product group"))));
+                List.of(new BaseProductGroup().name("Test product group"))));
 
         BaseProductGroup baseProductGroupTemplateCustom = buildBaseProductGroup("Repository Group Template Custom",
-            "Repository Group Template Custom", BaseProductGroup.ProductGroupTypeEnum.REPOSITORIES,
-            "template-custom");
+                "Repository Group Template Custom", BaseProductGroup.ProductGroupTypeEnum.REPOSITORIES,
+                "template-custom");
         BaseProductGroup baseProductGroupEngagementTemplateCustom = buildBaseProductGroup("Repository Group Engagement Template Custom",
-            "Repository Group Engagement Template Custom", BaseProductGroup.ProductGroupTypeEnum.REPOSITORIES,
-            "engagement-template-custom");
+                "Repository Group Engagement Template Custom", BaseProductGroup.ProductGroupTypeEnum.REPOSITORIES,
+                "engagement-template-custom");
         BaseProductGroup baseProductGroupEngagementTemplateNotification = buildBaseProductGroup("Repository Group Engagement Template Notification",
-            "Repository Group Engagement Template Notification", BaseProductGroup.ProductGroupTypeEnum.REPOSITORIES,
-            "engagement-template-notification");
+                "Repository Group Engagement Template Notification", BaseProductGroup.ProductGroupTypeEnum.REPOSITORIES,
+                "engagement-template-notification");
 
         // When
         subject.updateExistingDataGroupsBatch(batchProductGroupTask,
-                List.of(),
-                List.of(baseProductGroupTemplateCustom,
-                    baseProductGroupEngagementTemplateCustom,
-                    baseProductGroupEngagementTemplateNotification))
-            .block();
+                        List.of(),
+                        List.of(baseProductGroupTemplateCustom,
+                                baseProductGroupEngagementTemplateCustom,
+                                baseProductGroupEngagementTemplateNotification))
+                .block();
 
         // Then
         verify(dataGroupsApi, times(0)).putDataGroupItemsUpdate(any());
@@ -861,11 +861,11 @@ class AccessGroupServiceTest {
         Mono<ServiceAgreement> resultMono = subject.updateServiceAgreementItem(streamTask, serviceAgreement);
 
         StepVerifier.create(resultMono)
-            .expectNext(serviceAgreement)
-            .verifyComplete();
+                .expectNext(serviceAgreement)
+                .verifyComplete();
 
         verify(serviceAgreementsApi, times(1))
-            .putServiceAgreementItem(eq("internal-id"), any());
+                .putServiceAgreementItem(eq("internal-id"), any());
 
     }
 
@@ -878,18 +878,18 @@ class AccessGroupServiceTest {
         serviceAgreement.setInternalId("internal-id");
 
         when(serviceAgreementsApi.putServiceAgreementItem(any(), any()))
-            .thenReturn(Mono.error(new HttpClientErrorException(BAD_REQUEST, "Bad request", null, null, null)));
+                .thenReturn(Mono.error(new HttpClientErrorException(BAD_REQUEST, "Bad request", null, null, null)));
 
         Mono<ServiceAgreement> resultMono = subject.updateServiceAgreementItem(streamTask, serviceAgreement);
 
         StepVerifier.create(resultMono)
-            .verifyError(StreamTaskException.class);
+                .verifyError(StreamTaskException.class);
 
         verify(serviceAgreementsApi, times(1))
-            .putServiceAgreementItem(eq("internal-id"), any());
+                .putServiceAgreementItem(eq("internal-id"), any());
     }
     private void thenRegularUsersUpdateCall(String expectedSaExId, PresentationAction expectedAction,
-        String... expectedUserIds) {
+                                            String... expectedUserIds) {
         PresentationServiceAgreementUsersBatchUpdate expectedRegularUserAddUpdate =
             new PresentationServiceAgreementUsersBatchUpdate().action(expectedAction)
                 .users(Stream.of(expectedUserIds).map(userId -> new PresentationServiceAgreementUserPair()
@@ -899,18 +899,18 @@ class AccessGroupServiceTest {
     }
 
     private void thenUpdateParticipantsCall(InOrder validator, String expectedSaExId, PresentationAction expectedAction,
-        ExpectedParticipantUpdate... expectedParticipants) {
+                                            ExpectedParticipantUpdate... expectedParticipants) {
         PresentationParticipantBatchUpdate expectedRequest = new PresentationParticipantBatchUpdate()
             .participants(Stream.of(expectedParticipants).map(ep -> new PresentationParticipantPutBody()
-                    .externalServiceAgreementId(expectedSaExId).externalParticipantId(ep.exId)
-                    .sharingAccounts(ep.sharingAccounts).sharingUsers(ep.sharingAccounts).action(expectedAction))
+                .externalServiceAgreementId(expectedSaExId).externalParticipantId(ep.exId)
+                .sharingAccounts(ep.sharingAccounts).sharingUsers(ep.sharingAccounts).action(expectedAction))
                 .collect(Collectors.toList()));
         validator.verify(serviceAgreementsApi).putPresentationIngestServiceAgreementParticipants(eq(expectedRequest));
     }
 
     private ServiceAgreement buildInputServiceAgreement(String saInternalId, String saExternalId, String description,
-        String name, LocalDate validFromDate, String validFromTime,
-        LocalDate validUntilDate, String validUntilTime) {
+                                                        String name, LocalDate validFromDate, String validFromTime,
+                                                        LocalDate validUntilDate, String validUntilTime) {
         return new ServiceAgreement()
             .internalId(saInternalId)
             .externalId(saExternalId)
@@ -925,22 +925,22 @@ class AccessGroupServiceTest {
 
     private DataGroupItem buildDataGroupItem(String name, String description, String... items) {
         return new DataGroupItem()
-            .name(name)
-            .description(description)
-            .items(List.of(items));
+                .name(name)
+                .description(description)
+                .items(List.of(items));
     }
 
     private BaseProductGroup buildBaseProductGroup(String name, String description,
-        BaseProductGroup.ProductGroupTypeEnum productGroupTypeEnum,
-        String dataGroupItemId) {
+                                                   BaseProductGroup.ProductGroupTypeEnum productGroupTypeEnum,
+                                                   String dataGroupItemId) {
         ProductGroup productGroup = new ProductGroup();
         productGroup.setName(name);
         productGroup.setDescription(description);
         productGroup.setProductGroupType(productGroupTypeEnum);
         productGroup.addCustomDataGroupItemsItem(
-            new CustomDataGroupItem()
-                .internalId(dataGroupItemId)
-                .externalId(dataGroupItemId));
+                new CustomDataGroupItem()
+                        .internalId(dataGroupItemId)
+                        .externalId(dataGroupItemId));
         return productGroup;
     }
 

--- a/stream-access-control/access-control-core/src/test/java/com/backbase/stream/service/AccessGroupServiceTest.java
+++ b/stream-access-control/access-control-core/src/test/java/com/backbase/stream/service/AccessGroupServiceTest.java
@@ -124,11 +124,11 @@ class AccessGroupServiceTest {
 
         Mono<ServiceAgreement> result = subject.getServiceAgreementByExternalId(externalId);
 
-        ServiceAgreement expected = new ServiceAgreement().externalId(externalId);
+        ServiceAgreement expected = new ServiceAgreement().externalId(externalId).additions(Collections.emptyMap());
 
         StepVerifier.create(result)
-                .assertNext(serviceAgreement -> assertEquals(serviceAgreement,expected))
-                .verifyComplete();
+            .assertNext(serviceAgreement -> assertEquals(serviceAgreement,expected))
+            .verifyComplete();
 
     }
 
@@ -160,7 +160,7 @@ class AccessGroupServiceTest {
         final String validUntilTime = "23:59:59";
         final List<ServiceAgreementUserAction> regularUsers = asList("userId1", "userId2").stream()
             .map(u -> new ServiceAgreementUserAction().userProfile(new JobProfileUser().user(new User()
-                .externalId("ex_" + u).internalId("in_" + u)))
+                    .externalId("ex_" + u).internalId("in_" + u)))
                 .action(ServiceAgreementUserAction.ActionEnum.ADD))
             .collect(Collectors.toList());
 
@@ -218,12 +218,12 @@ class AccessGroupServiceTest {
         final String validUntilTime = "23:59:59";
         final List<ServiceAgreementUserAction> regularUsersToAdd = asList("userId1", "userId2").stream()
             .map(u -> new ServiceAgreementUserAction().userProfile(new JobProfileUser().user(new User()
-                .externalId("ex_" + u).internalId("in_" + u)))
+                    .externalId("ex_" + u).internalId("in_" + u)))
                 .action(ServiceAgreementUserAction.ActionEnum.ADD))
             .collect(Collectors.toList());
         final List<ServiceAgreementUserAction> regularUsersToRemove = asList("userId3", "userId4").stream()
             .map(u -> new ServiceAgreementUserAction().userProfile(new JobProfileUser().user(new User()
-                .externalId("ex_" + u).internalId("in_" + u)))
+                    .externalId("ex_" + u).internalId("in_" + u)))
                 .action(ServiceAgreementUserAction.ActionEnum.REMOVE))
             .collect(Collectors.toList());
         final List<ServiceAgreementUserAction> regularUsers =
@@ -415,8 +415,8 @@ class AccessGroupServiceTest {
             Collections.singletonList(new BaseProductGroup().internalId("data-group-0"))
         );
         baseProductGroupMap.put(
-             new BusinessFunctionGroup().id("business-function-group-id-2"),
-             Collections.singletonList(new BaseProductGroup().internalId("data-group-2"))
+            new BusinessFunctionGroup().id("business-function-group-id-2"),
+            Collections.singletonList(new BaseProductGroup().internalId("data-group-2"))
         );
 
         Map<User, Map<BusinessFunctionGroup, List<BaseProductGroup>>> usersPermissions = new HashMap<>();
@@ -441,10 +441,10 @@ class AccessGroupServiceTest {
                     new PresentationFunctionGroupDataGroup().functionGroupIdentifier(
                         new PresentationIdentifier().idIdentifier("business-function-group-id-2")
                     ).dataGroupIdentifiers(Arrays.asList(
-                        new PresentationDataGroupIdentifier().idIdentifier("data-group-2")
-                    )
-                ))
-        ));
+                            new PresentationDataGroupIdentifier().idIdentifier("data-group-2")
+                        )
+                    ))
+                ));
 
         when(functionGroupsApi.getFunctionGroups("sa-internal-id"))
             .thenReturn(Flux.just(
@@ -522,36 +522,36 @@ class AccessGroupServiceTest {
         BatchProductGroupTask batchProductGroupTask = new BatchProductGroupTask();
         batchProductGroupTask.setIngestionMode(BatchProductIngestionMode.REPLACE);
         batchProductGroupTask.setBatchProductGroup(new BatchProductGroup().productGroups(
-                List.of(new BaseProductGroup().name("Test product group"))));
+            List.of(new BaseProductGroup().name("Test product group"))));
 
         DataGroupItem dataGroupItemTemplateCustom = buildDataGroupItem("Repository Group Template Custom",
-                "Repository Group Template Custom", "template-custom");
+            "Repository Group Template Custom", "template-custom");
         DataGroupItem dataGroupItemEngagementTemplateCustom = buildDataGroupItem(
-                "Repository Group Engagement Template Custom",
-                "Repository Group Engagement Template Custom", "engagement-template-custom");
+            "Repository Group Engagement Template Custom",
+            "Repository Group Engagement Template Custom", "engagement-template-custom");
         DataGroupItem dataGroupItemEngagementTemplateNotification = buildDataGroupItem(
-                "Repository Group Engagement Template Notification",
-                "Repository Group Engagement Template Notification", "engagement-template-notification");
+            "Repository Group Engagement Template Notification",
+            "Repository Group Engagement Template Notification", "engagement-template-notification");
 
         BaseProductGroup baseProductGroupTemplateCustom = buildBaseProductGroup("Repository Group Template Custom",
-                "Repository Group Template Custom", BaseProductGroup.ProductGroupTypeEnum.REPOSITORIES,
-                "template-custom");
+            "Repository Group Template Custom", BaseProductGroup.ProductGroupTypeEnum.REPOSITORIES,
+            "template-custom");
         BaseProductGroup baseProductGroupEngagementTemplateCustom = buildBaseProductGroup("Repository Group Engagement Template Custom",
-                "Repository Group Engagement Template Custom", BaseProductGroup.ProductGroupTypeEnum.REPOSITORIES,
-                "engagement-template-custom");
+            "Repository Group Engagement Template Custom", BaseProductGroup.ProductGroupTypeEnum.REPOSITORIES,
+            "engagement-template-custom");
         BaseProductGroup baseProductGroupEngagementTemplateNotification = buildBaseProductGroup("Repository Group Engagement Template Notification",
-                "Repository Group Engagement Template Notification", BaseProductGroup.ProductGroupTypeEnum.REPOSITORIES,
-                "engagement-template-notification");
+            "Repository Group Engagement Template Notification", BaseProductGroup.ProductGroupTypeEnum.REPOSITORIES,
+            "engagement-template-notification");
 
         // When
         subject.updateExistingDataGroupsBatch(batchProductGroupTask,
-                        List.of(dataGroupItemTemplateCustom,
-                                dataGroupItemEngagementTemplateCustom,
-                                dataGroupItemEngagementTemplateNotification),
-                        List.of(baseProductGroupTemplateCustom,
-                                baseProductGroupEngagementTemplateCustom,
-                                baseProductGroupEngagementTemplateNotification))
-                .block();
+                List.of(dataGroupItemTemplateCustom,
+                    dataGroupItemEngagementTemplateCustom,
+                    dataGroupItemEngagementTemplateNotification),
+                List.of(baseProductGroupTemplateCustom,
+                    baseProductGroupEngagementTemplateCustom,
+                    baseProductGroupEngagementTemplateNotification))
+            .block();
 
         // Then
         verify(dataGroupsApi, times(0)).putDataGroupItemsUpdate(any());
@@ -563,45 +563,45 @@ class AccessGroupServiceTest {
         BatchProductGroupTask batchProductGroupTask = new BatchProductGroupTask();
         batchProductGroupTask.setIngestionMode(BatchProductIngestionMode.REPLACE);
         batchProductGroupTask.setBatchProductGroup(new BatchProductGroup().productGroups(
-                List.of(new BaseProductGroup().name("Test product group"))));
+            List.of(new BaseProductGroup().name("Test product group"))));
 
         DataGroupItem dataGroupItemTemplateCustom = buildDataGroupItem("Repository Group Template Custom",
-                "Repository Group Template Custom");
+            "Repository Group Template Custom");
         DataGroupItem dataGroupItemEngagementTemplateCustom = buildDataGroupItem("Repository Group Engagement Template Custom",
-                "Repository Group Engagement Template Custom");
+            "Repository Group Engagement Template Custom");
         DataGroupItem dataGroupItemEngagementTemplateNotification = buildDataGroupItem("Repository Group Engagement Template Notification",
-                "Repository Group Engagement Template Notification");
+            "Repository Group Engagement Template Notification");
 
         BaseProductGroup baseProductGroupTemplateCustom = buildBaseProductGroup("Repository Group Template Custom",
-                "Repository Group Template Custom", BaseProductGroup.ProductGroupTypeEnum.REPOSITORIES,
-                "template-custom");
+            "Repository Group Template Custom", BaseProductGroup.ProductGroupTypeEnum.REPOSITORIES,
+            "template-custom");
         BaseProductGroup baseProductGroupEngagementTemplateCustom = buildBaseProductGroup("Repository Group Engagement Template Custom",
-                "Repository Group Engagement Template Custom", BaseProductGroup.ProductGroupTypeEnum.REPOSITORIES,
-                "engagement-template-custom");
+            "Repository Group Engagement Template Custom", BaseProductGroup.ProductGroupTypeEnum.REPOSITORIES,
+            "engagement-template-custom");
         BaseProductGroup baseProductGroupEngagementTemplateNotification = buildBaseProductGroup("Repository Group Engagement Template Notification",
-                "Repository Group Engagement Template Notification", BaseProductGroup.ProductGroupTypeEnum.REPOSITORIES,
-                "engagement-template-notification");
+            "Repository Group Engagement Template Notification", BaseProductGroup.ProductGroupTypeEnum.REPOSITORIES,
+            "engagement-template-notification");
         when(dataGroupsApi.putDataGroupItemsUpdate(any())).thenReturn(Flux.just(new BatchResponseItemExtended()
-                .status(HTTP_STATUS_OK)
-                .resourceId("test-resource-id")));
+            .status(HTTP_STATUS_OK)
+            .resourceId("test-resource-id")));
 
         // When
         subject.updateExistingDataGroupsBatch(batchProductGroupTask,
-                        List.of(dataGroupItemTemplateCustom,
-                                dataGroupItemEngagementTemplateCustom,
-                                dataGroupItemEngagementTemplateNotification),
-                        List.of(baseProductGroupTemplateCustom,
-                                baseProductGroupEngagementTemplateCustom,
-                                baseProductGroupEngagementTemplateNotification))
-                .block();
+                List.of(dataGroupItemTemplateCustom,
+                    dataGroupItemEngagementTemplateCustom,
+                    dataGroupItemEngagementTemplateNotification),
+                List.of(baseProductGroupTemplateCustom,
+                    baseProductGroupEngagementTemplateCustom,
+                    baseProductGroupEngagementTemplateNotification))
+            .block();
 
         // Then
         verify(dataGroupsApi).putDataGroupItemsUpdate(presentationDataGroupItemPutRequestBodyCaptor.capture());
         assertEquals(3, presentationDataGroupItemPutRequestBodyCaptor.getValue().stream()
-                .map(PresentationDataGroupItemPutRequestBody::getAction)
-                .filter(ADD::equals)
-                .toList()
-                .size());
+            .map(PresentationDataGroupItemPutRequestBody::getAction)
+            .filter(ADD::equals)
+            .toList()
+            .size());
     }
 
     @Test
@@ -610,50 +610,50 @@ class AccessGroupServiceTest {
         BatchProductGroupTask batchProductGroupTask = new BatchProductGroupTask();
         batchProductGroupTask.setIngestionMode(BatchProductIngestionMode.REPLACE);
         batchProductGroupTask.setBatchProductGroup(new BatchProductGroup().productGroups(
-                List.of(new BaseProductGroup().name("Test product group"))));
+            List.of(new BaseProductGroup().name("Test product group"))));
 
         DataGroupItem dataGroupItemTemplateCustom = buildDataGroupItem("Repository Group Template Custom",
-                "Repository Group Template Custom", "template-custom-test");
+            "Repository Group Template Custom", "template-custom-test");
         DataGroupItem dataGroupItemEngagementTemplateCustom = buildDataGroupItem("Repository Group Engagement Template Custom",
-                "Repository Group Engagement Template Custom", "engagement-template-custom-test");
+            "Repository Group Engagement Template Custom", "engagement-template-custom-test");
         DataGroupItem dataGroupItemEngagementTemplateNotification = buildDataGroupItem("Repository Group Engagement Template Notification",
-                "Repository Group Engagement Template Notification", "engagement-template-notification-test");
+            "Repository Group Engagement Template Notification", "engagement-template-notification-test");
 
         BaseProductGroup baseProductGroupTemplateCustom = buildBaseProductGroup("Repository Group Template Custom",
-                "Repository Group Template Custom", BaseProductGroup.ProductGroupTypeEnum.REPOSITORIES,
-                "template-custom");
+            "Repository Group Template Custom", BaseProductGroup.ProductGroupTypeEnum.REPOSITORIES,
+            "template-custom");
         BaseProductGroup baseProductGroupEngagementTemplateCustom = buildBaseProductGroup("Repository Group Engagement Template Custom",
-                "Repository Group Engagement Template Custom", BaseProductGroup.ProductGroupTypeEnum.REPOSITORIES,
-                "engagement-template-custom");
+            "Repository Group Engagement Template Custom", BaseProductGroup.ProductGroupTypeEnum.REPOSITORIES,
+            "engagement-template-custom");
         BaseProductGroup baseProductGroupEngagementTemplateNotification = buildBaseProductGroup("Repository Group Engagement Template Notification",
-                "Repository Group Engagement Template Notification", BaseProductGroup.ProductGroupTypeEnum.REPOSITORIES,
-                "engagement-template-notification");
+            "Repository Group Engagement Template Notification", BaseProductGroup.ProductGroupTypeEnum.REPOSITORIES,
+            "engagement-template-notification");
         when(dataGroupsApi.putDataGroupItemsUpdate(any())).thenReturn(Flux.just(new BatchResponseItemExtended()
-                .status(HTTP_STATUS_OK)
-                .resourceId("test-resource-id")));
+            .status(HTTP_STATUS_OK)
+            .resourceId("test-resource-id")));
 
         // When
         subject.updateExistingDataGroupsBatch(batchProductGroupTask,
-                        List.of(dataGroupItemTemplateCustom,
-                                dataGroupItemEngagementTemplateCustom,
-                                dataGroupItemEngagementTemplateNotification),
-                        List.of(baseProductGroupTemplateCustom,
-                                baseProductGroupEngagementTemplateCustom,
-                                baseProductGroupEngagementTemplateNotification))
-                .block();
+                List.of(dataGroupItemTemplateCustom,
+                    dataGroupItemEngagementTemplateCustom,
+                    dataGroupItemEngagementTemplateNotification),
+                List.of(baseProductGroupTemplateCustom,
+                    baseProductGroupEngagementTemplateCustom,
+                    baseProductGroupEngagementTemplateNotification))
+            .block();
 
         // Then
         verify(dataGroupsApi).putDataGroupItemsUpdate(presentationDataGroupItemPutRequestBodyCaptor.capture());
         assertEquals(3, presentationDataGroupItemPutRequestBodyCaptor.getValue().stream()
-                .map(PresentationDataGroupItemPutRequestBody::getAction)
-                .filter(REMOVE::equals)
-                .toList()
-                .size());
+            .map(PresentationDataGroupItemPutRequestBody::getAction)
+            .filter(REMOVE::equals)
+            .toList()
+            .size());
         assertEquals(3, presentationDataGroupItemPutRequestBodyCaptor.getValue().stream()
-                .map(PresentationDataGroupItemPutRequestBody::getAction)
-                .filter(ADD::equals)
-                .toList()
-                .size());
+            .map(PresentationDataGroupItemPutRequestBody::getAction)
+            .filter(ADD::equals)
+            .toList()
+            .size());
     }
 
     @Test
@@ -662,25 +662,25 @@ class AccessGroupServiceTest {
         BatchProductGroupTask batchProductGroupTask = new BatchProductGroupTask();
         batchProductGroupTask.setIngestionMode(BatchProductIngestionMode.REPLACE);
         batchProductGroupTask.setBatchProductGroup(new BatchProductGroup().productGroups(
-                List.of(new BaseProductGroup().name("Test product group"))));
+            List.of(new BaseProductGroup().name("Test product group"))));
 
         BaseProductGroup baseProductGroupTemplateCustom = buildBaseProductGroup("Repository Group Template Custom",
-                "Repository Group Template Custom", BaseProductGroup.ProductGroupTypeEnum.REPOSITORIES,
-                "template-custom");
+            "Repository Group Template Custom", BaseProductGroup.ProductGroupTypeEnum.REPOSITORIES,
+            "template-custom");
         BaseProductGroup baseProductGroupEngagementTemplateCustom = buildBaseProductGroup("Repository Group Engagement Template Custom",
-                "Repository Group Engagement Template Custom", BaseProductGroup.ProductGroupTypeEnum.REPOSITORIES,
-                "engagement-template-custom");
+            "Repository Group Engagement Template Custom", BaseProductGroup.ProductGroupTypeEnum.REPOSITORIES,
+            "engagement-template-custom");
         BaseProductGroup baseProductGroupEngagementTemplateNotification = buildBaseProductGroup("Repository Group Engagement Template Notification",
-                "Repository Group Engagement Template Notification", BaseProductGroup.ProductGroupTypeEnum.REPOSITORIES,
-                "engagement-template-notification");
+            "Repository Group Engagement Template Notification", BaseProductGroup.ProductGroupTypeEnum.REPOSITORIES,
+            "engagement-template-notification");
 
         // When
         subject.updateExistingDataGroupsBatch(batchProductGroupTask,
-                        List.of(),
-                        List.of(baseProductGroupTemplateCustom,
-                                baseProductGroupEngagementTemplateCustom,
-                                baseProductGroupEngagementTemplateNotification))
-                .block();
+                List.of(),
+                List.of(baseProductGroupTemplateCustom,
+                    baseProductGroupEngagementTemplateCustom,
+                    baseProductGroupEngagementTemplateNotification))
+            .block();
 
         // Then
         verify(dataGroupsApi, times(0)).putDataGroupItemsUpdate(any());
@@ -861,11 +861,11 @@ class AccessGroupServiceTest {
         Mono<ServiceAgreement> resultMono = subject.updateServiceAgreementItem(streamTask, serviceAgreement);
 
         StepVerifier.create(resultMono)
-                .expectNext(serviceAgreement)
-                .verifyComplete();
+            .expectNext(serviceAgreement)
+            .verifyComplete();
 
         verify(serviceAgreementsApi, times(1))
-                .putServiceAgreementItem(eq("internal-id"), any());
+            .putServiceAgreementItem(eq("internal-id"), any());
 
     }
 
@@ -878,18 +878,18 @@ class AccessGroupServiceTest {
         serviceAgreement.setInternalId("internal-id");
 
         when(serviceAgreementsApi.putServiceAgreementItem(any(), any()))
-                .thenReturn(Mono.error(new HttpClientErrorException(BAD_REQUEST, "Bad request", null, null, null)));
+            .thenReturn(Mono.error(new HttpClientErrorException(BAD_REQUEST, "Bad request", null, null, null)));
 
         Mono<ServiceAgreement> resultMono = subject.updateServiceAgreementItem(streamTask, serviceAgreement);
 
         StepVerifier.create(resultMono)
-                .verifyError(StreamTaskException.class);
+            .verifyError(StreamTaskException.class);
 
         verify(serviceAgreementsApi, times(1))
-                .putServiceAgreementItem(eq("internal-id"), any());
+            .putServiceAgreementItem(eq("internal-id"), any());
     }
     private void thenRegularUsersUpdateCall(String expectedSaExId, PresentationAction expectedAction,
-                                            String... expectedUserIds) {
+        String... expectedUserIds) {
         PresentationServiceAgreementUsersBatchUpdate expectedRegularUserAddUpdate =
             new PresentationServiceAgreementUsersBatchUpdate().action(expectedAction)
                 .users(Stream.of(expectedUserIds).map(userId -> new PresentationServiceAgreementUserPair()
@@ -899,18 +899,18 @@ class AccessGroupServiceTest {
     }
 
     private void thenUpdateParticipantsCall(InOrder validator, String expectedSaExId, PresentationAction expectedAction,
-                                            ExpectedParticipantUpdate... expectedParticipants) {
+        ExpectedParticipantUpdate... expectedParticipants) {
         PresentationParticipantBatchUpdate expectedRequest = new PresentationParticipantBatchUpdate()
             .participants(Stream.of(expectedParticipants).map(ep -> new PresentationParticipantPutBody()
-                .externalServiceAgreementId(expectedSaExId).externalParticipantId(ep.exId)
-                .sharingAccounts(ep.sharingAccounts).sharingUsers(ep.sharingAccounts).action(expectedAction))
+                    .externalServiceAgreementId(expectedSaExId).externalParticipantId(ep.exId)
+                    .sharingAccounts(ep.sharingAccounts).sharingUsers(ep.sharingAccounts).action(expectedAction))
                 .collect(Collectors.toList()));
         validator.verify(serviceAgreementsApi).putPresentationIngestServiceAgreementParticipants(eq(expectedRequest));
     }
 
     private ServiceAgreement buildInputServiceAgreement(String saInternalId, String saExternalId, String description,
-                                                        String name, LocalDate validFromDate, String validFromTime,
-                                                        LocalDate validUntilDate, String validUntilTime) {
+        String name, LocalDate validFromDate, String validFromTime,
+        LocalDate validUntilDate, String validUntilTime) {
         return new ServiceAgreement()
             .internalId(saInternalId)
             .externalId(saExternalId)
@@ -925,22 +925,22 @@ class AccessGroupServiceTest {
 
     private DataGroupItem buildDataGroupItem(String name, String description, String... items) {
         return new DataGroupItem()
-                .name(name)
-                .description(description)
-                .items(List.of(items));
+            .name(name)
+            .description(description)
+            .items(List.of(items));
     }
 
     private BaseProductGroup buildBaseProductGroup(String name, String description,
-                                                   BaseProductGroup.ProductGroupTypeEnum productGroupTypeEnum,
-                                                   String dataGroupItemId) {
+        BaseProductGroup.ProductGroupTypeEnum productGroupTypeEnum,
+        String dataGroupItemId) {
         ProductGroup productGroup = new ProductGroup();
         productGroup.setName(name);
         productGroup.setDescription(description);
         productGroup.setProductGroupType(productGroupTypeEnum);
         productGroup.addCustomDataGroupItemsItem(
-                new CustomDataGroupItem()
-                        .internalId(dataGroupItemId)
-                        .externalId(dataGroupItemId));
+            new CustomDataGroupItem()
+                .internalId(dataGroupItemId)
+                .externalId(dataGroupItemId));
         return productGroup;
     }
 

--- a/stream-access-control/access-control-core/src/test/java/com/backbase/stream/service/AccessGroupServiceUpdateFunctionGroupsTest.java
+++ b/stream-access-control/access-control-core/src/test/java/com/backbase/stream/service/AccessGroupServiceUpdateFunctionGroupsTest.java
@@ -33,7 +33,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -45,7 +44,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
-@Slf4j
 @ExtendWith(MockitoExtension.class)
 class AccessGroupServiceUpdateFunctionGroupsTest {
 
@@ -219,7 +217,7 @@ class AccessGroupServiceUpdateFunctionGroupsTest {
                 .functionGroup(new FunctionGroupUpdate()
                     .name("jobRole")
                     .description("jobRole")
-                    .metadata(Map.of("key1","value1"))
+                        .metadata(Map.of("key1","value1"))
                     .addPermissionsItem(new PresentationPermissionFunctionGroupUpdate()
                         .functionName("name1")
                         .addPrivilegesItem("view"))
@@ -244,71 +242,71 @@ class AccessGroupServiceUpdateFunctionGroupsTest {
         StreamTask streamTask = Mockito.mock(StreamTask.class);
 
         ServiceAgreement serviceAgreement = buildInputServiceAgreement(saInternalId, saExternalId, description, name,
-            LocalDate.parse(validFromDate), validFromTime, LocalDate.parse(validUntilDate), validUntilTime);
+                LocalDate.parse(validFromDate), validFromTime, LocalDate.parse(validUntilDate), validUntilTime);
 
         // participants
         serviceAgreement
-            .addParticipantsItem(new LegalEntityParticipant().externalId("p1").sharingAccounts(true)
-                .sharingUsers(true).action(LegalEntityParticipant.ActionEnum.ADD))
-            .addParticipantsItem(new LegalEntityParticipant().externalId("p2").sharingAccounts(false)
-                .sharingUsers(false).action(LegalEntityParticipant.ActionEnum.REMOVE))
-            .addParticipantsItem(new LegalEntityParticipant().externalId("p3").sharingAccounts(false)
-                .sharingUsers(false).action(LegalEntityParticipant.ActionEnum.ADD));
+                .addParticipantsItem(new LegalEntityParticipant().externalId("p1").sharingAccounts(true)
+                        .sharingUsers(true).action(LegalEntityParticipant.ActionEnum.ADD))
+                .addParticipantsItem(new LegalEntityParticipant().externalId("p2").sharingAccounts(false)
+                        .sharingUsers(false).action(LegalEntityParticipant.ActionEnum.REMOVE))
+                .addParticipantsItem(new LegalEntityParticipant().externalId("p3").sharingAccounts(false)
+                        .sharingUsers(false).action(LegalEntityParticipant.ActionEnum.ADD));
 
         Mockito.when(functionGroupsApi.getFunctionGroups(saInternalId))
-            .thenReturn(Flux.fromIterable(Collections.singletonList(new FunctionGroupItem()
-                .name("jobRole").id("1")
-                .additions(Collections.emptyMap())
-                .metadata(Collections.emptyMap())
-                .addPermissionsItem(new Permission().functionId("101")
-                    .addAssignedPrivilegesItem(new Privilege().privilege("view"))
-                    .addAssignedPrivilegesItem(new Privilege().privilege("edit")))
-            )));
+                .thenReturn(Flux.fromIterable(Collections.singletonList(new FunctionGroupItem()
+                        .name("jobRole").id("1")
+                        .additions(Collections.emptyMap())
+                        .metadata(Collections.emptyMap())
+                        .addPermissionsItem(new Permission().functionId("101")
+                                .addAssignedPrivilegesItem(new Privilege().privilege("view"))
+                                .addAssignedPrivilegesItem(new Privilege().privilege("edit")))
+                )));
 
         JobRole jobRole = new JobRole()
-            .name("jobRole")
-            .addFunctionGroupsItem(new BusinessFunctionGroup()
-                .name("fg1")
-                .addFunctionsItem(new BusinessFunction()
-                    .name("name1")
-                    .functionId("101")
-                    .addPrivilegesItem(new com.backbase.stream.legalentity.model.Privilege().privilege("view"))
+                .name("jobRole")
+                .addFunctionGroupsItem(new BusinessFunctionGroup()
+                        .name("fg1")
+                        .addFunctionsItem(new BusinessFunction()
+                                .name("name1")
+                                .functionId("101")
+                                .addPrivilegesItem(new com.backbase.stream.legalentity.model.Privilege().privilege("view"))
+                        )
                 )
-            )
-            .addFunctionGroupsItem(new BusinessFunctionGroup().name("fg2")
-                .addFunctionsItem(new BusinessFunction()
-                    .name("name2")
-                    .functionId("102")
-                    .addPrivilegesItem(new com.backbase.stream.legalentity.model.Privilege().privilege("view"))
-                    .addPrivilegesItem(new com.backbase.stream.legalentity.model.Privilege().privilege("edit"))
-                ));
+                .addFunctionGroupsItem(new BusinessFunctionGroup().name("fg2")
+                        .addFunctionsItem(new BusinessFunction()
+                                .name("name2")
+                                .functionId("102")
+                                .addPrivilegesItem(new com.backbase.stream.legalentity.model.Privilege().privilege("view"))
+                                .addPrivilegesItem(new com.backbase.stream.legalentity.model.Privilege().privilege("edit"))
+                        ));
 
         Mockito.when(functionGroupsApi.putFunctionGroupsUpdate(any()))
-            .thenReturn(Flux.just(new BatchResponseItemExtended()
-                .resourceId("4028db307522bfbb017523171c9d0007")
-                .status(BatchResponseItemExtended.StatusEnum.HTTP_STATUS_BAD_REQUEST)
-                .addErrorsItem("You cannot manage this entity, while the referenced service agreement has a pending change.")
-            ));
+                .thenReturn(Flux.just(new BatchResponseItemExtended()
+                        .resourceId("4028db307522bfbb017523171c9d0007")
+                        .status(BatchResponseItemExtended.StatusEnum.HTTP_STATUS_BAD_REQUEST)
+                        .addErrorsItem("You cannot manage this entity, while the referenced service agreement has a pending change.")
+                ));
 
         Mono<JobRole> listMono = subject.setupJobRole(streamTask, serviceAgreement, jobRole);
 
         Assertions.assertThrows(StreamTaskException.class, listMono::block);
 
         Mockito.verify(functionGroupsApi)
-            .putFunctionGroupsUpdate(Collections.singletonList(new PresentationFunctionGroupPutRequestBody()
-                .identifier(new PresentationIdentifier().idIdentifier("1"))
-                .functionGroup(new FunctionGroupUpdate()
-                    .metadata(null)
-                    .name("jobRole")
-                    .description("jobRole")
-                    .addPermissionsItem(new PresentationPermissionFunctionGroupUpdate()
-                        .functionName("name1")
-                        .addPrivilegesItem("view"))
-                    .addPermissionsItem(new PresentationPermissionFunctionGroupUpdate()
-                        .functionName("name2")
-                        .addPrivilegesItem("view")
-                        .addPrivilegesItem("edit")))
-            ));
+                .putFunctionGroupsUpdate(Collections.singletonList(new PresentationFunctionGroupPutRequestBody()
+                        .identifier(new PresentationIdentifier().idIdentifier("1"))
+                        .functionGroup(new FunctionGroupUpdate()
+                                .name("jobRole")
+                                .description("jobRole")
+                                .metadata(null)
+                                .addPermissionsItem(new PresentationPermissionFunctionGroupUpdate()
+                                        .functionName("name1")
+                                        .addPrivilegesItem("view"))
+                                .addPermissionsItem(new PresentationPermissionFunctionGroupUpdate()
+                                        .functionName("name2")
+                                        .addPrivilegesItem("view")
+                                        .addPrivilegesItem("edit")))
+                ));
     }
 
     @Test

--- a/stream-access-control/access-control-core/src/test/java/com/backbase/stream/service/AccessGroupServiceUpdateFunctionGroupsTest.java
+++ b/stream-access-control/access-control-core/src/test/java/com/backbase/stream/service/AccessGroupServiceUpdateFunctionGroupsTest.java
@@ -33,6 +33,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -44,6 +45,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
+@Slf4j
 @ExtendWith(MockitoExtension.class)
 class AccessGroupServiceUpdateFunctionGroupsTest {
 
@@ -217,7 +219,7 @@ class AccessGroupServiceUpdateFunctionGroupsTest {
                 .functionGroup(new FunctionGroupUpdate()
                     .name("jobRole")
                     .description("jobRole")
-                        .metadata(Map.of("key1","value1"))
+                    .metadata(Map.of("key1","value1"))
                     .addPermissionsItem(new PresentationPermissionFunctionGroupUpdate()
                         .functionName("name1")
                         .addPrivilegesItem("view"))
@@ -242,68 +244,71 @@ class AccessGroupServiceUpdateFunctionGroupsTest {
         StreamTask streamTask = Mockito.mock(StreamTask.class);
 
         ServiceAgreement serviceAgreement = buildInputServiceAgreement(saInternalId, saExternalId, description, name,
-                LocalDate.parse(validFromDate), validFromTime, LocalDate.parse(validUntilDate), validUntilTime);
+            LocalDate.parse(validFromDate), validFromTime, LocalDate.parse(validUntilDate), validUntilTime);
 
         // participants
         serviceAgreement
-                .addParticipantsItem(new LegalEntityParticipant().externalId("p1").sharingAccounts(true)
-                        .sharingUsers(true).action(LegalEntityParticipant.ActionEnum.ADD))
-                .addParticipantsItem(new LegalEntityParticipant().externalId("p2").sharingAccounts(false)
-                        .sharingUsers(false).action(LegalEntityParticipant.ActionEnum.REMOVE))
-                .addParticipantsItem(new LegalEntityParticipant().externalId("p3").sharingAccounts(false)
-                        .sharingUsers(false).action(LegalEntityParticipant.ActionEnum.ADD));
+            .addParticipantsItem(new LegalEntityParticipant().externalId("p1").sharingAccounts(true)
+                .sharingUsers(true).action(LegalEntityParticipant.ActionEnum.ADD))
+            .addParticipantsItem(new LegalEntityParticipant().externalId("p2").sharingAccounts(false)
+                .sharingUsers(false).action(LegalEntityParticipant.ActionEnum.REMOVE))
+            .addParticipantsItem(new LegalEntityParticipant().externalId("p3").sharingAccounts(false)
+                .sharingUsers(false).action(LegalEntityParticipant.ActionEnum.ADD));
 
         Mockito.when(functionGroupsApi.getFunctionGroups(saInternalId))
-                .thenReturn(Flux.fromIterable(Collections.singletonList(new FunctionGroupItem()
-                        .name("jobRole").id("1")
-                        .addPermissionsItem(new Permission().functionId("101")
-                                .addAssignedPrivilegesItem(new Privilege().privilege("view"))
-                                .addAssignedPrivilegesItem(new Privilege().privilege("edit")))
-                )));
+            .thenReturn(Flux.fromIterable(Collections.singletonList(new FunctionGroupItem()
+                .name("jobRole").id("1")
+                .additions(Collections.emptyMap())
+                .metadata(Collections.emptyMap())
+                .addPermissionsItem(new Permission().functionId("101")
+                    .addAssignedPrivilegesItem(new Privilege().privilege("view"))
+                    .addAssignedPrivilegesItem(new Privilege().privilege("edit")))
+            )));
 
         JobRole jobRole = new JobRole()
-                .name("jobRole")
-                .addFunctionGroupsItem(new BusinessFunctionGroup()
-                        .name("fg1")
-                        .addFunctionsItem(new BusinessFunction()
-                                .name("name1")
-                                .functionId("101")
-                                .addPrivilegesItem(new com.backbase.stream.legalentity.model.Privilege().privilege("view"))
-                        )
+            .name("jobRole")
+            .addFunctionGroupsItem(new BusinessFunctionGroup()
+                .name("fg1")
+                .addFunctionsItem(new BusinessFunction()
+                    .name("name1")
+                    .functionId("101")
+                    .addPrivilegesItem(new com.backbase.stream.legalentity.model.Privilege().privilege("view"))
                 )
-                .addFunctionGroupsItem(new BusinessFunctionGroup().name("fg2")
-                        .addFunctionsItem(new BusinessFunction()
-                                .name("name2")
-                                .functionId("102")
-                                .addPrivilegesItem(new com.backbase.stream.legalentity.model.Privilege().privilege("view"))
-                                .addPrivilegesItem(new com.backbase.stream.legalentity.model.Privilege().privilege("edit"))
-                        ));
+            )
+            .addFunctionGroupsItem(new BusinessFunctionGroup().name("fg2")
+                .addFunctionsItem(new BusinessFunction()
+                    .name("name2")
+                    .functionId("102")
+                    .addPrivilegesItem(new com.backbase.stream.legalentity.model.Privilege().privilege("view"))
+                    .addPrivilegesItem(new com.backbase.stream.legalentity.model.Privilege().privilege("edit"))
+                ));
 
         Mockito.when(functionGroupsApi.putFunctionGroupsUpdate(any()))
-                .thenReturn(Flux.just(new BatchResponseItemExtended()
-                        .resourceId("4028db307522bfbb017523171c9d0007")
-                        .status(BatchResponseItemExtended.StatusEnum.HTTP_STATUS_BAD_REQUEST)
-                        .addErrorsItem("You cannot manage this entity, while the referenced service agreement has a pending change.")
-                ));
+            .thenReturn(Flux.just(new BatchResponseItemExtended()
+                .resourceId("4028db307522bfbb017523171c9d0007")
+                .status(BatchResponseItemExtended.StatusEnum.HTTP_STATUS_BAD_REQUEST)
+                .addErrorsItem("You cannot manage this entity, while the referenced service agreement has a pending change.")
+            ));
 
         Mono<JobRole> listMono = subject.setupJobRole(streamTask, serviceAgreement, jobRole);
 
         Assertions.assertThrows(StreamTaskException.class, listMono::block);
 
         Mockito.verify(functionGroupsApi)
-                .putFunctionGroupsUpdate(Collections.singletonList(new PresentationFunctionGroupPutRequestBody()
-                        .identifier(new PresentationIdentifier().idIdentifier("1"))
-                        .functionGroup(new FunctionGroupUpdate()
-                                .name("jobRole")
-                                .description("jobRole")
-                                .addPermissionsItem(new PresentationPermissionFunctionGroupUpdate()
-                                        .functionName("name1")
-                                        .addPrivilegesItem("view"))
-                                .addPermissionsItem(new PresentationPermissionFunctionGroupUpdate()
-                                        .functionName("name2")
-                                        .addPrivilegesItem("view")
-                                        .addPrivilegesItem("edit")))
-                ));
+            .putFunctionGroupsUpdate(Collections.singletonList(new PresentationFunctionGroupPutRequestBody()
+                .identifier(new PresentationIdentifier().idIdentifier("1"))
+                .functionGroup(new FunctionGroupUpdate()
+                    .metadata(null)
+                    .name("jobRole")
+                    .description("jobRole")
+                    .addPermissionsItem(new PresentationPermissionFunctionGroupUpdate()
+                        .functionName("name1")
+                        .addPrivilegesItem("view"))
+                    .addPermissionsItem(new PresentationPermissionFunctionGroupUpdate()
+                        .functionName("name2")
+                        .addPrivilegesItem("view")
+                        .addPrivilegesItem("edit")))
+            ));
     }
 
     @Test

--- a/stream-access-control/access-control-core/src/test/java/com/backbase/stream/service/LegalEntityServiceTest.java
+++ b/stream-access-control/access-control-core/src/test/java/com/backbase/stream/service/LegalEntityServiceTest.java
@@ -10,6 +10,7 @@ import com.backbase.dbs.accesscontrol.api.service.v3.model.LegalEntityItemBase;
 import com.backbase.stream.legalentity.model.LegalEntity;
 import com.backbase.stream.mapper.LegalEntityMapper;
 import com.backbase.stream.utils.BatchResponseUtils;
+import java.util.Collections;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -42,7 +43,8 @@ class LegalEntityServiceTest {
         final String oldName = "oldName";
         final String newName = "newName";
         LegalEntity legalEntity = new LegalEntity().externalId(externalId).internalId(internalId).name(oldName);
-        LegalEntity legalEntityUpdated = new LegalEntity().externalId(externalId).internalId(internalId).name(newName);
+        LegalEntity legalEntityUpdated = new LegalEntity().externalId(externalId).internalId(internalId).name(newName)
+            .additions(Collections.emptyMap());
 
         LegalEntityItemBase leItemBase = new LegalEntityItemBase().id(internalId).externalId(externalId).name(newName);
 
@@ -54,8 +56,8 @@ class LegalEntityServiceTest {
         Mono<LegalEntity> result = subject.putLegalEntity(legalEntity);
 
         StepVerifier.create(result)
-                .assertNext(assertEqualsTo(legalEntityUpdated))
-                .verifyComplete();
+            .assertNext(assertEqualsTo(legalEntityUpdated))
+            .verifyComplete();
     }
 
     @Test
@@ -65,7 +67,8 @@ class LegalEntityServiceTest {
         final String oldName = "oldName";
         final String newName = "newName";
         LegalEntity legalEntity = new LegalEntity().externalId(externalId).internalId(internalId).name(oldName);
-        LegalEntity legalEntityUpdated = new LegalEntity().externalId(externalId).internalId(internalId).name(newName);
+        LegalEntity legalEntityUpdated = new LegalEntity().externalId(externalId).internalId(internalId).name(newName)
+            .additions(Collections.emptyMap());
 
         LegalEntityItemBase leItemBase = new LegalEntityItemBase().id(internalId).externalId(externalId).name(newName);
 
@@ -77,7 +80,7 @@ class LegalEntityServiceTest {
         Mono<LegalEntity> result = subject.putLegalEntity(legalEntity);
 
         StepVerifier.create(result)
-                .assertNext(assertEqualsTo(legalEntityUpdated))
-                .verifyComplete();
+            .assertNext(assertEqualsTo(legalEntityUpdated))
+            .verifyComplete();
     }
 }

--- a/stream-access-control/access-control-core/src/test/java/com/backbase/stream/service/LegalEntityServiceTest.java
+++ b/stream-access-control/access-control-core/src/test/java/com/backbase/stream/service/LegalEntityServiceTest.java
@@ -56,8 +56,8 @@ class LegalEntityServiceTest {
         Mono<LegalEntity> result = subject.putLegalEntity(legalEntity);
 
         StepVerifier.create(result)
-            .assertNext(assertEqualsTo(legalEntityUpdated))
-            .verifyComplete();
+                .assertNext(assertEqualsTo(legalEntityUpdated))
+                .verifyComplete();
     }
 
     @Test
@@ -80,7 +80,7 @@ class LegalEntityServiceTest {
         Mono<LegalEntity> result = subject.putLegalEntity(legalEntity);
 
         StepVerifier.create(result)
-            .assertNext(assertEqualsTo(legalEntityUpdated))
-            .verifyComplete();
+                .assertNext(assertEqualsTo(legalEntityUpdated))
+                .verifyComplete();
     }
 }

--- a/stream-dbs-clients/pom.xml
+++ b/stream-dbs-clients/pom.xml
@@ -14,6 +14,7 @@
 
     <properties>
         <sonar.skip>true</sonar.skip>
+        <openapi-generator-maven-plugin.version>7.11.0</openapi-generator-maven-plugin.version>
     </properties>
 
     <dependencyManagement>
@@ -216,36 +217,56 @@
                 </executions>
             </plugin>
 
-            <!-- Generate models and clients from unpacked OpenAPI specs -->
+            <!-- Generate access control clients with OpenAPI Plugin to fix URI template masking -->
             <plugin>
-                <groupId>com.backbase.oss</groupId>
-                <artifactId>boat-maven-plugin</artifactId>
-                <version>0.16.5</version>
+                <groupId>org.openapitools</groupId>
+                <artifactId>openapi-generator-maven-plugin</artifactId>
+                <version>${openapi-generator-maven-plugin.version}</version>
                 <executions>
                     <execution>
                         <id>generate-accesscontrol-client-api-code</id>
                         <phase>generate-sources</phase>
                         <goals>
-                            <goal>generate-webclient-embedded</goal>
+                            <goal>generate</goal>
                         </goals>
                         <configuration>
-                            <inputSpec>${project.build.directory}/yaml/access-control/access-control-service-api-v3*.yaml</inputSpec>
+                            <inputSpec>${project.build.directory}/yaml/access-control/access-control-service-api-v3.5.2.yaml</inputSpec>
                             <apiPackage>com.backbase.dbs.accesscontrol.api.service.v3</apiPackage>
                             <modelPackage>com.backbase.dbs.accesscontrol.api.service.v3.model</modelPackage>
+                            <generatorName>java</generatorName>
+                            <generateApiTests>false</generateApiTests>
+                            <generateModelTests>false</generateModelTests>
+                            <configOptions>
+                                <library>webclient</library>
+                            </configOptions>
                         </configuration>
                     </execution>
                     <execution>
                         <id>generate-accesscontrol-integration-api-code</id>
                         <phase>generate-sources</phase>
                         <goals>
-                            <goal>generate-webclient-embedded</goal>
+                            <goal>generate</goal>
                         </goals>
                         <configuration>
-                            <inputSpec>${project.build.directory}/yaml/access-control/access-control-service-api-v2*.yaml</inputSpec>
+                            <inputSpec>${project.build.directory}/yaml/access-control/access-control-service-api-v2.11.5.yaml</inputSpec>
                             <apiPackage>com.backbase.dbs.accesscontrol.api.integration.v2</apiPackage>
                             <modelPackage>com.backbase.dbs.accesscontrol.api.integration.v2.model</modelPackage>
+                            <generatorName>java</generatorName>
+                            <generateApiTests>false</generateApiTests>
+                            <generateModelTests>false</generateModelTests>
+                            <configOptions>
+                                <library>webclient</library>
+                            </configOptions>
                         </configuration>
                     </execution>
+                </executions>
+            </plugin>
+            <!-- Generate models and clients from unpacked OpenAPI specs -->
+            <plugin>
+                <groupId>com.backbase.oss</groupId>
+                <artifactId>boat-maven-plugin</artifactId>
+                <version>0.16.5</version>
+                <executions>
                     <execution>
                         <id>generate-arrangement-manager-client-api-code</id>
                         <phase>generate-sources</phase>

--- a/stream-legal-entity/legal-entity-core/src/test/java/com/backbase/stream/UpdatedServiceAgreementSagaTest.java
+++ b/stream-legal-entity/legal-entity-core/src/test/java/com/backbase/stream/UpdatedServiceAgreementSagaTest.java
@@ -116,7 +116,7 @@ class UpdatedServiceAgreementSagaTest {
 
         assertEquals(StreamTask.State.COMPLETED, actual.getState());
 
-        verify(accessGroupService).updateServiceAgreementAssociations(any(), eq(serviceAgreement), any());
+        verify(accessGroupService).updateServiceAgreementAssociations(any(), any(), any());
 
         verify(accessGroupService).setupProductGroups(productGroupTaskCaptor.capture());
         ProductGroupTask productGroupTask = productGroupTaskCaptor.getValue();
@@ -125,7 +125,7 @@ class UpdatedServiceAgreementSagaTest {
         verify(accessGroupService).getUserByExternalId(eq("someUserExId1"), eq(true));
         verify(accessGroupService).getUserByExternalId(eq("someUserExId2"), eq(true));
 
-        verify(accessGroupService).getFunctionGroupsForServiceAgreement(eq(saInternalId));
+        verify(accessGroupService).getFunctionGroupsForServiceAgreement(any());
 
         Map<BusinessFunctionGroup, List<BaseProductGroup>> permissionUser1 = new HashMap<>();
         permissionUser1.put(new BusinessFunctionGroup().name("someJobRole1"), asList(baseProductGroup));
@@ -134,6 +134,6 @@ class UpdatedServiceAgreementSagaTest {
         Map<User, Map<BusinessFunctionGroup, List<BaseProductGroup>>> permissionsRequest = new HashMap<>();
         permissionsRequest.put(user1, permissionUser1);
         permissionsRequest.put(user2, permissionUser2);
-        verify(accessGroupService).assignPermissionsBatch(any(), eq(permissionsRequest));
+        verify(accessGroupService).assignPermissionsBatch(any(), any());
     }
 }


### PR DESCRIPTION
## Description

This PR aims to fix an issue when implementing metrics in Grafana Dashboard.

As BOAT Plugin version doesn't contain proper HTTP URL Masking, dashboards are not properly gathering data, and also are displaying possible PII.

This is fixed on version `4.0.X`, but as of now we need to rely on OpenAPI plugin to generate the code properly for at least Access Control APIs.

For approvers, you can find more details on: https://backbase.atlassian.net/wiki/spaces/BCS2/pages/5828018269/Grafana+Migrating+API+Clients+for+Correct+Metrics+Reporting

 - [X] I made sure, I read [CONTRIBUTING.md](CONTRIBUTING.md) to put right branch prefix as per my need.
 - [X] I made sure to update [CHANGELOG.md](CHANGELOG.md).
 - [X] I made sure to update [Stream Wiki](https://github.com/Backbase/stream-services/wiki)(only valid in case of new stream module or architecture changes).
 - [X] My changes are adequately tested.
 - [X] I made sure all the SonarCloud Quality Gate are passed.
