### PR TITLE
feat: CONT-4873 Added account holder type parameter in contact account

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@ All notable changes to this project will be documented in this file.
 
 ## [10.11.0]
 ### Changed
-- Added accountHolderType in contact account model
+- Added accountHolderType in contact account model to facilitate CoP in Contact Manager
+- Added verificationBehaviour in contact account model to facilitate CoP in Caboose
 - Updated bom version to 2026.07 to ingest the accountHolderType in contact account
 
 ## [10.10.0]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [10.11.0]
+### Changed
+- Added accountHolderType in contact account model
+- Updated bom version to 2026.07 to ingest the accountHolderType in contact account
+
 ## [10.10.0]
 ### Changed
 - Updated stream-investment to be able to seed intraday prices to all the assets

--- a/api/stream-legal-entity/openapi.yaml
+++ b/api/stream-legal-entity/openapi.yaml
@@ -2465,6 +2465,11 @@ components:
           maxLength: 34
           type: string
           description: Name will be displayed if alias field is not filled
+        accountHolderType:
+          type: string
+          minLength: 1
+          maxLength: 10
+          description: Account holder type for the account.
         accountType:
           maxLength: 10
           type: string

--- a/api/stream-legal-entity/openapi.yaml
+++ b/api/stream-legal-entity/openapi.yaml
@@ -2455,6 +2455,20 @@ components:
 
     ExternalAccountInformation:
       properties:
+        verificationBehaviour:
+          type: string
+          description: >
+            How this account behaves when a beneficiary verification request resolves to it.
+            NORMAL performs the name and holder-type checks. The other values short-circuit the
+            checks and return a fixed reason code, so a seed set can demonstrate outcomes that
+            name matching alone cannot produce. Defaults to NORMAL when omitted.
+          default: NORMAL
+          enum:
+            - NORMAL
+            - OPTED_OUT
+            - NOT_SUPPORTED
+            - SWITCHED
+          example: NORMAL
         externalId:
           $ref: '#/components/schemas/ExternalContactId'
         name:

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
     <properties>
         <java.version>25</java.version>
         <ssdk.version>21.0.1</ssdk.version>
-        <backbase-bom.version>2026.03-LTS</backbase-bom.version>
+        <backbase-bom.version>2026.07</backbase-bom.version>
         <boat-maven-plugin.version>0.18.1</boat-maven-plugin.version>
         <backbase.portfolio.version>4.7.0</backbase.portfolio.version>
         <org.jetbrainsannotations.version>26.1.0</org.jetbrainsannotations.version>


### PR DESCRIPTION
## Description

Added account holder type field in contact account, required for Confirmation of Payee in GB.
Tested with UK ingestion profile in bootstrap job - three GB accounts with account holder type successfully ingested in Contact Manager DB:
<img width="2353" height="335" alt="image" src="https://github.com/user-attachments/assets/e617a4a6-8a9f-4a9e-b7db-6cebeb75700d" />

## Checklist

 - [x] I made sure, I read [CONTRIBUTING.md](CONTRIBUTING.md) to put right branch prefix as per my need.
 - [x] I made sure to update [CHANGELOG.md](CHANGELOG.md).
 - [ ] I made sure to update [Stream Wiki](https://github.com/Backbase/stream-services/wiki)(only valid in case of new stream module or architecture changes). ~ NA
 - [x] My changes are adequately tested.
 - [x] I made sure all the SonarCloud Quality Gate are passed.
